### PR TITLE
Add ability to customize fields captured in snapshots

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -341,10 +341,12 @@ class Variant extends Purchasable
         $data['product'] = $this->getProduct() ? $this->getProduct()->getSnapshot() : [];
 
         // Variant Custom Field values
-        $data['productFields'] = $this->getProduct() ? $this->getProduct()->getSerializedFieldValues() : [];
+        $productFields = Plugin::getInstance()->getSettings()->productSnapshotFields;
+        $data['productFields'] = $this->getProduct() ? $this->getProduct()->getSerializedFieldValues($productFields) : [];
 
         // Variant Custom Field values
-        $data['fields'] = $this->getSerializedFieldValues();
+        $variantFields = Plugin::getInstance()->getSettings()->variantSnapshotFields;
+        $data['fields'] = $this->getSerializedFieldValues($variantFields);
 
         return array_merge($this->getAttributes(), $data);
     }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -137,6 +137,16 @@ class Settings extends Model
      */
     public $gatewaySettings = [];
 
+    /**
+     * @var null|array A list of Product field handles to be captured as part of the snapshot, when a new LineItem is created, or `null` for all fields.
+     */
+    public $variantSnapshotFields = null;
+
+    /**
+     * @var null|array A list of Variant field handles to be captured as part of the snapshot, when a new LineItem is created, or `null` for all fields.
+     */
+    public $productSnapshotFields = null;
+
     // Public Methods
     // =========================================================================
 


### PR DESCRIPTION
In a project's `commerce.php` config file, merchants/developers can provide two new keys:
1. `variantSnapshotFields`
2. `productSnapshotFields`

…both can be set to an empty array to disable any content field fetching, or to select just a subset of available fields. Each element in the array must be a field's handle.

This applies to both Variants and Products. A default `null` value preserves current functionality.