### PR TITLE
Rename `getShippingCategoriesByProductId` method and single call

### DIFF
--- a/src/models/ProductType.php
+++ b/src/models/ProductType.php
@@ -202,7 +202,7 @@ class ProductType extends Model
     public function getShippingCategories(): array
     {
         if (!$this->_shippingCategories) {
-            $this->_shippingCategories = Plugin::getInstance()->getShippingCategories()->getShippingCategoriesByProductId($this->id);
+            $this->_shippingCategories = Plugin::getInstance()->getShippingCategories()->getShippingCategoriesByProductTypeId($this->id);
         }
 
         return $this->_shippingCategories;

--- a/src/services/ShippingCategories.php
+++ b/src/services/ShippingCategories.php
@@ -231,7 +231,7 @@ class ShippingCategories extends Component
      * @param $productTypeId
      * @return array
      */
-    public function getShippingCategoriesByProductId($productTypeId): array
+    public function getShippingCategoriesByProductTypeId($productTypeId): array
     {
         $rows = $this->_createShippingCategoryQuery()
             ->innerJoin('{{%commerce_producttypes_shippingcategories}} productTypeShippingCategories', '[[shippingCategories.id]] = [[productTypeShippingCategories.shippingCategoryId]]')


### PR DESCRIPTION
Now `getShippingCategoriesByProductTypeId`, to reflect that it's fetching _Product Type_ -> Shipping Category relationships, not _Product_ -> Shipping Category relationships (for which there isn't a join table, and a service method isn't needed/available).

This appears to be a safe change (only reference was in `ProductType::getShippingCategories`), but might require a deprecation notice, in case someone is using this service method directly in their templates?