### PR TITLE
Fixed bug where a variant was trying to get a fieldlayout from a deleted product

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -395,8 +395,14 @@ class Variant extends Purchasable
      */
     public function getFieldLayout()
     {
+        $fieldLayout = parent::getFieldLayout();
+        
         // TODO: If we ever resave all products in a migration, we can remove this fallback and just use the default getFieldLayout()
-        return parent::getFieldLayout() ?? $this->getProduct()->getType()->getVariantFieldLayout();
+        if (!$fieldLayout && !$this->deletedWithProduct) {
+            $fieldLayout = $this->getProduct()->getType()->getVariantFieldLayout();
+        }
+
+        return $fieldLayout;
     }
 
     /**

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -398,7 +398,7 @@ class Variant extends Purchasable
         $fieldLayout = parent::getFieldLayout();
         
         // TODO: If we ever resave all products in a migration, we can remove this fallback and just use the default getFieldLayout()
-        if (!$fieldLayout && !$this->deletedWithProduct) {
+        if (!$fieldLayout && $this->deletedWithProduct) {
             $fieldLayout = $this->getProduct()->getType()->getVariantFieldLayout();
         }
 

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -398,7 +398,7 @@ class Variant extends Purchasable
         $fieldLayout = parent::getFieldLayout();
         
         // TODO: If we ever resave all products in a migration, we can remove this fallback and just use the default getFieldLayout()
-        if (!$fieldLayout && $this->deletedWithProduct) {
+        if (!$fieldLayout && $this->productId) {
             $fieldLayout = $this->getProduct()->getType()->getVariantFieldLayout();
         }
 


### PR DESCRIPTION
Fixes this case:

```
web_1         | 2020-10-30 10:30:06 [-][-][-][error][yii\base\InvalidConfigException] yii\base\InvalidConfigException: Variant is missing its product in /app/user/vendor/craftcms/commerce/src/elements/Variant.php:415
web_1         | Stack trace:
web_1         | #0 /app/user/vendor/craftcms/commerce/src/elements/Variant.php(399): craft\commerce\elements\Variant->getProduct()
web_1         | #1 /app/user/vendor/craftcms/cms/src/base/Element.php(3412): craft\commerce\elements\Variant->getFieldLayout()
web_1         | #2 /app/user/vendor/craftcms/cms/src/base/Element.php(3235): craft\base\Element->fieldLayoutFields()
web_1         | #3 /app/user/vendor/craftcms/commerce/src/elements/Variant.php(1139): craft\base\Element->beforeDelete()
web_1         | #4 /app/user/vendor/craftcms/cms/src/services/Elements.php(1465): craft\commerce\elements\Variant->beforeDelete()
web_1         | #5 /app/user/vendor/craftcms/commerce/src/elements/Product.php(852): craft\services\Elements->deleteElement(Object(craft\commerce\elements\Variant), true)
web_1         | #6 /app/user/vendor/craftcms/cms/src/services/Elements.php(1504): craft\commerce\elements\Product->afterDelete()
web_1         | #7 /app/user/vendor/craftcms/cms/src/test/fixtures/elements/ElementFixture.php(144): craft\services\Elements->deleteElement(Object(craft\commerce\elements\Product), true)
```