### PR TITLE
Tip to install plugin in Craft if using Composer.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,6 +23,10 @@ Run the following Composer command from within your Craft 3 project:
 composer require craftcms/commerce
 ```
 
+::: tip
+Once installed via Composer don't forget to install the plugin in Craft itself via Settings → Plugins.
+:::
+
 ## Example Templates
 
 We provide [example templates](example-templates.md) to help get you started learning how to use Commerce.


### PR DESCRIPTION
Just added a little note to make sure it's clear that you actually have to install the plugin in Craft if you use Composer.

As a new comer wanting to use Commerce without having disabled with Craft CMS Plugins it was not immediately obvious I had to actually install the Plugin. In hindsight I should of used the plugin store!