### PR TITLE
Update deprecation warning to correct method

### DIFF
--- a/src/plugin/DeprecatedVariables.php
+++ b/src/plugin/DeprecatedVariables.php
@@ -55,7 +55,7 @@ trait DeprecatedVariables
      */
     public function getCountriesList(): array
     {
-        Craft::$app->getDeprecator()->log('craft.commerce.countriesList', 'craft.commerce.countriesList has been deprecated. Use craft.commerce.countries.countriesAsList instead');
+        Craft::$app->getDeprecator()->log('craft.commerce.countriesList', 'craft.commerce.countriesList has been deprecated. Use craft.commerce.countries.allCountriesAsList instead');
 
         return $this->getCountries()->getAllCountriesAsList();
     }


### PR DESCRIPTION
This name says it all. I got this deprecation warning and then the template failed. After checking, what this method was calling I noticed it had been renamed in the new service.