### PR TITLE
Boolean fixes for Postgres

### DIFF
--- a/src/services/OrderStatuses.php
+++ b/src/services/OrderStatuses.php
@@ -145,7 +145,7 @@ class OrderStatuses extends Component
         }
 
         $result = $this->_createOrderStatusesQuery()
-            ->where(['default' => 1])
+            ->where(['default' => true])
             ->one();
 
         return new OrderStatus($result);
@@ -256,7 +256,7 @@ class OrderStatuses extends Component
             $statusRecord->save(false);
 
             if ($statusRecord->default) {
-                OrderStatusRecord::updateAll(['default' => 0], ['not', ['id' => $statusRecord->id]]);
+                OrderStatusRecord::updateAll(['default' => false], ['not', ['id' => $statusRecord->id]]);
             }
 
             $connection = Craft::$app->getDb();

--- a/src/services/ShippingCategories.php
+++ b/src/services/ShippingCategories.php
@@ -141,7 +141,7 @@ class ShippingCategories extends Component
         }
 
         $row = $this->_createShippingCategoryQuery()
-            ->where(['default' => 1])
+            ->where(['default' => true])
             ->one();
 
         if (!$row) {
@@ -194,7 +194,7 @@ class ShippingCategories extends Component
 
         // If this was the default make all others not the default.
         if ($shippingCategory->default) {
-            ShippingCategoryRecord::updateAll(['default' => 0], ['not', ['id' => $record->id]]);
+            ShippingCategoryRecord::updateAll(['default' => false], ['not', ['id' => $record->id]]);
         }
 
         // Remove existing Categories <-> ProductType relationships

--- a/src/services/TaxCategories.php
+++ b/src/services/TaxCategories.php
@@ -155,7 +155,7 @@ class TaxCategories extends Component
         }
 
         $result = $this->_createTaxCategoryQuery()
-            ->where(['default' => 1])
+            ->where(['default' => true])
             ->one();
 
         if (!$result) {
@@ -210,7 +210,7 @@ class TaxCategories extends Component
 
         // If this was the default make all others not the default.
         if ($taxCategory->default) {
-            TaxCategoryRecord::updateAll(['default' => 0], ['not', ['id' => $record->id]]);
+            TaxCategoryRecord::updateAll(['default' => false], ['not', ['id' => $record->id]]);
         }
 
         // Remove existing Categories <-> ProductType relationships

--- a/src/services/TaxZones.php
+++ b/src/services/TaxZones.php
@@ -181,7 +181,7 @@ class TaxZones extends Component
 
             //If this was the default make all others not the default.
             if ($model->default) {
-                TaxZoneRecord::updateAll(['default' => 0], ['not', ['id' => $record->id]]);
+                TaxZoneRecord::updateAll(['default' => false], ['not', ['id' => $record->id]]);
             }
 
             $transaction->commit();


### PR DESCRIPTION
Fixes errors like these on Postgres:

```
Undefined function: 7 ERROR:  operator does not exist: boolean = integer
LINE 3: WHERE "default"=1
                       ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
The SQL being executed was: SELECT "shippingCategories"."id", "shippingCategories"."name", "shippingCategories"."handle", "shippingCategories"."description", "shippingCategories"."default"
FROM "commerce_shippingcategories" "shippingCategories"
WHERE "default"=1
LIMIT 1  
```