### PR TITLE
Fix getrate shippingCategoryId

### DIFF
--- a/src/models/ShippingRule.php
+++ b/src/models/ShippingRule.php
@@ -363,7 +363,7 @@ class ShippingRule extends Model implements ShippingRuleInterface
         }
 
         foreach ($this->getShippingRuleCategories() as $ruleCategory) {
-            if ($shippingCategoryId === $ruleCategory->shippingCategoryId && $ruleCategory->$attribute !== null) {
+            if ( (int) $shippingCategoryId === (int) $ruleCategory->shippingCategoryId && $ruleCategory->$attribute !== null) {
                 return $ruleCategory->$attribute;
             }
         }


### PR DESCRIPTION
This fix issue #381 by casting $shippingCategoryId and $ruleCategory->shippingCategoryId as integer.

On the shipping method page, both of them are strings and are _getRate is returning the proper amount. On the saving action, $shippingCategoryId is an integer and $ruleCategory->shippingCategoryId is a string, thus the condition is never true and the shipping amount is never updated on the payment page.