### PR TITLE
Add Check Variant Availability Event

### DIFF
--- a/src/events/CheckVariantAvailabilityEvent.php
+++ b/src/events/CheckVariantAvailabilityEvent.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use craft\commerce\elements\Product;
+use craft\commerce\elements\Variant;
+use craft\events\CancelableEvent;
+
+/**
+ * Class CheckVariantAvailabilityEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.3.0
+ */
+class CheckVariantAvailabilityEvent extends CancelableEvent
+{
+    /**
+     * @var Product The product model associated with the event.
+     */
+    public $product;
+
+    /**
+     * @var Variant The variant model associated with the event.
+     */
+    public $variant;
+}


### PR DESCRIPTION
Implements the event suggested here: #2106

Allows plugins and modules to control whether an item is available based on some custom logic eg think custom variant date fields stopSellingOn startSellingOn

By adding this event to the variant getIsAvailable() method you have the flexibility of being able to add custom logic to determine if a product / variant is available for purchase. Also great when combined with the new cart notices feature as it allows you to ensure variants are picked up by the recalculation and the correct notice is added when / if the variant becomes unavailable.

Cleanly replaces a lot of custom behavior logic / template that would be required to get something like this working.

### Related issues

#2106

