### PR TITLE
Product Titles are included in Field Layouts

### DIFF
--- a/src/fieldlayoutelements/ProductTitleField.php
+++ b/src/fieldlayoutelements/ProductTitleField.php
@@ -42,7 +42,7 @@ class ProductTitleField extends TitleField
             throw new InvalidArgumentException('ProductTitleField can only be used in product field layouts.');
         }
 
-        if (!$element->getType()->hasVariantTitleField && !$element->hasErrors('title')) {
+        if (!$element->getType()->hasProductTitleField && !$element->hasErrors('title')) {
             return null;
         }
 


### PR DESCRIPTION
### Description
The conditional in `craft\commerce\fieldlayoutelements\ProductTitleField` was using the `ProductType::hasVariantTitleField` to determine whether _Product_ titles were rendered, when it ought to have been using `ProductType::hasProductTitleField` property.

This just updates that part of the conditional for the field layout element.

### Related issues
Should fix #1613.