### PR TITLE
Switch the Order element to override `Element::tableAttributeHtml()`.

### DIFF
--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -6,6 +6,7 @@
 - Fixed a PHP error on the Order edit page when viewing inactive carts. ([#826](https://github.com/craftcms/commerce/issues/826))
 - Fixed a deprecation warning. ([#825](https://github.com/craftcms/commerce/issues/825))
 - Fixed a bug where the default variant was set to the wrong variant on product save. ([#830](https://github.com/craftcms/commerce/issues/830))
+- Fixed an issue where plugins and modules couldn’t add custom index table attributes. ([#832](https://github.com/craftcms/commerce/pull/832))
 
 ### Changed
 - Improved performance of the Order index page. ([#828](https://github.com/craftcms/commerce/issues/828))

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1716,7 +1716,7 @@ class Order extends Element
     /**
      * @inheritdoc
      */
-    public function getTableAttributeHtml(string $attribute): string
+    protected function tableAttributeHtml(string $attribute): string
     {
         switch ($attribute) {
             case 'orderStatus':


### PR DESCRIPTION
This PR changes the Order element to override `Element::tableAttributeHtml()` instead of `Element::getTableAttributeHtml()` and fixes an issue where plugins and modules couldn’t add custom index table attributes via the `Element::EVENT_SET_TABLE_ATTRIBUTE_HTML` event.

That event gets fired in `Element::getTableAttributeHtml()` and the method in the Order element class wasn’t then falling back to using that in the default part of the switch statement (line 1820).

This change is in line with the method used in the Entry element class.