### PR TITLE
Fixed Product editor unknown error

### DIFF
--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -627,7 +627,7 @@ class Product extends Element
             $namespace = $viewService->getNamespace();
             $newNamespace = 'variants[' . ($variant->id ?: 'new1') . ']';
             $viewService->setNamespace($newNamespace);
-            $html .= $viewService->namespaceInputs($viewService->renderTemplateMacro('commerce/products/_fields', 'generalVariantFields', [$variant]));
+            $html .= $viewService->namespaceInputs($viewService->renderTemplateMacro('commerce/products/_fields', 'generalVariantFields', [$variant, $this]));
 
             if ($productType->hasDimensions) {
                 $html .= $viewService->namespaceInputs($viewService->renderTemplateMacro('commerce/products/_fields', 'dimensionVariantFields', [$variant]));


### PR DESCRIPTION
Was getting an unknown error when trying to access the Product editor by double clicking a product in a relational field. Looks like the `generalVariantFields` macro was getting passed a variant but not a product as well.