### PR TITLE
Additional hook in product edit template for adding action links to Save button

### DIFF
--- a/src/templates/products/_edit.html
+++ b/src/templates/products/_edit.html
@@ -101,6 +101,9 @@
                     </li>
                 </ul>
             {% endif %}
+            
+            {% hook "cp.commerce.product.action.button" %}
+
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Additional hook to allow for inclusion of action links in Save button menu

I'm currently building an integration with a third-party inventory management system. One of the things I need to include is the ability to manually get product data from the system and update the Commerce Product with it.

I've got a button injected into the sidebar but that appears quite far down the page and requires a bit of scrolling of the sidebar to reach it.

It struck me that having an option to "Update data from <system> and Save" under the Save action menu would be logical. Hence the request for the hook.

