### PR TITLE
Issue 644 - Default the $_sourceSnapshot to an array

### DIFF
--- a/src/models/OrderAdjustment.php
+++ b/src/models/OrderAdjustment.php
@@ -58,7 +58,7 @@ class OrderAdjustment extends Model
     /**
      * @var mixed Adjuster options
      */
-    private $_sourceSnapshot;
+    private $_sourceSnapshot = [];
 
     /**
      * @var int Order ID


### PR DESCRIPTION
When bumping our Craft Commerce version up we had the following error:

```
craft\commerce\models\OrderAdjustment::getSourceSnapshot() must be of the type array, null returned
```

This was originally reported here:

https://github.com/craftcms/commerce/issues/644

If people are bumping their versions and use adjusters this PR will save them on having to amend their adjusters like so:

```
$discountAdjuster->sourceSnapshot = [];
```

By default `$_sourceSnapshot` to an array.