### PR TITLE
Get Plans by Information Entry ID

### DIFF
--- a/src/services/Plans.php
+++ b/src/services/Plans.php
@@ -97,17 +97,7 @@ class Plans extends Component
         $results = $this->_createPlansQuery()
             ->all();
 
-        $plans = [];
-
-        foreach ($results as $result) {
-            try {
-                $plans[] = $this->_populatePlan($result);
-            } catch (InvalidConfigException $exception) {
-                continue; // Just skip this
-            }
-        }
-
-        return $plans;
+        return $this->_populatePlans($results);
     }
 
     /**
@@ -121,17 +111,7 @@ class Plans extends Component
             ->where(['enabled' => true])
             ->all();
 
-        $sources = [];
-
-        foreach ($results as $result) {
-            try {
-                $sources[] = $this->_populatePlan($result);
-            } catch (InvalidConfigException $exception) {
-                continue; // Just skip this
-            }
-        }
-
-        return $sources;
+        return $this->_populatePlans($results);
     }
 
     /**
@@ -146,17 +126,7 @@ class Plans extends Component
             ->where(['gatewayId' => $gatewayId])
             ->all();
 
-        $plans = [];
-
-        foreach ($results as $result) {
-            try {
-                $plans[] = $this->_populatePlan($result);
-            } catch (InvalidConfigException $exception) {
-                continue; // Just skip this
-            }
-        }
-
-        return $plans;
+        return $this->_populatePlans($results);
     }
 
     /**
@@ -336,6 +306,27 @@ class Plans extends Component
             ])
             ->where(['isArchived' => false])
             ->from(['{{%commerce_plans}}']);
+    }
+
+    /**
+     * Populate an array of plans from their database table rows
+     *
+     * @param array $results
+     * @return Plan[]
+     */
+    private function _populatePlans(array $results): array
+    {
+        $plans = [];
+
+        foreach ($results as $result) {
+            try {
+                $plans[] = $this->_populatePlan($result);
+            } catch (InvalidConfigException $exception) {
+                continue; // Just skip this
+            }
+        }
+
+        return $plans;
     }
 
     /**

--- a/src/services/Plans.php
+++ b/src/services/Plans.php
@@ -194,6 +194,22 @@ class Plans extends Component
     }
 
     /**
+     * Returns plans which use the provided Entry for its "information"
+     *
+     * @param string $id The Entry ID to search by
+     * @return Plan|null
+     * @throws InvalidConfigException if the plan configuration is not correct
+     */
+    public function getPlansByInformationEntryId(int $entryId)
+    {
+        $results = $this->_createPlansQuery()
+            ->where(['planInformationId' => $entryId])
+            ->all();
+
+        return $this->_populatedPlans($results);
+    }
+
+    /**
      * Save a subscription plan
      *
      * @param Plan $plan The payment source being saved.


### PR DESCRIPTION
This seemed like a useful method—we'll often have a plan's informational Entry tucked away on a page, and need to be able to do a reverse-lookup to render a subscription form.

In a template, this makes it possible to:

```twig
{% set plan = craft.commerce.plans.getPlansByInformationEntryId(entry.id) | first %}
```

I figured returning an array was safer, granted you _can_ attach the same Entry to multiple plans…