### PR TITLE
Fixed product validation error

### DIFF
--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -813,7 +813,7 @@ class Product extends Element
                 /** @var Product $model */
                 $skus = [];
                 foreach ($this->getVariants() as $variant) {
-                    $skus[] = $variant->getSku();
+                    $skus[] = $variant->sku;
                 }
 
                 if (count(array_unique($skus)) < count($skus)) {


### PR DESCRIPTION
Fixed a product validation error when a variant didn’t have a sku: Return value of craft\commerce\elements\Variant::getSku() must be of the type string, null returned