### PR TITLE
Added a transaction cache on orders

### DIFF
--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -354,7 +354,7 @@ class OrdersController extends Controller
                 'title' => $order->reference,
                 'url' => $order->getCpEditUrl(),
                 'date' => $order->dateOrdered->format('D jS M Y'),
-                'total' => Craft::$app->getFormatter()->asCurrency($order->getTotalPaid(), $order->currency, [], [], false),
+                'total' => Craft::$app->getFormatter()->asCurrency($order->getTotalPrice(), $order->currency, [], [], false),
                 'orderStatus' => $order->getOrderStatusHtml(),
             ];
         }

--- a/src/services/Discounts.php
+++ b/src/services/Discounts.php
@@ -541,12 +541,14 @@ class Discounts extends Component
             return false;
         }
 
-        $orderDiscountConditionParams = [
-            'order' => $order->toArray([], ['lineItems.snapshot', 'shippingAddress', 'billingAddress'])
-        ];
+        if ($discount->orderConditionFormula) {
+            $orderDiscountConditionParams = [
+                'order' => $order->toArray([], ['lineItems.snapshot', 'shippingAddress', 'billingAddress'])
+            ];
 
-        if ($discount->orderConditionFormula && !Plugin::getInstance()->getFormulas()->evaluateCondition($discount->orderConditionFormula, $orderDiscountConditionParams, 'Evaluate Order Discount Condition Formula')) {
-            return false;
+            if (!Plugin::getInstance()->getFormulas()->evaluateCondition($discount->orderConditionFormula, $orderDiscountConditionParams, 'Evaluate Order Discount Condition Formula')) {
+                return false;
+            }
         }
 
         if (($discount->allPurchasables && $discount->allCategories) && $discount->purchaseTotal > 0 && $order->getItemSubtotal() < $discount->purchaseTotal) {


### PR DESCRIPTION
Before transaction (sum) refactor: 37.8 seconds

![image](https://user-images.githubusercontent.com/133571/85724566-e82b1800-b726-11ea-87f7-7172267d60d5.png)

After transaction refactor (removal of sum transactions query) : 15.8s

![image](https://user-images.githubusercontent.com/133571/85724654-fe38d880-b726-11ea-93b7-30fce08208e1.png)

- Move the total paid/refunded/authorized to order model and out of payments service
- Transactions cached on order model
- Transactions cleared when updateOrderPaid is called on the order. This would/should be done by anyone creating transactions on the order so it gives us the oppotunity to clear the cache
- Fixed the order total in a customer’s orders with admin table