### PR TITLE
Progress meter on checkout page breaks if website in subfolder

### DIFF
--- a/templates/shop/_includes/meter.html
+++ b/templates/shop/_includes/meter.html
@@ -26,7 +26,7 @@
         {% for key, step in steps %}
 
             {% set class = '' %}
-            {% if craft.app.request.url|slice(1) == step.url %}
+            {% if craft.app.request.pathInfo == step.url %}
                 {% set width = ((key + 1) * 100 / steps|length) - 20 %}
                 {% set class = "sel" %}
                 {% set currentStep = key %}


### PR DESCRIPTION
Using `craft.app.request.url|slice(1)` will cause a mismatch if the site lives in a subfolder, using `craft.app.request.pathInfo` fixes this.

If your website URL is domain.com/subfolder/, craft will interpret the current checkout step as `subfolder/shop/checkout/address` instead of `shop/checkout/address`