### PR TITLE
Added get variant stock event

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -2792,7 +2792,15 @@ class Order extends Element
         // Delete any line items that no longer will be saved on this order.
         foreach ($previousLineItems as $previousLineItem) {
             if (!in_array($previousLineItem->id, $currentLineItemIds, false)) {
-                $previousLineItem->delete();
+				$lineItem = Plugin::getInstance()->getLineItems()->getLineItemById($previousLineItem->id);
+				$previousLineItem->delete();
+				
+				// Raising the 'afterRemoveLineItemToOrder' event
+				if ($this->hasEventHandlers(self::EVENT_AFTER_REMOVE_LINE_ITEM)) {
+					$this->trigger(self::EVENT_AFTER_REMOVE_LINE_ITEM, new LineItemEvent([
+						'lineItem' => $lineItem,
+					]));
+				}
             }
         }
 

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -674,8 +674,8 @@ class Variant extends Purchasable
     public function getStock(): int
     {
         // Allow plugins to modify Variant stock
-        if ($this->hasEventHandlers(self::EVENT_VARIANT_STOCK)) {
-            $this->trigger(self::EVENT_VARIANT_STOCK);
+        if ($this->hasEventHandlers(self::EVENT_GET_VARIANT_STOCK)) {
+            $this->trigger(self::EVENT_GET_VARIANT_STOCK);
 		}
 		//Craft::dd($this->stock);
         return $this->stock;


### PR DESCRIPTION
This will allow the ability for plugins to say how much stock is available for a variant. We can achieve negative stock/back ordering/etc using this.

I've added the EVENT_AFTER_REMOVE_LINE_ITEM to the_saveLineItems function in the Order element.