### PR TITLE
Improve error reporting when sending Order Emails

### DIFF
--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -578,15 +578,9 @@ class OrdersController extends Controller
 
         $success = true;
         try {
-            if (!Plugin::getInstance()->getEmails()->sendEmail($email, $order)) {
-                $success = false;
-            }
+            Plugin::getInstance()->getEmails()->sendEmail($email, $order);
         } catch (\Exception $exception) {
-            $success = false;
-        }
-
-        if (!$success) {
-            return $this->asErrorJson(Craft::t('commerce', 'Could not send email'));
+            return $this->asErrorJson($exception->getMessage());
         }
 
         return $this->asJson(['success' => true]);

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -577,7 +577,10 @@ class OrdersController extends Controller
         }
 
         try {
-            Plugin::getInstance()->getEmails()->sendEmail($email, $order);
+            if (!Plugin::getInstance()->getEmails()->sendEmail($email, $order)) {
+                // Likely, a plugin prevented it:
+                return $this->asErrorJson(Craft::t('commerce', 'The email was not sent.'));
+            }
         } catch (\Exception $exception) {
             return $this->asErrorJson($exception->getMessage());
         }

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -576,7 +576,6 @@ class OrdersController extends Controller
             return $this->asErrorJson(Craft::t('commerce', 'Can not find order'));
         }
 
-        $success = true;
         try {
             Plugin::getInstance()->getEmails()->sendEmail($email, $order);
         } catch (\Exception $exception) {


### PR DESCRIPTION
This addresses #1379. I've felt for a while now that this is a necessary change for developers and administrators to know where issues are occurring with their customer emails.

Instead of swallowing errors (and only reporting them to the log), this lets them bubble out of `sendEmail`, either halting the parent `SendEmail` job, or the `OrderController::actionSendEmail` method.

As a result, emails that fail to send are either:

1. Immediately reported to the user, when using the "Send Email" function
2. Kept in the queue for review

The reported errors are more general (but still reflect whatever aspect failed)—perhaps the documentation can be amended, to suggest looking in the logs for more information?

![Screen Shot 2020-10-11 at 12 00 58 AM](https://user-images.githubusercontent.com/1895522/95672359-fe81a600-0b54-11eb-9dbf-468b2443e6ce.png)

I've used the existing `craft\commerce\errors\EmailException` class, but happy to create more specific errors for template/path, address, rendering, and/or PDF issues.

This was a one-shot attempt—let me know if it needs a style review, or if you've got something in the pipeline already. 😉

_It might be possible to let the individual exceptions bubble up (i.e. no `try/catch`), but I figured that a way of consolidating errors in a way that was meaningful to the admin/developer was better than pinpoint accuracy in a job or flash message…_