### PR TITLE
craft-sprout-import - Product Variants - extra content fields not importing

### DIFF
--- a/src/helpers/Product.php
+++ b/src/helpers/Product.php
@@ -59,6 +59,7 @@ class Product
         $variantModel->maxQty = LocalizationHelper::normalizeNumber($variant['maxQty']);
 
         if (isset($variant['fields'])) {
+            $variantModel->setFieldValues($variant['fields']);
             $variantModel->setFieldValuesFromRequest("variants.{$key}.fields");
         }
 


### PR DESCRIPTION
### Description

There is no way to import content fields due to the way craft\commerce\helpers\Product. It wants the data to be in the request, but in the case of an import then it's not.

Original issue was posted here: https://github.com/barrelstrength/craft-sprout-import/issues/55
