### PR TITLE
Move the 'stopProcessing' check, fix bug with multiple sales

### DIFF
--- a/src/services/Sales.php
+++ b/src/services/Sales.php
@@ -216,10 +216,10 @@ class Sales extends Component
 
             if ($this->matchPurchasableAndSale($purchasable, $sale, $order)) {
                 $matchedSales[] = $sale;
-            }
-
-            if ($sale->stopProcessing) {
-                break;
+                    
+                if ($sale->stopProcessing) {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
I ran into a bug where, if two sales where applied, of which the second one was only applied to purchasable A, it would not be applied if the first sale had 'stopProcessing' set to true. This change will make sure processing is only stopped if the first sale *applies* to the purchasable, not only if the sale exists and has stopProcessing set to true.