### PR TITLE
Event-based Variant and Product Snapshot Customization

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -11,6 +11,10 @@ use Craft;
 use craft\base\Element;
 use craft\commerce\base\Purchasable;
 use craft\commerce\elements\db\VariantQuery;
+use craft\commerce\events\CustomizeVariantSnapshotFieldsEvent;
+use craft\commerce\events\CustomizeVariantSnapshotDataEvent;
+use craft\commerce\events\CustomizeProductSnapshotFieldsEvent;
+use craft\commerce\events\CustomizeProductSnapshotDataEvent;
 use craft\commerce\helpers\Currency;
 use craft\commerce\models\LineItem;
 use craft\commerce\models\ProductType;
@@ -35,6 +39,83 @@ use yii\db\Expression;
  */
 class Variant extends Purchasable
 {
+    // Constants
+    // =========================================================================
+
+    /**
+     * @event craft\commerce\events\CustomizeVariantSnapshotFieldsEvent This event is raised before a variant's snapshot is captured
+     *
+     * Plugins can get notified before we capture a variant's field data, and customize which fields are included.
+     *
+     * ```php
+     * use craft\commerce\elements\Variant;
+     * use craft\commerce\events\CustomizeVariantSnapshotFieldsEvent;
+     *
+     * Event::on(Variant::class, Variant::EVENT_BEFORE_CAPTURE_VARIANT_SNAPSHOT, function(CustomizeVariantSnapshotFieldsEvent $e) {
+     *     $variant = $e->variant;
+     *     $fields = $e->fields;
+     *     // Modify fields, or set to `null` to capture all.
+     * });
+     * ```
+     */
+    const EVENT_BEFORE_CAPTURE_VARIANT_SNAPSHOT = 'beforeCaptureVariantSnapshot';
+
+    /**
+     * @event craft\commerce\events\CustomizeVariantSnapshotFieldsEvent This event is raised after a variant's snapshot is captured.
+     *
+     * Plugins can get notified after we capture a variant's field data, and customize, extend, or redact the data to be persisted.
+     *
+     * ```php
+     * use craft\commerce\elements\Variant;
+     * use craft\commerce\events\CustomizeVariantSnapshotDataEvent;
+     *
+     * Event::on(Variant::class, Variant::EVENT_AFTER_CAPTURE_VARIANT_SNAPSHOT, function(CustomizeVariantSnapshotFieldsEvent $e) {
+     *     $variant = $e->variant;
+     *     $data = $e->fieldData;
+     *     // Modify or redact captured `$data`...
+     * });
+     * ```
+     */
+    const EVENT_AFTER_CAPTURE_VARIANT_SNAPSHOT = 'afterCaptureVariantSnapshot';
+
+    /**
+     * @event craft\commerce\events\CustomizeProductSnapshotFieldsEvent This event is raised before a product snapshot is captured.
+     *
+     * Plugins can get notified before we capture a product's field data, and
+     * customize which fields are included.
+     *
+     * ```php
+     * use craft\commerce\elements\Variant;
+     * use craft\commerce\events\CustomizeProductSnapshotFieldsEvent;
+     *
+     * Event::on(Variant::class, Variant::EVENT_BEFORE_CAPTURE_PRODUCT_SNAPSHOT, function(CustomizeProductSnapshotFieldsEvent $e) {
+     *     $product = $e->product;
+     *     $fields = $e->fields;
+     *     // Modify fields, or set to `null` to capture all.
+     * });
+     * ```
+     */
+    const EVENT_BEFORE_CAPTURE_PRODUCT_SNAPSHOT = 'beforeCaptureProductSnapshot';
+
+    /**
+     * @event craft\commerce\events\CustomizeProductSnapshotDataEvent This event is raised before a product snapshot is captured
+     *
+     * Plugins can get notified after we capture a product's field data, and customize, extend, or redact the data to be persisted.
+     *
+     * ```php
+     * use craft\commerce\elements\Variant;
+     * use craft\commerce\events\CustomizeProductSnapshotDataEvent;
+     *
+     * Event::on(Variant::class, Variant::EVENT_AFTER_CAPTURE_PRODUCT_SNAPSHOT, function(CustomizeProductSnapshotFieldsEvent $e) {
+     *     $product = $e->product;
+     *     $data = $e->fieldData;
+     *     // Modify or redact captured `$data`...
+     * });
+     * ```
+     */
+    const EVENT_AFTER_CAPTURE_PRODUCT_SNAPSHOT = 'afterCaptureProductSnapshot';
+
+
     // Properties
     // =========================================================================
 
@@ -340,11 +421,57 @@ class Variant extends Purchasable
         // Product Attributes
         $data['product'] = $this->getProduct() ? $this->getProduct()->getSnapshot() : [];
 
-        // Variant Custom Field values
-        $data['productFields'] = $this->getProduct() ? $this->getProduct()->getSerializedFieldValues() : [];
+        // Default Product custom field handles
+        $productFields = null;
+        $productFieldsEvent = new CustomizeProductSnapshotFieldsEvent([
+            'product' => $this->getProduct(),
+            'fields' => $productFields
+        ]);
 
-        // Variant Custom Field values
-        $data['fields'] = $this->getSerializedFieldValues();
+        // Allow plugins to modify Product fields to be fetched
+        if ($this->hasEventHandlers(self::EVENT_BEFORE_CAPTURE_PRODUCT_SNAPSHOT)) {
+            $this->trigger(self::EVENT_BEFORE_CAPTURE_PRODUCT_SNAPSHOT, $productFieldsEvent);
+        }
+
+        // Capture specified Product field data
+        $productFieldData = $this->getProduct() ? $this->getProduct()->getSerializedFieldValues($productFieldsEvent->fields) : [];
+        $productDataEvent = new CustomizeProductSnapshotDataEvent([
+            'product' => $this->getProduct(),
+            'fieldData' => $productFieldData
+        ]);
+
+        // Allow plugins to modify captured Product data
+        if ($this->hasEventHandlers(self::EVENT_AFTER_CAPTURE_PRODUCT_SNAPSHOT)) {
+            $this->trigger(self::EVENT_AFTER_CAPTURE_PRODUCT_SNAPSHOT, $productDataEvent);
+        }
+
+        $data['productFields'] = $productDataEvent->fieldData;
+
+        // Default Variant custom field handles
+        $variantFields = null;
+        $variantFieldsEvent = new CustomizeVariantSnapshotFieldsEvent([
+            'variant' => $this,
+            'fields' => $variantFields
+        ]);
+
+        // Allow plugins to modify fields to be fetched
+        if ($this->hasEventHandlers(self::EVENT_BEFORE_CAPTURE_VARIANT_SNAPSHOT)) {
+            $this->trigger(self::EVENT_BEFORE_CAPTURE_VARIANT_SNAPSHOT, $variantFieldsEvent);
+        }
+
+        // Capture specified Variant field data
+        $variantFieldData = $this->getSerializedFieldValues($variantFieldsEvent->fields);
+        $variantDataEvent = new CustomizeVariantSnapshotDataEvent([
+            'variant' => $this,
+            'fieldData' => $variantFieldData
+        ]);
+
+        // Allow plugins to modify captured Variant data
+        if ($this->hasEventHandlers(self::EVENT_AFTER_CAPTURE_VARIANT_SNAPSHOT)) {
+            $this->trigger(self::EVENT_AFTER_CAPTURE_VARIANT_SNAPSHOT, $variantDataEvent);
+        }
+
+        $data['fields'] = $variantDataEvent->fieldData;
 
         return array_merge($this->getAttributes(), $data);
     }

--- a/src/events/CustomizeProductSnapshotDataEvent.php
+++ b/src/events/CustomizeProductSnapshotDataEvent.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use yii\base\Event;
+
+/**
+ * Class CustomizeProductSnapshotDataEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 2.0
+ */
+class CustomizeProductSnapshotDataEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Product The product
+     */
+    public $product;
+
+    /**
+     * @var array The captured data
+     */
+    public $fieldData;
+}

--- a/src/events/CustomizeProductSnapshotFieldsEvent.php
+++ b/src/events/CustomizeProductSnapshotFieldsEvent.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use yii\base\Event;
+
+/**
+ * Class CustomizeProductSnapshotFieldsEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 2.0
+ */
+class CustomizeProductSnapshotFieldsEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Product The product
+     */
+    public $product;
+
+    /**
+     * @var array|null The fields to be captured
+     */
+    public $fields;
+}

--- a/src/events/CustomizeVariantSnapshotDataEvent.php
+++ b/src/events/CustomizeVariantSnapshotDataEvent.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use yii\base\Event;
+
+/**
+ * Class CustomizeVariantSnapshotDataEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 2.0
+ */
+class CustomizeVariantSnapshotDataEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Variant The variant
+     */
+    public $variant;
+
+    /**
+     * @var array The captured data
+     */
+    public $fieldData;
+}

--- a/src/events/CustomizeVariantSnapshotFieldsEvent.php
+++ b/src/events/CustomizeVariantSnapshotFieldsEvent.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use yii\base\Event;
+
+/**
+ * Class CustomizeVariantSnapshotFieldsEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 2.0
+ */
+class CustomizeVariantSnapshotFieldsEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Variant The variant
+     */
+    public $variant;
+
+    /**
+     * @var array|null The fields to be captured
+     */
+    public $fields;
+}


### PR DESCRIPTION
This is accomplished by a series of two events, each for Variants and Products:
- Before the data is captured, there's an opportunity to modify the fields that will be gathered.
- After the data is captured, there's an opportunity to modify the data that comes back from the serialization.

This is a non-breaking change, as the default `null` value is preserved, if no plugins modify the field list.