### PR TITLE
Fix for associating adjustments to line items

### DIFF
--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -485,7 +485,7 @@ class LineItem extends Model
         $adjustments = $this->getOrder()->getAdjustments();
 
         foreach ($adjustments as $adjustment) {
-            if ($adjustment->lineItemId == $this->id) {
+            if ($adjustment->lineItemId && $adjustment->lineItemId == $this->id) {
                 $lineItemAdjustments[] = $adjustment;
             }
         }


### PR DESCRIPTION
Because new line items don't have an id yet, the `getAdjustments` method
on the line items model associates any base order adjustment with that new
line item. This adds a condition to avoid that weirdness.

This is very related to #498 and very much caused by #422