### PR TITLE
dannyvankooten/vat.php => ibericode/vat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "craftcms/cms": "^3.1.0",
     "dompdf/dompdf": "~0.8.2",
     "moneyphp/money": "^3.1.3",
-    "dannyvankooten/vat.php": "^1.1.2",
+    "ibericode/vat": "^1.1.2",
     "phpoffice/phpspreadsheet": "^1.4"
   },
   "autoload": {


### PR DESCRIPTION
`dannyvankooten/vat.php` is abandoned and replaced with `ibericode/vat`

Closes https://github.com/craftcms/commerce/issues/708