### PR TITLE
Return orderlines by dateCreated from LineItems service

### DIFF
--- a/src/services/LineItems.php
+++ b/src/services/LineItems.php
@@ -99,6 +99,7 @@ class LineItems extends Component
         if (!isset($this->_lineItemsByOrderId[$orderId])) {
             $results = $this->_createLineItemQuery()
                 ->where(['orderId' => $orderId])
+                ->orderBy('dateCreated')
                 ->all();
 
             $this->_lineItemsByOrderId[$orderId] = [];


### PR DESCRIPTION
Order Lines retrieved using the LineItems service `getAllLineItemsByOrderId` method are now returned in order of creation date.

Use case is one of our clients added products to their order in a specific way, and is querying why they appear in a different order in the CMS.