### PR TITLE
Also add orderSiteId on clean install

### DIFF
--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -409,6 +409,7 @@ class Install extends Migration
             'cancelUrl' => $this->string(),
             'shippingMethodHandle' => $this->string(),
             'shippingMethodName' => $this->string(),
+            'orderSiteId' => $this->integer(),
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
             'uid' => $this->uid(),


### PR DESCRIPTION
### Description

On a fresh install I see the following error:

```
 Undefined column: 7 ERROR: column commerce_orders.orderSiteId does not exist
LINE 1: ...e_orders"."itemSubtotal" AS "storedItemSubtotal", "commerce_...
```

It seems that orderSiteId is only added via a migration, not on fresh install.
This PR fixes that

