### PR TITLE
Add `$address` in save return for controller

### DIFF
--- a/src/controllers/CustomerAddressesController.php
+++ b/src/controllers/CustomerAddressesController.php
@@ -112,7 +112,7 @@ class CustomerAddressesController extends BaseFrontEndController
             }
 
             if (Craft::$app->getRequest()->getAcceptsJson()) {
-                return $this->asJson(['success' => true]);
+                return $this->asJson(['success' => true, 'address' => $address]);
             }
             $this->redirectToPostedUrl();
         } else {


### PR DESCRIPTION
This is inline with [AddressesController:107](https://github.com/craftcms/commerce/blob/develop/src/controllers/AddressesController.php#L107) which is doing a similar thing. Additionally, for non-JSON requests, the resulting address is returned through the `setRouteParams()` function, so it makes sense to do the same thing for JSON requests.