### PR TITLE
Fix a type hinting issue in LineItem model

### DIFF
--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -183,7 +183,7 @@ class LineItem extends Model
      */
     public function getOptions(): array
     {
-        return $this->_options;
+        return is_array($this->_options) ? $this->_options : [];
     }
 
     /**


### PR DESCRIPTION
If options are not explicitly set, calling $lineItem->getOptions() throws an error due to its return type (array).