### PR TITLE
Fixes actionButton on subscription plans in CP

### DIFF
--- a/src/templates/settings/subscriptions/plans.html
+++ b/src/templates/settings/subscriptions/plans.html
@@ -16,7 +16,7 @@
     'No',
 ]) %}
 
-{% block activeButton %}
+{% block actionButton %}
     <a href="{{ url('commerce/settings/subscriptions/plan/new') }}" class="btn submit add icon">{{ 'New subscription plan'|t('commerce') }}</a>
 {% endblock %}
 


### PR DESCRIPTION
This fixes the miss-spelling of «actionButton» block, current spelling is «activeButton», which causes the index page on Subscription plans to display no button to add new plans.