### PR TITLE
Move sending email to queue

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -172,6 +172,11 @@ class Settings extends Model
      * @var bool
      */
     public $pdfAllowRemoteImages = false;
+    
+    /**
+     * @var bool Whether the send all emails using queue jobs
+     */
+    public $useQueueForEmails = false;
 
     /**
      * @var string The order reference format

--- a/src/queue/jobs/SendEmail.php
+++ b/src/queue/jobs/SendEmail.php
@@ -1,0 +1,61 @@
+<?php
+namespace craft\commerce\queue\jobs;
+
+use craft\commerce\Plugin;
+use craft\commerce\elements\Order;
+use craft\commerce\models\Email;
+use craft\commerce\models\OrderHistory;
+
+use Craft;
+use craft\queue\BaseJob;
+
+use yii\base\Event;
+
+class SendEmail extends BaseJob
+{
+    // Properties
+    // =========================================================================
+
+    public $email;
+    public $order;
+    public $orderHistory;
+
+
+    // Public Methods
+    // =========================================================================
+
+    public function execute($queue)
+    {
+        $this->setProgress($queue, 1);
+
+        // Fetch the current Order and Order History so we can get a correct object
+        // but make sure to apply any serialised data saved at the time of this queue job generation.
+        // Reason being is that data may have changed between job lodging and job execution
+        // but we also need to send out service (and resulting emails) a proper object.
+        // Don't forget that we're passing the data as an array, not an object.
+        $order = Order::find()->id($this->order['id'])->one();
+
+        // Remove line items and adjusters - maybe just for now. I feel like these won't change too much?
+        unset($this->order['lineItems'], $this->order['orderAdjustments']);
+
+        // Populate (overwrite) with the potentially newer info
+        $order->setAttributes($this->order);
+
+        // Just create new models
+        $orderHistory = new OrderHistory($this->orderHistory);
+        $email = new Email($this->email);
+
+        Plugin::getInstance()->getEmails()->sendEmail($email, $order, $orderHistory);
+
+        return false;
+    }
+
+
+    // Protected Methods
+    // =========================================================================
+
+    protected function defaultDescription(): string
+    {
+        return 'Sending email for order #' . $this->order['id'];
+    }
+}


### PR DESCRIPTION
Tested pretty thoroughly, but the tricky part here is how to handle serialising the order data. As we can't guarantee immediate processing of this queue, we need to make sure we use the 'snapshot' of the order at the time.

This is sort of achieved through `$order->setAttributes($this->order);` where `$this->order` is an array of the order data. I'm ditching the lineItem and adjustment - probably not ideal? I feel like they won't change all that much?

We also need create objects so we don't have to refactor things, or change emails.