### PR TITLE
Add EVENT_BEFORE_DELETE_ADDRESS event

### DIFF
--- a/src/services/Addresses.php
+++ b/src/services/Addresses.php
@@ -86,6 +86,29 @@ class Addresses extends Component
     const EVENT_AFTER_SAVE_ADDRESS = 'afterSaveAddress';
 
     /**
+     * @event AddressEvent The event that is triggered before an address is deleted.
+     *
+     * ```php
+     * use craft\commerce\events\AddressEvent;
+     * use craft\commerce\services\Addresses;
+     * use craft\commerce\models\Address;
+     * use yii\base\Event;
+     *
+     * Event::on(
+     *     Addresses::class,
+     *     Addresses::EVENT_BEFORE_DELETE_ADDRESS,
+     *     function(AddressEvent $event) {
+     *         // @var Address $address
+     *         $address = $event->address;
+     *
+     *         // Invalidate customer address cache
+     *         // ...
+     *     }
+     * );
+     */
+    const EVENT_BEFORE_DELETE_ADDRESS = 'beforeDeleteAddress';
+
+    /**
      * @event AddressEvent The event that is triggered after an address is deleted.
      *
      * ```php
@@ -293,6 +316,14 @@ class Addresses extends Component
 
         // Get the Address model before deletion to pass to the Event.
         $address = $this->getAddressById($id);
+//
+        //Raise the beforeDeleteAddress event
+        if ($this->hasEventHandlers(self::EVENT_BEFORE_DELETE_ADDRESS)) {
+            $this->trigger(self::EVENT_BEFORE_DELETE_ADDRESS, new AddressEvent([
+                'address' => $address,
+                'isNew' => false
+            ]));
+        }
 
         $result = (bool)$addressRecord->delete();
 


### PR DESCRIPTION
### Description

This PR adds the `EVENT_BEFORE_DELETE_ADDRESS` to the Addresses service and allows for instances where you'd need to do some work based on the customer or some other relation to the address which would be deleted when the address record is deleted.

For example, with this change if we're caching a customers addresses, we can cache that data indefinitely and only invalidate it when an address linked to that customer is deleted (or updated).

### Related issues

This adds onto https://github.com/craftcms/commerce/pull/810 from last year.