### PR TITLE
Fixed saving variants with wrong field layout

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -1025,7 +1025,7 @@ class Variant extends Purchasable
         // Set the field layout
         /** @var ProductType $productType */
         $productType = $this->getProduct()->getType();
-        $this->fieldLayoutId = $productType->getFieldLayout()->id;
+        $this->fieldLayoutId = $productType->variantFieldLayoutId;
 
         return parent::beforeSave($isNew);
     }


### PR DESCRIPTION
Fixes issues like these: https://sentry.io/share/issue/466fd1d49aaf47cfb0e3500d9b4ad4aa/

Caused by: https://github.com/craftcms/commerce/commit/fb041defb32ca21265923483efb01114188cfe58#r38669443