### PR TITLE
Update $siteSettings to be used as an array

### DIFF
--- a/src/services/ProductTypes.php
+++ b/src/services/ProductTypes.php
@@ -481,7 +481,7 @@ class ProductTypes extends Component
 
                 if (!$siteSettingsRecord->getIsNewRecord()) {
                     // Did it used to have URLs, but not anymore?
-                    if ($siteSettingsRecord->isAttributeChanged('hasUrls', false) && !$siteSettings->hasUrls) {
+                    if ($siteSettingsRecord->isAttributeChanged('hasUrls', false) && !$siteSettings['hasUrls']) {
                         $sitesNowWithoutUrls[] = $siteId;
                     }
 


### PR DESCRIPTION
The $siteSettings usage on line 484 of ProductTypes is for an object

This is supposed to be an array, per the 3.1 upgrades

It appears like it was missed here: https://github.com/craftcms/commerce/commit/fc5fc52d379bd79e1d0e2e4e47dbc25a4ec5e4d4

Closes #645 