### PR TITLE
Add `EVENT_AFTER_REMOVE_LINE_ITEM` event for Order

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -122,6 +122,24 @@ class Order extends Element
     const EVENT_AFTER_ADD_LINE_ITEM = 'afterAddLineItemToOrder';
 
     /**
+     * @event \yii\base\Event This event is raised when a line item is removed from the order
+     *
+     * Plugins can get notified after a line item has been removed from the order
+     *
+     * ```php
+     * use craft\commerce\elements\Order;
+     * use yii\base\Event;
+     *
+     * Event::on(Order::class, Order::EVENT_AFTER_REMOVE_LINE_ITEM, function(Event $e) {
+     *     $lineItem = $e->lineItem;
+     *     $isNew = $e->isNew;
+     *     // ...
+     * });
+     * ```
+     */
+    const EVENT_AFTER_REMOVE_LINE_ITEM = 'afterRemoveLineItemToOrder';
+
+    /**
      * @event \yii\base\Event This event is raised when an order is completed
      *
      * Plugins can get notified before an order is completed
@@ -687,6 +705,13 @@ class Order extends Element
                 unset($lineItems[$key]);
                 $this->setLineItems($lineItems);
             }
+        }
+
+        // Raising the 'afterRemoveLineItemToOrder' event
+        if ($this->hasEventHandlers(self::EVENT_AFTER_REMOVE_LINE_ITEM)) {
+            $this->trigger(self::EVENT_AFTER_REMOVE_LINE_ITEM, new LineItemEvent([
+                'lineItem' => $lineItem,
+            ]));
         }
     }
 


### PR DESCRIPTION
Just wanted to add this event for compatibility with [Instant Analytics](https://github.com/nystudio107/craft-instantanalytics) but also just handy to have.