### PR TITLE
Fix warning on sale migration on mysql

### DIFF
--- a/src/migrations/m180217_130000_sale_migration.php
+++ b/src/migrations/m180217_130000_sale_migration.php
@@ -19,6 +19,8 @@ class m180217_130000_sale_migration extends Migration
      */
     public function safeUp()
     {
+        $this->alterColumn('{{%commerce_sales}}', 'discountType', $this->string());
+
         $this->update('{{%commerce_sales}}', ['discountType' => 'byPercent'], ['discountType' => 'percent']);
         $this->update('{{%commerce_sales}}', ['discountType' => 'byFlat'], ['discountType' => 'flat']);
 


### PR DESCRIPTION
Issue #282 has all of the info for what was happening. Basically, on mysql you get a warning if you try to update a value for an enum column where that value doesn't exist as a valid one on the enum. I can think of two ways to fix that, the first would be to update the enum column to add the possible values (along with the deprecated ones). Then after the update to remove the deprecated ones, update the enum to only include the new values.

The second way and in my opinion the simpler and more scalable way is just to update the enum column to a string so you update the values to whatever you want and then update it back to an enum after the operation happens.

The code that @samuelbirch posted in #282 is the exact same change this pull request handles.

Resolves #282