### PR TITLE
Fix for sites that require shipping method at checkout

### DIFF
--- a/src/controllers/PaymentsController.php
+++ b/src/controllers/PaymentsController.php
@@ -269,7 +269,7 @@ class PaymentsController extends BaseFrontEndController
         }
 
         // Does the order require shipping
-        if ($plugin->getSettings()->requireShippingMethodSelectionAtCheckout && !$order->getShippingMethodId) {
+        if ($plugin->getSettings()->requireShippingMethodSelectionAtCheckout && !$order->getShippingMethodId()) {
             $customError = Craft::t('commerce', 'There is no shipping method selected for this order.');
 
             if ($request->getAcceptsJson()) {


### PR DESCRIPTION
I updated our commerce version to 2.1.12 and was unable to checkout on our local instance. Traced the issue to what I think was a type on a property name: 

Update property `getShippingMethodId` to method call `getShippingMethodId()`