### PR TITLE
Add `beforeGenerateExport` event

### DIFF
--- a/src/events/ReportEvent.php
+++ b/src/events/ReportEvent.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use yii\base\Event;
+
+/**
+ * Class ReportEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 2.0
+ */
+class ReportEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    public $startDate;
+    public $endDate;
+    public $status;
+    public $orderQuery;
+    public $columns;
+    public $orders;
+    public $format;
+}

--- a/src/services/Reports.php
+++ b/src/services/Reports.php
@@ -33,6 +33,11 @@ use yii\web\BadRequestHttpException;
  */
 class Reports extends Component
 {
+    // Constants
+    // =========================================================================
+
+    const EVENT_BEFORE_GENERATE_EXPORT = 'beforeGenerateExport';
+    
     // Public Methods
     // =========================================================================
 


### PR DESCRIPTION
We have a need to modify the export from the default simply order export. Our client would like to export each line item and a row in a CSV. In addition, they want to extract out the line item options.

We've found is pretty commonplace with our clients, having order exports containing each line item information.

I've added this event to make it possible to modify the `columns` and `orders` variables in the reports service, while also having access to a bunch more variables to do your own implementations.

From this, we can now do:
```
use craft\commerce\events\ReportEvent;
use craft\commerce\services\Reports;
use yii\base\Event;

Event::on(Reports::class, Reports::EVENT_BEFORE_GENERATE_EXPORT, function(ReportEvent $e) {
    $lineItems = (new Query())
        ->select(['*', 'orders.id as orderId', 'lineitems.id as lineItemId'])
        ->from(['{{%commerce_lineitems}} lineitems'])
        ->leftJoin('{{%commerce_orders}} orders', 'orders.id = lineitems.orderId')
        ->where(['isCompleted' => true])
        ->andWhere(['>=', 'dateOrdered', Db::prepareDateForDb($event->startDate)])
        ->andWhere(['<=', 'dateOrdered', Db::prepareDateForDb($event->endDate)])
        ->all();

    $lineItemColumns = [
        'orderId',
        'lineItemId',
        'number',
        'email',
        'gatewayId',
        'paymentSourceId',
        'customerId',
        'orderStatusId',
        'couponCode',
        'itemTotal',
        'totalPrice',
        'totalPaid',
        'paidStatus',
        'isCompleted',
        'dateOrdered',
        'datePaid',
        'currency',
        'paymentCurrency',
        'lastIp',
        'orderLanguage',
        'message',
        'shippingMethodHandle',

        // Line Items
        'price',
        'saleAmount',
        'salePrice',
        'weight',
        'height',
        'length',
        'width',
        'subtotal',
        'total',
        'qty',
        'note',
    ];

    // Snapshot
    $snapshotColumns = [
        // ...
    ];

    // Normalised line item options
    $optionsColumns = [
        // ...
    ];

    $columns = array_merge($lineItemColumns, $snapshotColumns, $optionsColumns);

    $data = [];

    foreach ($lineItems as $lineItem) {
        $preppedData = [];

        $options = Json::decode($lineItem['options']);
        $snapshot = Json::decode($lineItem['snapshot']);

        foreach ($lineItemColumns as $key => $column) {
            $preppedData[$column] = $lineItem[$column] ?? '';
        }

        foreach ($snapshotColumns as $key => $column) {
            $preppedData[$column] = $snapshot[$column] ?? '';
        }

        foreach ($optionsColumns as $key => $column) {
            $preppedData[$column] = $options[$column] ?? '';
        }

        $data[] = $preppedData;
    }

    $event->columns = $columns;
    $event->orders = $data;
});

```