### PR TITLE
Remove blank element from `getStatesAsList` output

### DIFF
--- a/src/services/States.php
+++ b/src/services/States.php
@@ -110,11 +110,6 @@ class States extends Component
 
         foreach ($states as $state) {
             $cid2state += [$state->countryId => []];
-
-            if (!count($cid2state[$state->countryId])) {
-                $cid2state[$state->countryId][null] = '';
-            }
-
             $cid2state[$state->countryId][$state->id] = $state->name;
         }
 


### PR DESCRIPTION
A blank array element was inserted at the beginning of each Country group. I wouldn't consider this the expected output—seems like the template's responsibility to insert empty `option` elements, not to filter them out of what ought to be a clean representation of the data.

This PR eliminates the empty entry.