### PR TITLE
Update deprecation note for getTotalTax()

### DIFF
--- a/src/base/OrderDeprecatedTrait.php
+++ b/src/base/OrderDeprecatedTrait.php
@@ -23,7 +23,7 @@ trait OrderDeprecatedTrait
      */
     public function getTotalTax(): float
     {
-        Craft::$app->getDeprecator()->log('Order::getTotalTax()', 'Order::getTotalTax() has been deprecated. Use Order::getAdjustmentsTotalByType("taxIncluded") instead.');
+        Craft::$app->getDeprecator()->log('Order::getTotalTax()', 'Order::getTotalTax() has been deprecated. Use Order::getAdjustmentsTotalByType("tax") instead.');
 
         return $this->getAdjustmentsTotalByType('tax');
     }


### PR DESCRIPTION
The documentation wrongly implied using the 'taxIncluded' adjustment type for even the tax not included adjustment.