### PR TITLE
Fix Order::EVENT_BEFORE_ADD_LINE_ITEM event.

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -753,7 +753,7 @@ class Order extends Element
     public function addLineItem($lineItem)
     {
         $lineItems = $this->getLineItems();
-        $isNew = (bool)$lineItem->id;
+        $isNew = !$lineItem->id;
 
         if ($isNew) {
             if ($this->hasEventHandlers(self::EVENT_BEFORE_ADD_LINE_ITEM)) {


### PR DESCRIPTION
Fixes a small boolean logic bug that prevents Order::EVENT_BEFORE_ADD_LINE_ITEM event from firing for newly added line items.
In the previous version of the code the `$isNew` variable will be always `false` for the line items that don't have an ID, which should be the other way around.