### PR TITLE
Fix improper currency for OrderAdjustment

### DIFF
--- a/src/models/OrderAdjustment.php
+++ b/src/models/OrderAdjustment.php
@@ -112,7 +112,10 @@ class OrderAdjustment extends Model
         $behaviors['currencyAttributes'] = [
             'class' => CurrencyAttributeBehavior::class,
             'defaultCurrency' => Plugin::getInstance()->getPaymentCurrencies()->getPrimaryPaymentCurrencyIso(),
-            'currencyAttributes' => $this->currencyAttributes()
+            'currencyAttributes' => $this->currencyAttributes(),
+            'attributeCurrencyMap' => [
+                'amount' => $this->order->paymentCurrency
+            ]
         ];
 
         return $behaviors;


### PR DESCRIPTION
### Description

Order adjusters are being displayed as default currency instead of cart currency while the amount is correct.

![image](https://user-images.githubusercontent.com/577015/108423462-2cc86e00-7238-11eb-9b4b-7f052c3e3ac7.png)

I'm not sure if this is the proper way to populate `attributeCurrencyMap`, but it seemingly solves the problem on the admin.

