### PR TITLE
Fix isUnpaid condition in OrderQuery::beforePrepare()

### DIFF
--- a/src/elements/db/OrderQuery.php
+++ b/src/elements/db/OrderQuery.php
@@ -896,7 +896,7 @@ class OrderQuery extends ElementQuery
         }
 
         // Allow true ot false but not null
-        if ($this->isPaid !== null) {
+        if ($this->isUnpaid !== null) {
             if ($this->isUnpaid) {
                 $this->subQuery->andWhere('commerce_orders.totalPaid < commerce_orders.totalPrice');
             }


### PR DESCRIPTION
This fix the order query to get unpaid orders. This bug was introduced in the 2.1.5.2 release.