### PR TITLE
Removing non-existant column 'isArchived' from OrderStatus query

### DIFF
--- a/src/helpers/ProjectConfigData.php
+++ b/src/helpers/ProjectConfigData.php
@@ -234,7 +234,6 @@ class ProjectConfigData
                 'sortOrder',
                 'default',
             ])
-            ->where(['isArchived' => false])
             ->indexBy('id')
             ->orderBy('sortOrder')
             ->from([Table::ORDERSTATUSES])


### PR DESCRIPTION
#1082 

Remove `isArchived` from OrderStatus query