### PR TITLE
Save inactive product with variants

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -306,6 +306,7 @@ class Variant extends Purchasable
 
         $product = Product::find()
             ->id($this->productId)
+            ->status(null)
             ->siteId($this->siteId)
             ->trashed(null)
             ->one();


### PR DESCRIPTION
I've found that I was unable to save a product with variants when the status was inactive. I could create a product with an inactive status, but if I tried to save the product after that, an error stating that the product doesn't exist would occured.

I've just changed the get_product to search the product regardless of his status. My only concern is whether this change has a bigger impact than my case, but so far everything works for me.