### PR TITLE
Basic Velocity Filter

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -170,6 +170,26 @@ class Settings extends Model
      */
     public $gatewaySettings = [];
 
+    /**
+     * @var bool
+     */
+    public $enableVelocityFilter = false;
+
+    /**
+     * @var mixed
+     */
+    public $velocityFilterWindowDuration = 3600;
+
+    /**
+     * @var int
+     */
+    public $maxDeclinedTransactions = 5;
+
+    /**
+     * @var mixed
+     */
+    public $cooldownDuration = 300;
+
     // Public Methods
     // =========================================================================
 


### PR DESCRIPTION
The payment gateway we use with Commerce unfortunately doesn't have any velocity filter. This is my attempt at a basic configurable velocity filter to limit the number of transaction attempts by IP. Would it be possible to implement this or something similar to help prevent excessive card testing by fraudsters?