### PR TITLE
Fixing twig example code (changed endif to endfor)

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -950,7 +950,7 @@ class Order extends Element
      * ```twig
      * {% for lineItem in order.lineItems %}
      * {{ lineItem.description }}
-     * {% endif %}
+     * {% endfor %}
      * ```
      */
     private $_lineItems;
@@ -968,7 +968,7 @@ class Order extends Element
      * ```twig
      * {% for adjustment in order.adjustments %}
      * {{ adjustment.amount }}
-     * {% endif %}
+     * {% endfor %}
      * ```
      */
     private $_orderAdjustments;


### PR DESCRIPTION
### Description
Noticed a small typo in the example twig code. Replaced the errant `endif` with `endfor`.


