### PR TITLE
Return redirect result in PaymentsController#actionPay

### DIFF
--- a/src/controllers/PaymentsController.php
+++ b/src/controllers/PaymentsController.php
@@ -327,13 +327,10 @@ class PaymentsController extends BaseFrontEndController
         }
 
         if ($order->returnUrl) {
-            $this->redirect($order->returnUrl);
+            return $this->redirect($order->returnUrl);
         } else {
-            $this->redirectToPostedUrl($order);
+            return $this->redirectToPostedUrl($order);
         }
-
-        // should have been handled by now
-        return null;
     }
 
     /**


### PR DESCRIPTION
Think I've encountered a bug attempting to implement a custom payment gateway. On successful authorization/payment/whatever, the last thing that `actionPay` does is define the redirect target. However it then goes on to return `null`, seemingly invalidating the defined redirect.

This patch seems to do the trick for me locally in having the app redirect to the specified `$order->returnUrl` when it's available.