### PR TITLE
Fixed notice when a Customer Address was saved

### DIFF
--- a/src/controllers/CustomerAddressesController.php
+++ b/src/controllers/CustomerAddressesController.php
@@ -135,7 +135,7 @@ class CustomerAddressesController extends BaseFrontEndController
 
             $this->setSuccessFlash(Craft::t('commerce', 'Address saved.'));
 
-            $this->redirectToPostedUrl();
+            return $this->redirectToPostedUrl();
         } else {
             $errorMsg = Craft::t('commerce', 'Could not save address.');
 


### PR DESCRIPTION
Flash Notice is empty when an address was saved successfully.