### PR TITLE
Fixed active subnav item for commerce settings

### DIFF
--- a/src/templates/settings/emails/_edit.html
+++ b/src/templates/settings/emails/_edit.html
@@ -5,6 +5,8 @@
     { label: "Emails"|t('commerce'), url: url('commerce/settings/emails') },
 ] %}
 
+{% set selectedSubnavItem = 'settings' %}
+
 {% set fullPageForm = true %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/settings/gateways/_edit.html
+++ b/src/templates/settings/gateways/_edit.html
@@ -5,6 +5,8 @@
     { label: "Gateways"|t('commerce'), url: url('commerce/settings/gateways') },
 ] %}
 
+{% set selectedSubnavItem = 'settings' %}
+
 {% set fullPageForm = true %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/settings/orderstatuses/_edit.html
+++ b/src/templates/settings/orderstatuses/_edit.html
@@ -5,6 +5,8 @@
     { label: 'Order Statuses'|t('commerce'), url: url('commerce/settings/orderstatuses') }
 ] %}
 
+{% set selectedSubnavItem = 'settings' %}
+
 {% set fullPageForm = true %}
 
 {% set selectedTab = 'settings' %}

--- a/src/templates/settings/producttypes/_edit.html
+++ b/src/templates/settings/producttypes/_edit.html
@@ -6,6 +6,8 @@
     { label: "Product Types"|t('commerce'), url: url('commerce/settings/producttypes') },
 ] %}
 
+{% set selectedSubnavItem = 'settings' %}
+
 {% set fullPageForm = true %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/settings/subscriptions/_editPlan.html
+++ b/src/templates/settings/subscriptions/_editPlan.html
@@ -6,6 +6,8 @@
     { label: "Subscription plans"|t('commerce'), url: url('commerce/settings/subscriptions/plans') },
 ] %}
 
+{% set selectedSubnavItem = 'settings' %}
+
 {% set fullPageForm = gatewayOptions|length > 0 %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/shipping/shippingcategories/_edit.html
+++ b/src/templates/shipping/shippingcategories/_edit.html
@@ -5,6 +5,8 @@
     { label: "Shipping Categories"|t('commerce'), url: url('commerce/shipping/shippingcategories') },
 ] %}
 
+{% set selectedSubnavItem = 'shipping' %}
+
 {% set fullPageForm = true %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/shipping/shippingmethods/_edit.html
+++ b/src/templates/shipping/shippingmethods/_edit.html
@@ -5,6 +5,8 @@
     { label: "Shipping Methods"|t('commerce'), url: url('commerce/shipping/shippingmethods') },
 ] %}
 
+{% set selectedSubnavItem = 'shipping' %}
+
 {% set fullPageForm = true %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/shipping/shippingrules/_edit.html
+++ b/src/templates/shipping/shippingrules/_edit.html
@@ -6,6 +6,8 @@
     { label: shippingMethod.getName()|t('commerce'), url: url('commerce/shipping/shippingmethods/'~methodId) },
 ] %}
 
+{% set selectedSubnavItem = 'shipping' %}
+
 {% set fullPageForm = true %}
 
 {% macro lazyCreateSelect(selectParams, newOptionLabel, modalHeading, html, js, action, successText) %}

--- a/src/templates/shipping/shippingzones/_edit.html
+++ b/src/templates/shipping/shippingzones/_edit.html
@@ -5,6 +5,8 @@
     { label: "Shipping Zones"|t('commerce'), url: url('commerce/shipping/shippingzones') },
 ] %}
 
+{% set selectedSubnavItem = 'shipping' %}
+
 {% set fullPageForm = true %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/tax/taxcategories/_edit.html
+++ b/src/templates/tax/taxcategories/_edit.html
@@ -5,6 +5,8 @@
     { label: "Tax Categories"|t('commerce'), url: url('commerce/tax/taxcategories') },
 ] %}
 
+{% set selectedSubnavItem = 'tax' %}
+
 {% set fullPageForm = true %}
 
 {% import "_includes/forms" as forms %}

--- a/src/templates/tax/taxrates/_edit.html
+++ b/src/templates/tax/taxrates/_edit.html
@@ -5,6 +5,8 @@
     { label: "Tax Rates"|t('commerce'), url: url('commerce/tax/taxrates') },
 ] %}
 
+{% set selectedSubnavItem = 'tax' %}
+
 {% set fullPageForm = true %}
 
 {% block content %}

--- a/src/templates/tax/taxzones/_edit.html
+++ b/src/templates/tax/taxzones/_edit.html
@@ -5,6 +5,8 @@
     { label: "Tax Zones"|t('commerce'), url: url('commerce/tax/taxzones') },
 ] %}
 
+{% set selectedSubnavItem = 'tax' %}
+
 {% set fullPageForm = true %}
 
 {% block content %}


### PR DESCRIPTION
I noticed that the active sidebar item for most of the settings "new" or "edit" pages were not set correctly, this should fix that.