### PR TITLE
Add get all active discounts method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+### Added
+- Added `craft\commerce\services\Discounts::getAllActiveDiscounts()`.
+
+### Fixed
+- Fixed a bug where adding to cart was slow due to lots of disabled or outdated discounts.
+
 ## 2.2.13 - 2019-12-19
 
 ### Fixed

--- a/src/adjusters/Discount.php
+++ b/src/adjusters/Discount.php
@@ -76,7 +76,7 @@ class Discount extends Component implements AdjusterInterface
 
         $adjustments = [];
         $availableDiscounts = [];
-        $discounts = Plugin::getInstance()->getDiscounts()->getAllDiscounts();
+        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts();
 
         foreach ($discounts as $discount) {
             if (Plugin::getInstance()->getDiscounts()->matchOrder($order, $discount)) {

--- a/src/adjusters/Discount.php
+++ b/src/adjusters/Discount.php
@@ -76,7 +76,7 @@ class Discount extends Component implements AdjusterInterface
 
         $adjustments = [];
         $availableDiscounts = [];
-        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts();
+        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts($order);
 
         foreach ($discounts as $discount) {
             if (Plugin::getInstance()->getDiscounts()->matchOrder($order, $discount)) {

--- a/src/adjusters/Shipping.php
+++ b/src/adjusters/Shipping.php
@@ -82,7 +82,7 @@ class Shipping extends Component implements AdjusterInterface
 
         $adjustments = [];
 
-        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts();
+        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts($order);
 
         /** @var ShippingRule $rule */
         $rule = $shippingMethod->getMatchingShippingRule($this->_order);

--- a/src/adjusters/Shipping.php
+++ b/src/adjusters/Shipping.php
@@ -82,7 +82,7 @@ class Shipping extends Component implements AdjusterInterface
 
         $adjustments = [];
 
-        $discounts = Plugin::getInstance()->getDiscounts()->getAllDiscounts();
+        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts();
 
         /** @var ShippingRule $rule */
         $rule = $shippingMethod->getMatchingShippingRule($this->_order);

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -402,7 +402,7 @@ class LineItem extends Model
         $this->taxCategoryId = $purchasable->getTaxCategoryId();
         $this->shippingCategoryId = $purchasable->getShippingCategoryId();
 
-        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts();
+        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts($this->getOrder());
 
         // Check to see if there is a discount applied that ignores Sales
         $ignoreSales = false;

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -402,7 +402,7 @@ class LineItem extends Model
         $this->taxCategoryId = $purchasable->getTaxCategoryId();
         $this->shippingCategoryId = $purchasable->getShippingCategoryId();
 
-        $discounts = Plugin::getInstance()->getDiscounts()->getAllDiscounts();
+        $discounts = Plugin::getInstance()->getDiscounts()->getAllActiveDiscounts();
 
         // Check to see if there is a discount applied that ignores Sales
         $ignoreSales = false;

--- a/src/services/Discounts.php
+++ b/src/services/Discounts.php
@@ -174,13 +174,16 @@ class Discounts extends Component
     /**
      * Get all currently active discounts
      *
+     * @param Order|null $order
      * @return array
      * @throws \Exception
      * @since 2.2.14
      */
-    public function getAllActiveDiscounts(): array
+    public function getAllActiveDiscounts($order = null): array
     {
         if (null === $this->_allActiveDiscounts) {
+            $date = $order && $order->dateOrdered ? $order->dateOrdered : new DateTime();
+
             $discounts = $this->_createDiscountQuery()
                 ->addSelect([
                     'dp.purchasableId',
@@ -197,11 +200,11 @@ class Discounts extends Component
                 // Restrict by things that a definitely not in date
                 ->andWhere(['or',
                     ['dateFrom' => null],
-                    ['<=', 'dateFrom', Db::prepareDateForDb(new DateTime())]
+                    ['<=', 'dateFrom', Db::prepareDateForDb($date)]
                 ])
                 ->andWhere(['or',
                     ['dateTo' => null],
-                    ['>=', 'dateTo', Db::prepareDateForDb(new DateTime())]
+                    ['>=', 'dateTo', Db::prepareDateForDb($date)]
                 ])
                 ->all();
 

--- a/src/services/Discounts.php
+++ b/src/services/Discounts.php
@@ -24,6 +24,7 @@ use craft\commerce\records\DiscountUserGroup as DiscountUserGroupRecord;
 use craft\commerce\records\EmailDiscountUse as EmailDiscountUseRecord;
 use craft\db\Query;
 use craft\elements\Category;
+use craft\helpers\Db;
 use DateTime;
 use phpDocumentor\Reflection\Types\Boolean;
 use yii\base\Component;
@@ -120,6 +121,11 @@ class Discounts extends Component
      */
     private $_allDiscounts;
 
+    /**
+     * @var Discount[]
+     */
+    private $_allActiveDiscounts;
+
     // Public Methods
     // =========================================================================
 
@@ -159,42 +165,50 @@ class Discounts extends Component
                 ->leftJoin(Table::DISCOUNT_USERGROUPS . ' dug', '[[dug.discountId]]=[[discounts.id]]')
                 ->all();
 
-            $allDiscountsById = [];
-            $purchasables = [];
-            $categories = [];
-            $userGroups = [];
-
-            foreach ($discounts as $discount) {
-                $id = $discount['id'];
-                if ($discount['purchasableId']) {
-                    $purchasables[$id][] = $discount['purchasableId'];
-                }
-
-                if ($discount['categoryId']) {
-                    $categories[$id][] = $discount['categoryId'];
-                }
-
-                if ($discount['userGroupId']) {
-                    $userGroups[$id][] = $discount['userGroupId'];
-                }
-
-                unset($discount['purchasableId'], $discount['userGroupId'], $discount['categoryId']);
-
-                if (!isset($allDiscountsById[$id])) {
-                    $allDiscountsById[$id] = new Discount($discount);
-                }
-            }
-
-            foreach ($allDiscountsById as $id => $discount) {
-                $discount->setPurchasableIds($purchasables[$id] ?? []);
-                $discount->setCategoryIds($categories[$id] ?? []);
-                $discount->setUserGroupIds($userGroups[$id] ?? []);
-            }
-
-            $this->_allDiscounts = $allDiscountsById;
+            $this->_allDiscounts = $this->_populateDiscountsRelations($discounts);
         }
 
         return $this->_allDiscounts;
+    }
+
+    /**
+     * Get all currently active discounts
+     *
+     * @return array
+     * @throws \Exception
+     * @since 2.2.14
+     */
+    public function getAllActiveDiscounts(): array
+    {
+        if (null === $this->_allActiveDiscounts) {
+            $discounts = $this->_createDiscountQuery()
+                ->addSelect([
+                    'dp.purchasableId',
+                    'dpt.categoryId',
+                    'dug.userGroupId',
+                ])
+                ->leftJoin(Table::DISCOUNT_PURCHASABLES . ' dp', '[[dp.discountId]]=[[discounts.id]]')
+                ->leftJoin(Table::DISCOUNT_CATEGORIES . ' dpt', '[[dpt.discountId]]=[[discounts.id]]')
+                ->leftJoin(Table::DISCOUNT_USERGROUPS . ' dug', '[[dug.discountId]]=[[discounts.id]]')
+                // Restricted by enabled discounts
+                ->where([
+                    'enabled' => 1,
+                ])
+                // Restrict by things that a definitely not in date
+                ->andWhere(['or',
+                    ['dateFrom' => null],
+                    ['<=', 'dateFrom', Db::prepareDateForDb(new DateTime())]
+                ])
+                ->andWhere(['or',
+                    ['dateTo' => null],
+                    ['>=', 'dateTo', Db::prepareDateForDb(new DateTime())]
+                ])
+                ->all();
+
+            $this->_allActiveDiscounts = $this->_populateDiscountsRelations($discounts);
+        }
+
+        return $this->_allActiveDiscounts;
     }
 
     /**
@@ -854,6 +868,53 @@ class Discounts extends Component
         }
 
         return true;
+    }
+
+    /**
+     * @param $discounts
+     * @return array
+     * @since 2.2.14
+     */
+    private function _populateDiscountsRelations($discounts): array
+    {
+        $allDiscountsById = [];
+
+        if (empty($discounts)) {
+            return $allDiscountsById;
+        }
+
+        $purchasables = [];
+        $categories = [];
+        $userGroups = [];
+
+        foreach ($discounts as $discount) {
+            $id = $discount['id'];
+            if ($discount['purchasableId']) {
+                $purchasables[$id][] = $discount['purchasableId'];
+            }
+
+            if ($discount['categoryId']) {
+                $categories[$id][] = $discount['categoryId'];
+            }
+
+            if ($discount['userGroupId']) {
+                $userGroups[$id][] = $discount['userGroupId'];
+            }
+
+            unset($discount['purchasableId'], $discount['userGroupId'], $discount['categoryId']);
+
+            if (!isset($allDiscountsById[$id])) {
+                $allDiscountsById[$id] = new Discount($discount);
+            }
+        }
+
+        foreach ($allDiscountsById as $id => $discount) {
+            $discount->setPurchasableIds($purchasables[$id] ?? []);
+            $discount->setCategoryIds($categories[$id] ?? []);
+            $discount->setUserGroupIds($userGroups[$id] ?? []);
+        }
+
+        return $allDiscountsById;
     }
 
     /**


### PR DESCRIPTION
This attempts to reduce redundancy with `getAllDiscounts` method by ignoring discounts that definitely not be applicable either by `status` or `dateFrom` and `dateTo`.