### PR TITLE
Address validateState doesn't run if stateId/countryId is a numeric string

### DIFF
--- a/src/models/Address.php
+++ b/src/models/Address.php
@@ -302,7 +302,7 @@ class Address extends Model
 
         $rules[] = [
             ['stateId'], 'validateState', 'skipOnEmpty' => false, 'when' => function($model) {
-                return (!$model->countryId || is_int($model->countryId)) && (!$model->stateId || is_int($model->stateId));
+                return (!$model->countryId || is_numeric($model->countryId)) && (!$model->stateId || is_numeric($model->stateId));
             }
         ];
 


### PR DESCRIPTION
### Description
Change is_int to is_numeric when checking if validateState should be run


### Related issues

