### PR TITLE
Use uid instead of id for redactor sources

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -276,7 +276,7 @@ class Plugin extends BasePlugin
             $currentSiteId = Craft::$app->getSites()->getCurrentSite()->id;
             foreach ($this->getProductTypes()->getAllProductTypes() as $productType) {
                 if (isset($productType->getSiteSettings()[$currentSiteId]) && $productType->getSiteSettings()[$currentSiteId]->hasUrls) {
-                    $productSources[] = 'productType:' . $productType->id;
+                    $productSources[] = 'productType:' . $productType->uid;
                 }
             }
 


### PR DESCRIPTION
The Redactor **Link to a product** and **Link to a variant** options were returning no results since it was using the `id` instead of `uid`