### PR TITLE
Fixes JavaScript error #1273

### DIFF
--- a/src/templates/products/_edit.html
+++ b/src/templates/products/_edit.html
@@ -243,7 +243,7 @@
 
       new Craft.Commerce.ProductEdit({
         id: {{ product.id|raw }},
-        hasVariants: {{ productType.hasVariants|raw }},
+        hasVariants: {{ productType.hasVariants is defined and productType.hasVariants ? productType.hasVariants|raw : 'false' }},
         purchasables: {{ product.getVariants()|map(v => {id: v.id, title: v.title, sku: v.sku})|json_encode|raw }}
       });
   {% endjs %}


### PR DESCRIPTION
This fixes #1273 from the template side of things. It seems like `productType.hasVariants` can return `''` in this situation, so maybe there is a better place to fix it rather than this check in the template.