### PR TITLE
Bugfix: Removing all items from cart (Commerce Lite)

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1202,8 +1202,12 @@ class Order extends Element
         }
 
         if (Plugin::getInstance()->is(Plugin::EDITION_LITE)) {
-            $last = array_values(array_slice($lineItems, -1))[0];
-            $this->_lineItems = [$last];
+            if(count($lineItems)){
+                $last = array_values(array_slice($lineItems, -1))[0];
+                $this->_lineItems = [$last];
+            }else{
+                $this->_lineItems = [[]];
+            }
         } else {
             $this->_lineItems = $lineItems;
         }


### PR DESCRIPTION
Fixes an issue where removing the last item from the cart would cause an error:

> Undefined offset: 0 in _/craft/vendor/craftcms/commerce/src/elements/Order.php_

This would only happen in the Lite-Version, since it is limited to one item in the cart.

Checking at first, whether `$lineItems` has at least one item, before running `array_slice()`, fixes the issue.