### PR TITLE
Fix: make email null if empty on a order

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1085,7 +1085,7 @@ class Order extends Element
             $this->setEmail($this->getCustomer()->getUser()->email);
         }
 
-        return $this->_email ?? '';
+        return $this->_email ?? null;
     }
 
     /**


### PR DESCRIPTION
I noticed when an order is created and an email is not yet set it doesn't default to NULL like most of the other fields on the order.

This should just make it a bit more consistent especially when you need to query for orders that have emails set.