### PR TITLE
Fixed missing `error` and `success` keys on complete payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed a bug where the `commerce/reset-data` command did not delete addresses. ([#2042](https://github.com/craftcms/commerce/issues/2042))
+- Fixed a bug where `success` and `error` keys were missing from JSON response on requests to `commerce/payments/complete-payment`. ([#2043](https://github.com/craftcms/commerce/issues/2043))
 
 ## 3.2.17.1 - 2021-03-08
 

--- a/src/controllers/PaymentsController.php
+++ b/src/controllers/PaymentsController.php
@@ -488,7 +488,10 @@ class PaymentsController extends BaseFrontEndController
 
         if ($success) {
             if (Craft::$app->getRequest()->getAcceptsJson()) {
-                $response = ['url' => $transaction->order->returnUrl];
+                $response = [
+                    'success' => true,
+                    'url' => $transaction->order->returnUrl,
+                ];
 
                 return $this->asJson($response);
             }
@@ -496,10 +499,14 @@ class PaymentsController extends BaseFrontEndController
             return $this->redirect($transaction->order->returnUrl);
         }
 
-        $this->setFailFlash(Craft::t('commerce', 'Payment error: {message}', ['message' => $error]));
+        $errorMessage = Craft::t('commerce', 'Payment error: {message}', ['message' => $error]);
+        $this->setFailFlash($errorMessage);
 
         if (Craft::$app->getRequest()->getAcceptsJson()) {
-            $response = ['url' => $transaction->order->cancelUrl];
+            $response = [
+                'error' => $errorMessage,
+                'url' => $transaction->order->cancelUrl,
+            ];
 
             return $this->asJson($response);
         }


### PR DESCRIPTION
Fixes #2043 

Can you see anything wrong with this @lukeholder 

My only other note is that I didn't use `asErrorJson` because that only passes back and error and the cancel URL was already being returned.