### PR TITLE
Change E-Mail formfield to type="email"

### DIFF
--- a/templates/shop/checkout/addresses.html
+++ b/templates/shop/checkout/addresses.html
@@ -18,7 +18,7 @@
 
                 {% if not cart.email %}
                     <label for="email">Email</label>
-                    <input id="email" class="w-full" type="text" value="{{ cart.email }}" name="email"
+                    <input id="email" class="w-full" type="email" value="{{ cart.email }}" name="email"
                            placeholder="email@site.com"/>
 
                     <span class="flash">{{ cart.getErrors('email')|join }}</span><br>

--- a/templates/shop/style.css
+++ b/templates/shop/style.css
@@ -71,6 +71,7 @@ table td {
 input[type="text"],
 input[type="number"],
 input[type="password"],
+input[type="email"]
 input[type="tel"],
 textarea {
     border: 1px solid #ddd;


### PR DESCRIPTION
Is there a reason this is `type="text"` and not `type="email"`?

With `type="email"` you can apply [html5 frontend validation](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation) much nicer