### PR TITLE
Removed premature rounding that leads to errors

### DIFF
--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -403,8 +403,8 @@ class LineItem extends Model
         }
 
         // If a plugin used the above event and changed the price of the product or
-        // its saleAmount we need to ensure the salePrice works calculates correctly and is rounded
-        $this->salePrice = CurrencyHelper::round($this->saleAmount + $this->price);
+        // its saleAmount we need to ensure the salePrice works calculates correctly
+        $this->salePrice = $this->saleAmount + $this->price;
 
         // salePrice can not be negative
         $this->salePrice = max($this->salePrice, 0);


### PR DESCRIPTION
Fixes issue #695 .
The values are rounded in the final total price calculation step anyway.
This makes sure the tax adjuster can work with the correct non-rounded value.