### PR TITLE
Add _returnCart to RemoveAllLineItems

### DIFF
--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -118,6 +118,8 @@ class CartController extends BaseFrontEndController
     public function actionRemoveAllLineItems()
     {
         $this->_cart->setLineItems([]);
+        
+        return $this->_returnCart();
     }
 
     /**


### PR DESCRIPTION
This PR adds a `_returnCart` method call to the actionRemoveAllLineItems.

The _returnCart method saves the cart, thus by only calling setLineItems the cart doesn't update in the end. This results in a broken action.