### PR TITLE
Include product title in Variant `__toString`

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -125,8 +125,7 @@ class Variant extends Purchasable
     {
         $product = $this->getProduct();
 
-        // Use a combined Product and Variant title, if the variant is
-        // belongs to a product with other variants.
+        // Use a combined Product and Variant title, if the variant belongs to a product with other variants.
         if ($product && $product->getType()->hasVariants) {
             return "{$this->product}: {$this->title}";
         } else {

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -121,6 +121,20 @@ class Variant extends Purchasable
     /**
      * @inheritdoc
      */
+    public function __toString(): string
+    {
+        if ($this->product) {
+            return "{$this->product} {$this->title}";
+        } else if ($this->title) {
+            return (string)$this->title;
+        } else {
+            return (string)$this->id ?: static::class;
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function displayName(): string
     {
         return Craft::t('commerce', 'Product Variant');

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -123,12 +123,14 @@ class Variant extends Purchasable
      */
     public function __toString(): string
     {
-        if ($this->product) {
-            return "{$this->product} {$this->title}";
-        } else if ($this->title) {
-            return (string)$this->title;
+        $product = $this->getProduct();
+
+        // Use a combined Product and Variant title, if the variant is
+        // belongs to a product with other variants.
+        if ($product && $product->getType()->hasVariants) {
+            return "{$this->product}: {$this->title}";
         } else {
-            return (string)$this->id ?: static::class;
+            return parent::__toString();
         }
     }
 


### PR DESCRIPTION
This helps identify variants better, when their element chiclets are displayed in the CMS. Previously, the variant title alone was often confusing (i.e. "Red", rather than "Wrap Dress Red").

The new output looks like this pseudo-template: `{Product Name}: {Variant Name}`.

I don't think this is a "breaking" change (it still returns a string), but if anyone is relying on the `__toString` method for displaying variant information, they would need to switch to `$variant->title` to get the old string.

Note: In testing, I was getting some odd behavior from the `getTableAttributeHtml` function, in that it seemed to want to run `toString` for the `title` column. I couldn't supplant that behavior with a new `case` statement—any theories?