### PR TITLE
Fix for saving a line item with a negative total

### DIFF
--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -291,7 +291,7 @@ class LineItem extends Model
      */
     public function getTotal(): float
     {
-        return $this->getSubtotal() + $this->getAdjustmentsTotal();
+        return max($this->getSubtotal() + $this->getAdjustmentsTotal(), 0);
     }
 
     /**


### PR DESCRIPTION
When a line item's adjustments makes a the total for that line item negative saving
that line item errors out. This uses the same methodology that is used
for the sale price in that model.

Here is the SQL error:
```
SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'total' at row 1
```

You can replicate this by adding a custom adjuster that adds a discount greater than the salePrice of the item.