### PR TITLE
Fix SQL error when saving Order Statuses

### DIFF
--- a/src/services/OrderStatuses.php
+++ b/src/services/OrderStatuses.php
@@ -216,10 +216,10 @@ class OrderStatuses extends Component
 
             //Delete old links
             if ($model->id) {
-                $records = OrderStatusEmailRecord::find()->where(['orderStatusId' => $model->id])->all();
+                $orderStatusEmailRecords = OrderStatusEmailRecord::find()->where(['orderStatusId' => $model->id])->all();
 
-                foreach ($records as $record) {
-                    $record->delete();
+                foreach ($orderStatusEmailRecords as $orderStatusEmailRecord) {
+                    $orderStatusEmailRecord->delete();
                 }
             }
 


### PR DESCRIPTION
The `$record` variable in `craft\commerce\services\OrderStatuses::saveOrderStatus` was being re-assigned inside a `foreach` loop, and causing some unexpected behavior, described in the referenced issue.

Fixes #447!