### PR TITLE
Add a method to get the matching rule description

### DIFF
--- a/src/base/ShippingMethod.php
+++ b/src/base/ShippingMethod.php
@@ -175,7 +175,7 @@ abstract class ShippingMethod extends Model implements ShippingMethodInterface
 
     /**
      * @param Order $order
-     * @return float
+     * @return string
      */
     public function getDescriptionForOrder(Order $order)
     {

--- a/src/base/ShippingMethod.php
+++ b/src/base/ShippingMethod.php
@@ -174,6 +174,21 @@ abstract class ShippingMethod extends Model implements ShippingMethodInterface
     }
 
     /**
+     * @param Order $order
+     * @return float
+     */
+    public function getDescriptionForOrder(Order $order)
+    {
+        $shippingRule = $this->getMatchingShippingRule($order);
+
+        if (!$shippingRule) {
+            return 0;
+        }
+
+        return $shippingRule->description;
+    }
+    
+    /**
      * @deprecated in 2.0
      */
     public function getAmount()

--- a/src/base/ShippingMethod.php
+++ b/src/base/ShippingMethod.php
@@ -182,7 +182,7 @@ abstract class ShippingMethod extends Model implements ShippingMethodInterface
         $shippingRule = $this->getMatchingShippingRule($order);
 
         if (!$shippingRule) {
-            return 0;
+            return;
         }
 
         return $shippingRule->description;

--- a/src/base/ShippingMethodInterface.php
+++ b/src/base/ShippingMethodInterface.php
@@ -76,7 +76,13 @@ interface ShippingMethodInterface
      * @return float
      */
     public function getPriceForOrder(Order $order);
-
+    
+    /**
+     * @param Order $order
+     * @return float
+     */
+    public function getDescriptionForOrder(Order $order);
+    
     /**
      * The first matching shipping rule for this shipping method
      *

--- a/src/base/ShippingMethodInterface.php
+++ b/src/base/ShippingMethodInterface.php
@@ -79,7 +79,7 @@ interface ShippingMethodInterface
     
     /**
      * @param Order $order
-     * @return float
+     * @return string
      */
     public function getDescriptionForOrder(Order $order);
     


### PR DESCRIPTION
Similar to `getPriceForOrder()`, but to make the description easily available (without a json_encode filter on the rules).

Useful to display some specifics related to a ShippingMethod to the end user.