### PR TITLE
Add `EVENT_MODIFY_SHIPPING_PRICE_FOR_ORDER`

### DIFF
--- a/src/events/ModifyShippingPriceEvent.php
+++ b/src/events/ModifyShippingPriceEvent.php
@@ -1,0 +1,16 @@
+<?php
+namespace craft\commerce\events;
+
+use craft\commerce\models\Discount;
+use craft\commerce\models\LineItem;
+use craft\events\CancelableEvent;
+
+class ModifyShippingPriceEvent extends CancelableEvent
+{
+    // Properties
+    // =========================================================================
+
+    public $order;
+    public $shippingRule;
+    public $amount;
+}


### PR DESCRIPTION
Would love to get some feedback on this, whether it could be done better, another way, or if a valid approach.

We would like to modify the amount of a particular shipping method/rule depending on a set of circumstances. Its more advanced than this PR covers, but basically adds more logic to discounts, allowing you to set the price of certain shipping methods with a coupon code.

Adding this event allows us to modify the shipping price for a particular order. Not sure if you'd like to name the event differently as well.

I am aware of the `Remove all shipping costs from the order` setting, but that's not desirable, as:
- We only want certain shipping methods affected
- We want to set the price to something specific, not just free