### PR TITLE
Added a customer cache on order

### DIFF
--- a/src/controllers/CustomerAddressesController.php
+++ b/src/controllers/CustomerAddressesController.php
@@ -39,7 +39,7 @@ class CustomerAddressesController extends BaseFrontEndController
         $addressId = Craft::$app->getRequest()->getBodyParam('address.id');
 
         $customerService = Plugin::getInstance()->getCustomers();
-        $customerId = $customerService->getCustomerId();
+        $customerId = $customerService->getCustomer()->id;
         $addressIds = $customerService->getAddressIds($customerId);
         $customer = $customerService->getCustomerById($customerId);
 
@@ -170,7 +170,7 @@ class CustomerAddressesController extends BaseFrontEndController
     {
         $this->requirePostRequest();
 
-        $customerId = Plugin::getInstance()->getCustomers()->getCustomerId();
+        $customerId = Plugin::getInstance()->getCustomers()->getCustomer()->id;
         $addressIds = Plugin::getInstance()->getCustomers()->getAddressIds($customerId);
         $cart = Plugin::getInstance()->getCarts()->getCart(true);
 

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -113,7 +113,7 @@ class OrdersController extends Controller
             Plugin::getInstance()->getCustomers()->saveCustomer($customer);
         }
 
-        $order->customerId = $customer->id;
+        $order->setCustomer($customer);
         $order->origin = Order::ORIGIN_CP;
 
         if (!Craft::$app->getElements()->saveElement($order)) {
@@ -1063,7 +1063,12 @@ class OrdersController extends Controller
         $order->setRecalculationMode($orderRequestData['order']['recalculationMode']);
         $order->reference = $orderRequestData['order']['reference'];
         $order->email = $orderRequestData['order']['email'] ?? '';
-        $order->customerId = $orderRequestData['order']['customerId'] ?? null;
+        $customerId = $orderRequestData['order']['customerId'] ?? null;
+        if ($customerId) {
+            $order->setCustomer(Plugin::getInstance()->getCustomers()->getCustomerById($customerId));
+        } else {
+            $order->customerId = null;
+        }
         $order->couponCode = $orderRequestData['order']['couponCode'];
         $order->isCompleted = $orderRequestData['order']['isCompleted'];
         $order->orderStatusId = $orderRequestData['order']['orderStatusId'];
@@ -1103,7 +1108,7 @@ class OrdersController extends Controller
                 Plugin::getInstance()->getCustomers()->saveCustomer($customer);
             }
 
-            $order->customerId = $customer->id;
+            $order->setCustomer($customer);
         }
 
         // If the customer was changed, the payment source or gateway may not be valid on the order for the new customer and we should unset it.

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -923,6 +923,19 @@ class Order extends Element
      */
     private $_email;
 
+    /**
+     * @var Customer
+     * @see Order::getCustomer()
+     * @see Order::setCustomer()
+     * ---
+     * ```php
+     * echo $order->customer;
+     * ```
+     * ```twig
+     * {{ order.customer }}
+     * ```
+     */
+    private $_customer;
 
     /**
      * @inheritdoc
@@ -1058,7 +1071,7 @@ class Order extends Element
 
         // Get the customer ID from the session
         if (!$this->customerId && !Craft::$app->request->isConsoleRequest) {
-            $this->customerId = Plugin::getInstance()->getCustomers()->getCustomerId();
+            $this->setCustomer(Plugin::getInstance()->getCustomers()->getCustomer());
         }
 
         $customer = Plugin::getInstance()->getCustomers()->getCustomerById($this->customerId);
@@ -1858,11 +1871,24 @@ class Order extends Element
      */
     public function getCustomer()
     {
-        if ($this->customerId) {
-            return Plugin::getInstance()->getCustomers()->getCustomerById($this->customerId);
+        if ($this->_customer !== null) {
+            return $this->_customer;
         }
 
-        return null;
+        if ($this->customerId) {
+            $this->_customer = Plugin::getInstance()->getCustomers()->getCustomerById($this->customerId);
+        }
+
+        return $this->_customer;
+    }
+
+    /**
+     * @param Customer $customer
+     */
+    public function setCustomer(Customer $customer)
+    {
+        $this->_customer = $customer;
+        $this->customerId = $customer->id;
     }
 
     /**

--- a/src/models/Customer.php
+++ b/src/models/Customer.php
@@ -88,7 +88,6 @@ class Customer extends Model
      * Returns the user element associated with this customer.
      *
      * @return User|null
-     * @throws InvalidConfigException if [[userId]] is invalid
      */
     public function getUser()
     {
@@ -100,11 +99,9 @@ class Customer extends Model
             return null;
         }
 
-        if (($user = Craft::$app->getUsers()->getUserById($this->userId)) === null) {
-            return null; // They are probably soft-deleted
-        }
+        $this->_user = Craft::$app->getUsers()->getUserById($this->userId);
 
-        return $this->_user = $user;
+        return $this->_user;
     }
 
     /**

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -57,11 +57,11 @@ class Carts extends Component
      */
     public function getCart($forceSave = false): Order
     {
-        $customerId = Plugin::getInstance()->getCustomers()->getCustomerId();
+        $customer = Plugin::getInstance()->getCustomers()->getCustomer();
 
         // If there is no cart set for this request, and we can't get a cart from session, create one.
         if (null === $this->_cart && !$this->_cart = $this->_getCart()) {
-            $this->_cart = new Order(['customerId' => $customerId]);
+            $this->_cart = new Order(['customer' => $customer]);
             $this->_cart->number = $this->getSessionCartNumber();
         }
 
@@ -78,7 +78,7 @@ class Carts extends Component
         $this->_cart->lastIp = Craft::$app->getRequest()->userIP;
         $this->_cart->orderLanguage = Craft::$app->language;
         $this->_cart->paymentCurrency = $this->_getCartPaymentCurrencyIso();
-        $this->_cart->customerId = $customerId;
+        $this->_cart->setCustomer($customer);
         $this->_cart->origin = Order::ORIGIN_WEB;
 
         $changedIp = $originalIp != $this->_cart->lastIp;

--- a/src/services/OrderHistories.php
+++ b/src/services/OrderHistories.php
@@ -106,7 +106,7 @@ class OrderHistories extends Component
         $orderHistoryModel->orderId = $order->id;
         $orderHistoryModel->prevStatusId = $oldStatusId;
         $orderHistoryModel->newStatusId = $order->orderStatusId;
-        $orderHistoryModel->customerId = Craft::$app->request->isConsoleRequest ? $order->customerId : Plugin::getInstance()->getCustomers()->getCustomerId();
+        $orderHistoryModel->customerId = Craft::$app->request->isConsoleRequest ? $order->customerId : Plugin::getInstance()->getCustomers()->getCustomer()->id;
         $orderHistoryModel->message = $order->message;
 
         if (!$this->saveOrderHistory($orderHistoryModel)) {


### PR DESCRIPTION
Down to 1.8 seconds with same request (in addition to the transaction optimizations https://github.com/craftcms/commerce/pull/1537)

![image](https://user-images.githubusercontent.com/133571/85739020-0d258800-b733-11ea-8fe5-ffb2859ccde3.png)


- Order now has a `->setCustomer()`
- Query for user and user email way made everytime since a new customer was returned everytime
- Customers service `getCustomer()` now always returns a customer with ID
- Deprecated the `Customers::getCustomerId()`