### PR TITLE
Product + Subscription Hooks

### DIFF
--- a/src/templates/products/_edit.html
+++ b/src/templates/products/_edit.html
@@ -153,6 +153,8 @@
             </div>
         </div>
     {% endif %}
+
+    {% hook "cp.commerce.product.edit.content" %}
 {% endblock %}
 
 

--- a/src/templates/subscriptions/_edit.html
+++ b/src/templates/subscriptions/_edit.html
@@ -144,6 +144,8 @@
                 </form>
             {% endif %}
         </div>
+
+        {% hook 'cp.commerce.subscriptions.edit.content' %}
     </div>
 
     <form id="customFields" method="POST">
@@ -236,6 +238,8 @@
             readonly: true,
             rows: 3
         }) }}
+
+        {% hook 'cp.commerce.subscriptions.edit.meta' %}
     </div>
 {% endblock %}
 


### PR DESCRIPTION
This is rather self-serving, but: I'm working on something that could benefit from being able to inject a bit of information into the Subscription edit page, and thought I'd issue a PR with the patch in case y'all were sympathetic! ❤️

All this adds is three hooks:

1. Product "Content" area (unfortunately, appearing below any active tab content?)
2. Subscription "Content" area
3. Subscription "Details" area

I didn't see a section in the docs to mention these, so I haven't made any corresponding changes there.

✌️