### PR TITLE
Fix the price input value in variant edit

### DIFF
--- a/src/templates/products/_fields.html
+++ b/src/templates/products/_fields.html
@@ -148,7 +148,7 @@
         id: 'price',
         label: 'Price'|t('commerce'),
         name: 'price',
-        value: (variant.price == '0' ? '0'|number : (variant.price ? variant.price|number ?: '')),
+        value: (variant.price == '0' ? '0'|number : (variant.price ? variant.price|number_format(2,'.','') ?: '')),
         placeholder: 'Enter price'|t('commerce'),
         unit: craft.commerce.paymentCurrencies.primaryPaymentCurrency.iso,
         required: true,


### PR DESCRIPTION
In a product page with variant, the price formated with the **number** filter was causing a bug if the number was greater than 1000 or if the number has decimal.

1000 is formatted as 1&nbps;000
19.99 is formatted as 19,99

The problem is the number input doesn't validate these value and on the page load the field can not be populate with the last value.

I've replace the number filter by a standard number_format(2,'.','') to apply the correct format.