### PR TITLE
Implement delta saving for custom product fields.

### DIFF
--- a/src/templates/products/_edit.html
+++ b/src/templates/products/_edit.html
@@ -12,6 +12,7 @@
 
 {% set fullPageForm = true %}
 {% set saveShortcutRedirect = continueEditingUrl %}
+{% do view.setIsDeltaRegistrationActive(true) %}
 
 {% import "_includes/forms" as forms %}
 {% import "commerce/products/_fields" as productFields %}
@@ -126,6 +127,7 @@
                     {% include "_includes/fields" with {
                         fields: tab.getFields(),
                         element: product,
+                        registerDeltas: true,
                     } only %}
                 </div>
             {% endfor %}


### PR DESCRIPTION
Tells the view to activate delta registration and enable it for custom product fields. Intended for Craft 3.4.