### PR TITLE
Update HUF currency name to it's official name

### DIFF
--- a/src/etc/currencies.php
+++ b/src/etc/currencies.php
@@ -509,7 +509,7 @@ return [
     ],
     'HUF' => [
         'alphabeticCode' => 'HUF',
-        'currency' => 'Forint',
+        'currency' => 'Hungarian Forint',
         'entity' => 'HUNGARY',
         'minorUnit' => 2,
         'numericCode' => 348,


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Hungarian_forint