### PR TITLE
added afterPaymentTransaction event trigger

### DIFF
--- a/src/services/Payments.php
+++ b/src/services/Payments.php
@@ -436,6 +436,12 @@ class Payments extends Component
             $transaction->order->markAsComplete();
         }
 
+        if ($this->hasEventHandlers(self::EVENT_AFTER_PAYMENT_TRANSACTION)) {
+            $this->trigger(self::EVENT_AFTER_PAYMENT_TRANSACTION, new TransactionEvent([
+                'transaction' => $transaction
+            ]));
+        }
+
         if ($response->isRedirect() && $transaction->status === TransactionRecord::STATUS_REDIRECT) {
             $mutex->release($transactionLockName);
             $this->_handleRedirect($response, $redirect);


### PR DESCRIPTION
### Description
Adds a trigger for the EVENT_AFTER_PAYMENT_TRANSACTION event

More context here: https://github.com/craftcms/commerce/issues/1817


