### PR TITLE
Fix for payment processing of free orders

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -961,7 +961,7 @@ class Order extends Element
      */
     public function getIsPaid(): bool
     {
-        return $this->getOutstandingBalance() <= 0 && $this->isCompleted;
+        return !$this->hasOutstandingBalance() && $this->isCompleted;
     }
 
     /**
@@ -1029,6 +1029,14 @@ class Order extends Element
     }
 
     /**
+     * @return bool
+     */
+    public function hasOutstandingBalance()
+    {
+        return $this->getOutstandingBalance() > 0;
+    }
+
+    /**
      * Returns the total `purchase` and `captured` transactions belonging to this order.
      *
      * @return float
@@ -1043,7 +1051,7 @@ class Order extends Element
      */
     public function getIsUnpaid(): bool
     {
-        return $this->getOutstandingBalance() > 0;
+        return $this->hasOutstandingBalance();
     }
 
     /**

--- a/src/services/Payments.php
+++ b/src/services/Payments.php
@@ -187,7 +187,7 @@ class Payments extends Component
         }
 
         // Order could have zero totalPrice and already considered 'paid'. Free orders complete immediately.
-        if ($order->getIsPaid()) {
+        if (!$order->hasOutstandingBalance()) {
             if (!$order->datePaid) {
                 $order->datePaid = Db::prepareDateForDb(new \DateTime());
             }


### PR DESCRIPTION
Orders placed through `PaymentsController#actionPay` that do not have an
outstanding balance will still try to send to the payment gateway. This
causes issues with payment gateways that fail due to an invalid amount.
In this instance, commerce-stripe fails to process a payment because the
amount is a non-positive integer.

The root cause of this issue is that the `getIsPaid()` function on the
Order elements is checking if the order is complete to return whether it
was paid. I was afraid to remove the check of `isComplete` out of that
function because it seemed to be there intentionally.

To fix this, I added a new public function to the order element
`hasOutstandingBalance()` this actually helps remove some duplicated
conditionals throughout the codebase. Finally, I updated the payments
service to utilize this method instead of the `getIsPaid`.