### PR TITLE
fix position of closing div in product/_edit

### DIFF
--- a/src/templates/products/_edit.html
+++ b/src/templates/products/_edit.html
@@ -232,7 +232,8 @@
     {% endif %}
 
     {% hook "cp.commerce.product.edit.details" %}
-    {% endblock %}
+</div>
+{% endblock %}
 
 
     {% if not product.slug %}
@@ -240,4 +241,3 @@
             window.slugGenerator = new Craft.SlugGenerator('#title', '#slug');
         {% endjs %}
     {% endif %}
-</div>


### PR DESCRIPTION
#410 The last commit that was adding the </div> in the template `templates/products/_edit.hml` has broke the edit product page. The tag has been added outside the block statement and a twig error was thrown:

 `A template that extends another one cannot include content outside Twig blocks. Did you forget to put the content inside a {% block %} tag?`

I've move the closing tag juste before the endblock tag to resolve the error.