### PR TITLE
Mimic structure of sitemenu from other Craft elements

### DIFF
--- a/src/templates/products/_edit.html
+++ b/src/templates/products/_edit.html
@@ -37,7 +37,7 @@
 
 {% block contextMenu %}
     {% if craft.app.getIsMultiSite() %}
-        <div class="btn menubtn"
+        <div class="btn menubtn sitemenubtn"
              data-icon="world">{{ product.site.name|t('site') }}</div>
         <div class="menu">
             <ul class="padded">
@@ -46,12 +46,12 @@
                     {% set status = siteId in enabledSiteIds ? 'enabled' : 'disabled' %}
                     <li>
                         {% if siteId == product.siteId %}
-                            <a class="sel">
+                            <a class="sel" data-site-id="{{ siteId }}">
                                 <div class="status {{ status }}"></div>{{ site.name|t('site') }}
                             </a>
                         {% else %}
                             {% set url = url("commerce/products/#{productTypeHandle}/#{craft.app.request.getSegment(4)}/#{site.handle}") %}
-                            <a href="{{ url }}">
+                            <a href="{{ url }}" data-site-id="{{ siteId }}">
                                 <div class="status {{ status }}"></div>{{ site.name|t('site') }}
                             </a>
                         {% endif %}


### PR DESCRIPTION
The sitemenu button on other Craft element entry screens has the class of `sitemenubtn` and then each site item link within the menu has the appropriate `data-site-id`. This mimics that functionality so that we can more easily target this menu consistently with JS between Craft and Commerce.