### PR TITLE
Product element order status fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Fixed a bug where `craft\commerce\services\Discounts::getDiscountByCode()` was returning disabled discounts.
 - Fixed a bug where `craft\commerce\models\Address::setAttributes()` wasn’t setting the `businessId` by default. ([#1909](https://github.com/craftcms/commerce/issues/1909))
 - Fixed some PostgreSQL compatibility issues.
-- Fixed products still displaying in product entry page even post date is set in the future. ([]())
+- Fixed products still displaying in product entry page even post date is set in the future. ([#1929](https://github.com/craftcms/commerce/pull/1929))
 
 ## 3.2.12 - 2020-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed a bug where `craft\commerce\services\Discounts::getDiscountByCode()` was returning disabled discounts.
 - Fixed a bug where `craft\commerce\models\Address::setAttributes()` wasn’t setting the `businessId` by default. ([#1909](https://github.com/craftcms/commerce/issues/1909))
 - Fixed some PostgreSQL compatibility issues.
+- Fixed products still displaying in product entry page even post date is set in the future. ([]())
 
 ## 3.2.12 - 2020-11-17
 

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -1201,6 +1201,11 @@ class Product extends Element
      */
     protected function route()
     {
+        // Make sure that the product is actually live
+        if (!$this->previewing && $this->getStatus() != self::STATUS_LIVE) {
+            return null;
+        }
+        
         // Make sure the product type is set to have URLs for this site
         $siteId = Craft::$app->getSites()->currentSite->id;
         $productTypeSiteSettings = $this->getType()->getSiteSettings();


### PR DESCRIPTION
Fixed products still displaying in product entry page even post date is set in the future.