### PR TITLE
Table Notes + Messages Output

### DIFF
--- a/src/templates/orders/_history.html
+++ b/src/templates/orders/_history.html
@@ -34,7 +34,13 @@
                                 {{ orderHistory.order.email }}
                             {% endif %}
                         </td>
-                        <td>{{ orderHistory.message }}</td>
+                        <td>
+                            {% if orderHistory.message %}
+                                <span class="info">
+                                    {{ orderHistory.message | md }}
+                                </span>
+                            {% endif %}
+                        </td>
                         <td>{{ orderHistory.dateCreated|date }}</td>
                     </tr>
                 {% endfor %}

--- a/src/templates/orders/_orderDetails.html
+++ b/src/templates/orders/_orderDetails.html
@@ -56,7 +56,11 @@
                             {% endif %}
                         </td>
                         <td data-title="{{ 'Note'|t('commerce') }}">
-                            {% if lineItem.note %}{{ lineItem.note|nl2br }}{% endif %}
+                            {% if lineItem.note %}
+                                <span class="info">
+                                    {{ lineItem.note|nl2br }}
+                                </span>
+                            {% endif %}
                         </td>
                         <td data-title="{{ 'Price'|t('commerce') }}">
                             {{ lineItem.salePrice|currency(order.currency) }}


### PR DESCRIPTION
This moves line item notes and order status messages into tooltips, so the tables remain readable when long messages are included.

I believe this addresses the concern in #583!