### PR TITLE
Fix error in ShippingRules.php

### DIFF
--- a/src/services/ShippingRules.php
+++ b/src/services/ShippingRules.php
@@ -80,7 +80,7 @@ class ShippingRules extends Component
         }
 
         if ($this->_fetchedAllShippingRules) {
-            return null;
+            return [];
         }
 
         $results = $this->_createShippingRulesQuery()


### PR DESCRIPTION
I'm getting the following error (attached screenshot).

`Return value of craft\commerce\services\ShippingRules::getAllShippingRulesByShippingMethodId() must be of the type array, null returned`

This would seem a pretty easy fix, as noted by the functions return type.

<img width="1276" alt="screen shot 2018-10-14 at 12 12 27 am" src="https://user-images.githubusercontent.com/1221575/46905940-94729e00-cf46-11e8-9a1a-b46d9dae65b6.png">
