### PR TITLE
Update CRAFT_VENDOR_PATH

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -15,7 +15,7 @@ define('CRAFT_TEMPLATES_PATH', __DIR__ . '/_craft/templates');
 define('CRAFT_CONFIG_PATH', __DIR__ . '/_craft/config');
 define('CRAFT_MIGRATIONS_PATH', __DIR__ . '/_craft/migrations');
 define('CRAFT_TRANSLATIONS_PATH', __DIR__ . '/_craft/translations');
-define('CRAFT_VENDOR_PATH', dirname(__DIR__).'/vendor');
+define('CRAFT_VENDOR_PATH', dirname(dirname(dirname(__DIR__))));
 
 $devMode = true;
 

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -15,7 +15,7 @@ define('CRAFT_TEMPLATES_PATH', __DIR__ . '/_craft/templates');
 define('CRAFT_CONFIG_PATH', __DIR__ . '/_craft/config');
 define('CRAFT_MIGRATIONS_PATH', __DIR__ . '/_craft/migrations');
 define('CRAFT_TRANSLATIONS_PATH', __DIR__ . '/_craft/translations');
-define('CRAFT_VENDOR_PATH', dirname(dirname(dirname(__DIR__))));
+define('CRAFT_VENDOR_PATH', dirname(__DIR__, 3));
 
 $devMode = true;
 


### PR DESCRIPTION
Assuming the plugin is installed in `vendor/craftcms/commerce`, the `_bootstrap.php` file will be in `vendor/craftcms/commerce/tests` and therefore vendor path is 3 directories up, therefore:

```
define('CRAFT_VENDOR_PATH', dirname(__DIR__, 3));
```