### PR TITLE
Fix PDF not rendering

### DIFF
--- a/src/services/Pdf.php
+++ b/src/services/Pdf.php
@@ -137,7 +137,7 @@ class Pdf extends Component
             'option' => $event->option,
             'template' => $event->template,
             'variables' => $variables,
-            'pdf' => $dompdf->stream(),
+            'pdf' => $dompdf->output(),
         ]);
         $this->trigger(self::EVENT_AFTER_RENDER_PDF, $afterEvent);
 

--- a/src/services/Pdf.php
+++ b/src/services/Pdf.php
@@ -141,6 +141,6 @@ class Pdf extends Component
         ]);
         $this->trigger(self::EVENT_AFTER_RENDER_PDF, $afterEvent);
 
-        return $event->pdf;
+        return $afterEvent->pdf;
     }
 }

--- a/src/services/Pdf.php
+++ b/src/services/Pdf.php
@@ -135,9 +135,9 @@ class Pdf extends Component
         $afterEvent = new PdfEvent([
             'order' => $event->order,
             'option' => $event->option,
-            'template' => $event->templatePath,
+            'template' => $event->template,
             'variables' => $variables,
-            'pdf' => $dompdf->output(),
+            'pdf' => $dompdf->stream(),
         ]);
         $this->trigger(self::EVENT_AFTER_RENDER_PDF, $afterEvent);
 


### PR DESCRIPTION
I was trying out the 2.2 release and got an error when trying to download an order PDF due to `templatePath` not existing on the PdfEvent. 