### PR TITLE
Split custom emails by commas into an array

### DIFF
--- a/src/services/Emails.php
+++ b/src/services/Emails.php
@@ -209,7 +209,10 @@ class Emails extends Component
         if ($email->recipientType == EmailRecord::TYPE_CUSTOM) {
             // To:
             try {
-                $newEmail->setTo($view->renderString($email->to, $renderVariables));
+                $emails = $view->renderString($email->to, $renderVariables);
+                $emails = preg_split('/[\s,]+/', $emails);
+
+                $newEmail->setTo($emails);
             } catch (\Exception $e) {
                 $error = Craft::t('commerce', 'Email template parse error for custom email “{email}” in “To:”. Order: “{order}”. Template error: “{message}”', [
                     'email' => $email->name,
@@ -239,7 +242,7 @@ class Emails extends Component
         try {
             $bcc = $view->renderString($email->bcc, $renderVariables);
             $bcc = str_replace(';', ',', $bcc);
-            $bcc = explode(',', $bcc);
+            $bcc = preg_split('/[\s,]+/', $bcc);
 
             if (array_filter($bcc)) {
                 $newEmail->setBcc($bcc);


### PR DESCRIPTION
Docs say you can `select "Send to custom recipients", which allows you to add any email addresses seperated by a comma`. Currently though, there's no parsing of this string so the "to" attribute of the email is set to the single string of comma separated emails, which bombs out as an invalid email address.

This PR splits the incoming `to` field by whitespace/comma and passes the resulting array in.