### PR TITLE
Update all customer's primary addresses in single query

### DIFF
--- a/src/migrations/m180402_161903_primary_customer_addresses_relations.php
+++ b/src/migrations/m180402_161903_primary_customer_addresses_relations.php
@@ -27,9 +27,7 @@ class m180402_161903_primary_customer_addresses_relations extends Migration
             ->andWhere(['not', ['customers.primaryBillingAddressId' => null]])
             ->column();
 
-        foreach ($rougueOnes as $id) {
-            $this->update('{{%commerce_customers}}', ['primaryBillingAddressId' => null], ['primaryBillingAddressId' => $id]);
-        }
+        $this->update('{{%commerce_customers}}', ['primaryBillingAddressId' => null], ['primaryBillingAddressId' => $rougueOnes]);
 
         $rougueTwos = (new \craft\db\Query())
             ->select('customers.primaryShippingAddressId')
@@ -39,9 +37,7 @@ class m180402_161903_primary_customer_addresses_relations extends Migration
             ->andWhere(['not', ['customers.primaryShippingAddressId' => null]])
             ->column();
 
-        foreach ($rougueTwos as $id) {
-            $this->update('{{%commerce_customers}}', ['primaryShippingAddressId' => null], ['primaryShippingAddressId' => $id]);
-        }
+        $this->update('{{%commerce_customers}}', ['primaryShippingAddressId' => null], ['primaryShippingAddressId' => $rougueTwos]);
 
         $this->addForeignKey(null, '{{%commerce_customers}}', ['primaryBillingAddressId'], '{{%commerce_addresses}}', ['id'], 'SET NULL');
         $this->addForeignKey(null, '{{%commerce_customers}}', ['primaryShippingAddressId'], '{{%commerce_addresses}}', ['id'], 'SET NULL');


### PR DESCRIPTION
TL;DR
This migration was taking hours for it to run on my database. I figured I'd check out why. It looks like it was running a bunch of queries. I'm hoping y'all look at this and are like oh yeah we totally should have done this, hindsight 20/20 and whatnot.

----------

So I'm in the middle of upgrading our Craft Site to Craft 3, Commerce is next up on the plate. I just start devouring the migrations. As in, each time I run the migration something new breaks (most of them database integrity/my fault). Brad via support email was just stellar in resolving some of the issues that weren't my fault. 

Regardless, I keep chugging through migrations until I get to `m170830_130000_order_refactor`. That thing is a beast and probably no way to make faster. It consistently took about 30 minutes to run. That's fine. Whatever. When we upgrade production I'll just grab a couple beers and make sure my boss doesn't call me while the sites down. 

Yada yada keep on chugging and then I get to this bad boy `m180402_161903_primary_customer_addresses_relations`. IT. TOOK. FOREVER. After 1.7 hours my nginx timed out (that I just upped to accommodate for long migrations). Anyways, I'm sitting here thinking I can just up the nginx timeout again and run through this process, but the back of my mind is like "No, David. That's too long. Maybe you can make it better. Maybe you can change the world." So I did. I got up from my desk, went to the little automated kiosk they have in my co-working space, bought a bag of Andersson Pretzels, and then updated that file.

All this to say, I'm fairly certain my updates are doing the exact same thing the migration was previously doing and accomplishing it much faster. Rather than a separate query for each update, this will group them all together into a single update query.