### PR TITLE
Discounts - Add template hook and `beforeSave`, `afterSave` and `afterDelete` events

### DIFF
--- a/src/events/DiscountEvent.php
+++ b/src/events/DiscountEvent.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use craft\commerce\models\Discount;
+use yii\base\Event;
+
+/**
+ * Class DiscountEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 2.0
+ */
+class DiscountEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var Discount The discount model
+     */
+    public $discount;
+
+    /**
+     * @var bool If this is a new discount
+     */
+    public $isNew;
+}

--- a/src/templates/promotions/discounts/_edit.html
+++ b/src/templates/promotions/discounts/_edit.html
@@ -75,6 +75,7 @@
             errors: discount.getErrors('enabled')
         }) }}
 
+        {% hook "cp.commerce.discount.edit" %}
     </div>
 
     <div id="coupon" class="hidden">


### PR DESCRIPTION
We have a need for some custom logic with discounts, but would like to extend the functionality of discounts rather than completely roll our own solution or duplicate code. For example, we want to implement applying discounts to chosen product types.

This PR includes a template hook to allow additional fields to be added to the first tab of discounts. Then I've also added events on the save and delete of a discount, so through a custom module, we can listen on these events, and store our custom data in a separate table, for applying later.