### PR TITLE
GraphQL: added “isAvailable” field in Variant schema

### DIFF
--- a/src/gql/interfaces/elements/Variant.php
+++ b/src/gql/interfaces/elements/Variant.php
@@ -73,6 +73,11 @@ class Variant extends Element
                 'type' => Type::boolean(),
                 'description' => 'If the variant is the default for the product.',
             ],
+            'isAvailable' => [
+                'name' => 'isAvailable',
+                'type' => Type::boolean(),
+                'description' => 'If the variant is available to be purchased.',
+            ],
             'price' => [
                 'name' => 'price',
                 'type' => Type::float(),


### PR DESCRIPTION
Could be very useful use the existent `isAvailable` method instead of make all checks manually (status, stock, product available for purchase, ...).

https://github.com/craftcms/commerce/blob/develop/src/elements/Variant.php#L922