### PR TITLE
Sort order in orders widget

### DIFF
--- a/src/widgets/Orders.php
+++ b/src/widgets/Orders.php
@@ -133,7 +133,7 @@ class Orders extends Widget
         $query->isCompleted(true);
         $query->dateOrdered(':notempty:');
         $query->limit($limit);
-        $query->orderBy('dateOrdered');
+        $query->orderBy('dateOrdered DESC');
 
         if ($orderStatusId) {
             $query->orderStatusId($orderStatusId);


### PR DESCRIPTION
The orders were sorted by date ASC, which should be DESC, in the Recent Orders widget.