### PR TITLE
Check if coupon availaible with discount condition formula

### DIFF
--- a/src/services/Discounts.php
+++ b/src/services/Discounts.php
@@ -365,6 +365,11 @@ class Discounts extends Component
             return false;
         }
 
+        if (!$this->_isDiscountConditionFormulaValid($order, $discount)) {
+            $explanation = Plugin::t('Discount is not allowed for the order');
+            return false;
+        }
+
         if (!$this->_isDiscountDateValid($order, $discount)) {
             $explanation = Plugin::t('Discount is out of date.');
             return false;
@@ -969,6 +974,24 @@ class Discounts extends Component
         $to = $discount->dateTo;
 
         return !(($from && $from > $now) || ($to && $to < $now));
+    }
+
+    /**
+     * @param Order $order
+     * @param Discount $discount
+     * @return bool
+     */
+    private function _isDiscountConditionFormulaValid(Order $order, Discount $discount): bool
+    {
+        if ($discount->orderConditionFormula) {
+            $orderDiscountConditionParams = [
+                'order' => $order->toArray([], ['lineItems.snapshot', 'shippingAddress', 'billingAddress'])
+            ];
+
+            return Plugin::getInstance()->getFormulas()->evaluateCondition($discount->orderConditionFormula, $orderDiscountConditionParams, 'Evaluate Order Discount Condition Formula');
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
#### The problem
Craft's commerce does not return an error when a user wants to add an existing coupon code to the cart via the action `commerce/cart/update-cart` and the order condition formula did not pass.

#### The solution
I added this simple check based on your code style and existing code to validate and send an error when the coupon is not valid because of the condition formula.

Please let me know if this PR is problematic, I am ready to change the code or adapt to your guidelines.

Thanks for Craft and thanks for the commerce plugin. Much love from Montreal ❤