### PR TITLE
Add event trigger to deleteAddressById method in the Addresses service.

### DIFF
--- a/src/services/Addresses.php
+++ b/src/services/Addresses.php
@@ -50,7 +50,7 @@ class Addresses extends Component
     /**
      * @event AddressEvent The event that is raised after an address is saved.
      *
-     * Plugins can get notified before an address is being saved
+     * Plugins can get notified after an address has been saved
      *
      * ```php
      * use craft\commerce\events\AddressEvent;

--- a/src/services/Addresses.php
+++ b/src/services/Addresses.php
@@ -64,6 +64,23 @@ class Addresses extends Component
      */
     const EVENT_AFTER_SAVE_ADDRESS = 'afterSaveAddress';
 
+    /**
+     * @event AddressEvent The event that is raised after an address is deleted.
+     *
+     * Plugins can get notified after an address has been deleted.
+     *
+     * ```php
+     * use craft\commerce\events\AddressEvent;
+     * use craft\commerce\services\Addresses;
+     * use yii\base\Event;
+     *
+     * Event::on(Addresses::class, Addresses::EVENT_AFTER_DELETE_ADDRESS, function(AddressEvent $e) {
+     *     // Do something - perhaps remove this address from a payment gateway.
+     * });
+     * ```
+     */
+    const EVENT_AFTER_DELETE_ADDRESS = 'afterDeleteAddress';
+
     // Properties
     // =========================================================================
 
@@ -236,13 +253,26 @@ class Addresses extends Component
      */
     public function deleteAddressById(int $id): bool
     {
-        $address = AddressRecord::findOne($id);
+        $addressRecord = AddressRecord::findOne($id);
 
-        if (!$address) {
+        if (!$addressRecord) {
             return false;
         }
 
-        return (bool)$address->delete();
+        // Get the Address model before deletion to pass to the Event.
+        $address = $this->getAddressById($id);
+
+        $result = (bool) $addressRecord->delete();
+
+        //Raise the afterDeleteAddress event
+        if ($this->hasEventHandlers(self::EVENT_AFTER_DELETE_ADDRESS)) {
+            $this->trigger(self::EVENT_AFTER_DELETE_ADDRESS, new AddressEvent([
+                'address' => $address,
+                'isNew' => false
+            ]));
+        }
+
+        return $result;
     }
 
     /**


### PR DESCRIPTION
We are building a Gateway plugin for Craft Commerce and need a way to remove addresses from the gateway when a customer deletes an address from Commerce. I've added an event trigger to the deleteAddressById method that we can listen for and then run our own gateway code.

I reused the AddressEvent class and only needed to add a call to getAddressById to get the AddressModel of the address that was being deleted. I would be interested in feedback or suggestions for improvement.

Also, I made a simple typo correction in the documentation comment of the other events in the Addresses service class.