### PR TITLE
Fix merging an empty guest cart on login #704

### DIFF
--- a/src/services/Customers.php
+++ b/src/services/Customers.php
@@ -263,8 +263,16 @@ class Customers extends Component
 
         // Recover previous cart(s) of user
         $previousOrder = null;
-        $cart = Plugin::getInstance()->getCarts()->getCart();
+
         $previousOrders = Order::find()->isCompleted(false)->user($user)->all();
+
+        if(!empty($previousOrders)){
+            $cart = Plugin::getInstance()->getCarts()->getCart(true);
+        }else{
+            $cart = Plugin::getInstance()->getCarts()->getCart();
+        }
+
+
         foreach ($previousOrders as $previousOrder) {
             if ($cart->id != $previousOrder->id) {
                 OrderHelper::mergeOrders($cart, $previousOrder);


### PR DESCRIPTION
@lukeholder @brandonkelly I hope this can make it to a release quickly so we can all use the Persistant cart.

I have tested all scenarios with this fix and everything seems to be working fine now.

- Test with no orders associated to the user and then login
- Test with items in a cart for the user and then login to the account with items in the guest cart
- Test with items in a cart for the user and then login to the account without any items (no active cart).  This is where the issue was.

