### PR TITLE
Clean up addition of X-Powered-By header

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -467,11 +467,7 @@ class Plugin extends BasePlugin
             $headers = Craft::$app->getResponse()->getHeaders();
             // Send the X-Powered-By header?
             if (Craft::$app->getConfig()->getGeneral()->sendPoweredByHeader) {
-                $original = $headers->get('X-Powered-By');
-                $headers->set('X-Powered-By', $original . ($original ? ',' : '') . 'Craft Commerce');
-            } else {
-                // In case PHP is already setting one
-                header_remove('X-Powered-By');
+                $headers->add('X-Powered-By', 'Craft Commerce');
             }
         }
     }


### PR DESCRIPTION
This PR refactors some code that feels a big legacy and that can be achieved in a single line of code. It also feels better to me to have a single `X-Powered-By` header per plugin (as SEOmatic and Blitz do), rather than comma separating them.

Old header: 
```
X-Powered-By: Craft CMS,Craft Commerce
```

New headers: 
```
X-Powered-By: Craft CMS
X-Powered-By: Craft Commerce
```