### PR TITLE
perf: purge orphaned customers using nested query

### DIFF
--- a/src/services/Customers.php
+++ b/src/services/Customers.php
@@ -375,15 +375,12 @@ class Customers extends Component
             ->select(['[[customers.id]] id'])
             ->from(Table::CUSTOMERS . ' customers')
             ->leftJoin(Table::ORDERS . ' orders', '[[customers.id]] = [[orders.customerId]]')
-            ->where(['[[orders.customerId]]' => null, '[[customers.userId]]' => null])
-            ->column();
-
-        if ($customers) {
-            // This will also remove all addresses related to the customer.
-            Craft::$app->getDb()->createCommand()
-                ->delete(Table::CUSTOMERS, ['id' => $customers])
-                ->execute();
-        }
+            ->where(['[[orders.customerId]]' => null, '[[customers.userId]]' => null]);
+        
+        // This will also remove all addresses related to the customer.
+        Craft::$app->getDb()->createCommand()
+            ->delete(Table::CUSTOMERS, ['id' => $customers])
+            ->execute();
     }
 
     /**


### PR DESCRIPTION
### Problem experienced:

Haven't run purge in a while the number of orphaned customers can grow to the millions (I have found 4,5 million orphaned customers last time I ran this) and that scenario breaks the craft gc/run due the size of the id list parameter.

### Solution:

Proper nested query for the delete command.