### PR TITLE
Reset Data Console Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## Unreleased
 
 ### Added
+- Added the `commerce/reset-data` console command. ([#581](https://github.com/craftcms/commerce/issues/581))
 - Added a “Variants” column to the Products index page. ([#1765](https://github.com/craftcms/commerce/issues/1765))
-- Added `craft\commerce\services\PaymentSources::getAllPaymentSourcesByGatewayId()`.
-- Added `craft\commerce\helpers\Purchasable`.
+- Added `craft\commerce\console\controlllers\ResetData`.
 - Added `craft\commerce\elements\Variants::getSkuAsText()`.
+- Added `craft\commerce\helpers\Purchasable`.
+- Added `craft\commerce\services\PaymentSources::getAllPaymentSourcesByGatewayId()`.
 
 ### Changed
 - Coupon codes are no longer case-sensitive. ([#1763](https://github.com/craftcms/commerce/issues/1763))

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -130,7 +130,7 @@ class Plugin extends BasePlugin
     /**
      * @inheritDoc
      */
-    public $schemaVersion = '3.2.6';
+    public $schemaVersion = '3.2.7';
 
     /**
      * @inheritdoc

--- a/src/console/controllers/ResetDataController.php
+++ b/src/console/controllers/ResetDataController.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\console\controllers;
+
+use Craft;
+use craft\commerce\db\Table;
+use craft\console\Controller;
+use craft\db\Query;
+use craft\db\Table as CraftTable;
+use craft\helpers\Console;
+use yii\console\ExitCode;
+
+/**
+ * Allows you to reset Commerce data.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.x
+ */
+class ResetDataController extends Controller
+{
+    /**
+     * Reset Commerce data.
+     *
+     * @return int
+     * @throws \yii\db\Exception
+     */
+    public function actionIndex(): int
+    {
+        $reset = $this->prompt('Resetting Commerce data will delete all orders, subscriptions, payment sources, customers, addresses and reset discount usages ... do you wish to continue?', [
+            'required' => true,
+            'default' => 'no',
+            'validator' => function($input) {
+                if (!in_array($input, ['yes', 'no'])) {
+                    $this->stderr('You must answer either "yes" or "no".' . PHP_EOL, Console::FG_RED);
+                    return false;
+                }
+
+                return true;
+        }]);
+
+        if ($reset == 'yes') {
+            $this->stdout('Resetting Commerce data ...' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+
+            // Orders
+            $this->stdout('Deleting orders ...' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+            $ids = (new Query())
+                ->select(['orders.id'])
+                ->from(['orders' => Table::ORDERS])
+                ->column();
+
+            Craft::$app->getDb()->createCommand()
+                ->delete(CraftTable::ELEMENTS, ['id' => $ids])
+                ->execute();
+
+            // Subscriptions
+            $this->stdout('Deleting subscriptions ...' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+            $subscriptionIds = (new Query())
+                ->select(['subscriptions.id'])
+                ->from(['subscriptions' => Table::SUBSCRIPTIONS])
+                ->column();
+
+            Craft::$app->getDb()->createCommand()
+                ->delete(CraftTable::ELEMENTS, ['id' => $subscriptionIds])
+                ->execute();
+
+            // These should really be deleted with a cascade
+            Craft::$app->getDb()->createCommand()
+                ->delete(Table::SUBSCRIPTIONS)
+                ->execute();
+
+            // Payment Sources
+            $this->stdout('Deleting payment sources ...' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+            Craft::$app->getDb()->createCommand()
+                ->delete(Table::PAYMENTSOURCES)
+                ->execute();
+
+            // Customers
+            $this->stdout('Deleting customers ...' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+            Craft::$app->getDb()->createCommand()
+                ->delete(Table::CUSTOMERS, ['userId' => null])
+                ->execute();
+
+            // Address
+            $this->stdout('Deleting addresses ...' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+            Craft::$app->getDb()->createCommand()
+                ->delete(Table::ADDRESSES, ['isStoreLocation' => null])
+                ->execute();
+
+            // Discount usage
+            $this->stdout('Resetting discount usage data ...' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+            Craft::$app->getDb()->createCommand()
+                ->delete(Table::CUSTOMER_DISCOUNTUSES)
+                ->execute();
+            Craft::$app->getDb()->createCommand()
+                ->delete(Table::EMAIL_DISCOUNTUSES)
+                ->execute();
+            Craft::$app->getDb()->createCommand()
+                ->update(Table::DISCOUNTS, ['totalDiscountUses' => 0], '', [], false)
+                ->execute();
+
+            $this->stdout('Finished.' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+        } else {
+            $this->stdout('Skipping data reset.' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
+        }
+
+        return ExitCode::OK;
+    }
+}

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1099,6 +1099,7 @@ class Install extends Migration
         $this->addForeignKey(null, Table::SHIPPINGZONE_STATES, ['shippingZoneId'], Table::SHIPPINGZONES, ['id'], 'CASCADE', 'CASCADE');
         $this->addForeignKey(null, Table::SHIPPINGZONE_STATES, ['stateId'], Table::STATES, ['id'], 'CASCADE', 'CASCADE');
         $this->addForeignKey(null, Table::STATES, ['countryId'], Table::COUNTRIES, ['id'], 'CASCADE', 'CASCADE');
+        $this->addForeignKey(null, Table::SUBSCRIPTIONS, ['id'], '{{%elements}}', ['id'], 'CASCADE');
         $this->addForeignKey(null, Table::SUBSCRIPTIONS, ['userId'], '{{%users}}', ['id'], 'RESTRICT');
         $this->addForeignKey(null, Table::SUBSCRIPTIONS, ['planId'], Table::PLANS, ['id'], 'RESTRICT');
         $this->addForeignKey(null, Table::SUBSCRIPTIONS, ['gatewayId'], Table::GATEWAYS, ['id'], 'RESTRICT');

--- a/src/migrations/m201013_064230_add_subscription_id_fk.php
+++ b/src/migrations/m201013_064230_add_subscription_id_fk.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace craft\commerce\migrations;
+
+use Craft;
+use craft\commerce\elements\Subscription;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\helpers\MigrationHelper;
+
+/**
+ * m201013_064230_add_subscription_id_fk migration.
+ */
+class m201013_064230_add_subscription_id_fk extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $ids = (new Query())
+            ->select(['id'])
+            ->from('{{%elements}}')
+            ->where(['type' => Subscription::class])
+            ->column();
+
+        $orphanedSubs = (new Query())
+            ->select(['id'])
+            ->from('{{%commerce_subscriptions}}')
+            ->where(['not', ['id' => $ids]])
+            ->column();
+
+        $this->delete('{{%commerce_subscriptions}}', ['id' => $orphanedSubs]);
+
+        MigrationHelper::dropAllForeignKeysOnTable('{{%commerce_subscriptions}}', $this);
+
+        $this->addForeignKey(null, '{{%commerce_subscriptions}}', ['id'], '{{%elements}}', ['id'], 'CASCADE');
+        $this->addForeignKey(null, '{{%commerce_subscriptions}}', ['userId'], '{{%users}}', ['id'], 'RESTRICT');
+        $this->addForeignKey(null, '{{%commerce_subscriptions}}', ['planId'], '{{%commerce_plans}}', ['id'], 'RESTRICT');
+        $this->addForeignKey(null, '{{%commerce_subscriptions}}', ['gatewayId'], '{{%commerce_gateways}}', ['id'], 'RESTRICT');
+        $this->addForeignKey(null, '{{%commerce_subscriptions}}', ['orderId'], '{{%commerce_orders}}', ['id'], 'SET NULL');
+
+        return true;
+
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m201013_064230_add_subscription_id_fk cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
### Description
This adds a console command for resetting Commerce data. The command takes the following actions:

- Deletes all orders/carts
- Deletes all subscriptions
- Deletes all payment sources
- Deletes all guest customers
- Deletes all addresses (for both guest and user customers)
- Resets all discount usage counters (total uses, customer usage and email usage)

This is useful for people developing to be able to clear any data before migrating the database.

A prompt is given before the reset action takes place.

### Related issues
#581 

