### PR TITLE
Fix for tax category editing issue #1840

### DIFF
--- a/src/templates/tax/taxcategories/_fields.html
+++ b/src/templates/tax/taxcategories/_fields.html
@@ -49,9 +49,9 @@
         value: 1,
         checked: taxCategory is defined ? taxCategory.default,
         errors: taxCategory is defined ? taxCategory.getErrors('default'),
-        disabled: (isDefaultAndOnlyCategory is defined and isDefaultAndOnlyCategory) or (taxCategory.id and taxCategory.default)
+        disabled: (isDefaultAndOnlyCategory is defined and isDefaultAndOnlyCategory) or (taxCategory is defined and taxCategory.id and taxCategory.default)
     }) }}
-    {% if (isDefaultAndOnlyCategory is defined and isDefaultAndOnlyCategory) or (taxCategory.id and taxCategory.default) %}
+    {% if (isDefaultAndOnlyCategory is defined and isDefaultAndOnlyCategory) or (taxCategory is defined and taxCategory.id and taxCategory.default) %}
       {{ hiddenInput('default', 1) }}
     {% endif %}
 {% endset %}


### PR DESCRIPTION
### Description
This PR will fix the twig runtime error when adding or editing a tax category in commerce 3.2.9

### Related issues
#1840 Unable to add or edit a tax category
