### PR TITLE
Order export doesn't use paid status filtering

### DIFF
--- a/src/controllers/DownloadsController.php
+++ b/src/controllers/DownloadsController.php
@@ -9,6 +9,7 @@ namespace craft\commerce\controllers;
 
 use Craft;
 use craft\commerce\Plugin;
+use craft\commerce\elements\Order;
 use HttpInvalidParamException;
 use Throwable;
 use yii\base\Exception;
@@ -88,11 +89,18 @@ class DownloadsController extends BaseFrontEndController
             $sourceHandle = explode(':', $source)[1];
         }
 
+        $paidStatus = null;
+
+        // Check to see if we're filtering by paid statuses
+        if (in_array($source, [Order::PAID_STATUS_PAID, Order::PAID_STATUS_UNPAID, Order::PAID_STATUS_PARTIAL])) {
+            $paidStatus = $source;
+        }
+
         // null order status is ok, will then find all order statuses
         $orderStatusId = isset($sourceHandle) ? Plugin::getInstance()->getOrderStatuses()->getOrderStatusByHandle($sourceHandle)->id : null;
 
         // Get the generated file saved into a temporary location
-        $tempFile = Plugin::getInstance()->getReports()->getOrdersExportFile($format, $startDate, $endDate, $orderStatusId);
+        $tempFile = Plugin::getInstance()->getReports()->getOrdersExportFile($format, $startDate, $endDate, $orderStatusId, $paidStatus);
 
         return Craft::$app->getResponse()->sendFile($tempFile, 'orders.' . $format);
     }

--- a/src/events/ReportEvent.php
+++ b/src/events/ReportEvent.php
@@ -27,4 +27,5 @@ class ReportEvent extends Event
     public $columns;
     public $orders;
     public $format;
+    public $paidStatus;
 }

--- a/src/services/Reports.php
+++ b/src/services/Reports.php
@@ -53,7 +53,7 @@ class Reports extends Component
      * @throws \PhpOffice\PhpSpreadsheet\Exception
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function getOrdersExportFile($format, $startDate, $endDate, $orderStatusId = null)
+    public function getOrdersExportFile($format, $startDate, $endDate, $orderStatusId = null, $paidStatus = null)
     {
         $columns = [
             'id',
@@ -97,6 +97,10 @@ class Reports extends Component
             $orderQuery->andWhere('orderStatusId = :id', [':id' => $status->id]);
         }
 
+        if ($paidStatus) {
+            $orderQuery->andWhere('paidStatus = :paidStatus', [':paidStatus' => $paidStatus]);
+        }
+
         $orders = $orderQuery->all();
 
         // Raise the beforeGenerateExport event
@@ -108,6 +112,7 @@ class Reports extends Component
             'columns' => $columns,
             'orders' => $orders,
             'format' => $format,
+            'paidStatus' => $paidStatus,
         ]);
         $this->trigger(self::EVENT_BEFORE_GENERATE_EXPORT, $event);
 


### PR DESCRIPTION
When trying to export Unpaid or Paid orders, using the sidebar filtering for these, orders aren't correctly filtered and exported. This is because there's a lack of checking if we're filtering by order statuses, or paid status. This PR includes that.

As an aside, there's also probably unnecessary order status fetching via https://github.com/craftcms/commerce/blob/develop/src/services/Reports.php#L95, since the parameter to the function is already an ID, and that's all that's used. Thinking it might just be better to pass the order status from the controller in a single call (which is being done anyway - https://github.com/craftcms/commerce/blob/develop/src/controllers/DownloadsController.php#L92)