### PR TITLE
Fix incorrect shipping zone submission url

### DIFF
--- a/src/templates/shipping/shippingrules/_edit.html
+++ b/src/templates/shipping/shippingrules/_edit.html
@@ -217,7 +217,7 @@
             'Create a new shipping zone'|t('commerce'),
             newShippingZoneFields,
             newShippingZoneJs,
-            'commerce/shippingZones/save',
+            'commerce/shipping-zones/save',
             'Shipping zone saved.'|t
         ) }}
 


### PR DESCRIPTION
Fixes an incorrect URL for the creation of shipping zones

URL for shipping zone creation form was wrong.

https://github.com/craftcms/commerce/issues/1809