### PR TITLE
Improve IDE return for Variants service

### DIFF
--- a/src/services/Variants.php
+++ b/src/services/Variants.php
@@ -8,7 +8,6 @@
 namespace craft\commerce\services;
 
 use Craft;
-use craft\base\ElementInterface;
 use craft\commerce\elements\Variant;
 use yii\base\Component;
 
@@ -45,7 +44,7 @@ class Variants extends Component
      *
      * @param int $variantId The variant’s ID.
      * @param int|null $siteId The site ID for which to fetch the variant. Defaults to `null` which is current site.
-     * @return ElementInterface|null
+     * @return Variant|null
      */
     public function getVariantById(int $variantId, int $siteId = null)
     {


### PR DESCRIPTION
Rather than promising to return an ElementInterface, instead show that a Variant (or null) will be returned (as the Products service already does, though for Products)