### PR TITLE
Make product sources' labels translatable

### DIFF
--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -969,7 +969,7 @@ class Product extends Element
 
             $sources[$key] = [
                 'key' => $key,
-                'label' => $productType->name,
+                'label' => Craft::t('commerce', $productType->name),
                 'data' => [
                     'handle' => $productType->handle,
                     'editable' => $canEditProducts


### PR DESCRIPTION
This PR adds support for translations in the side view of the product's element index table.
I'm not sure if the `commerce` translation category is the correct one, or if `site` would be better suited.

### Before

![image](https://user-images.githubusercontent.com/29916275/81559242-5a21ea80-938f-11ea-86b7-ae8e44101261.png)

### After

![image](https://user-images.githubusercontent.com/29916275/81559216-4d9d9200-938f-11ea-9ab8-8a28db7e5fb6.png)

