### PR TITLE
Added purchasable available event

### DIFF
--- a/CHANGELOG-3.3.1.md
+++ b/CHANGELOG-3.3.1.md
@@ -2,5 +2,9 @@
 
 ## Unreleased 3.3.1
 
+### Added
+- Added `craft\commerce\services\Purchasables::EVENT_PURCHASABLE_AVAILABLE`.
+- Added `craft\commerce\services\Purchasables::isPurchasableAvailable()`.
+
 ### Changed
 - Order condition forumlas now include serialized custom field values for use in formulas. ([#2066]https://github.com/craftcms/commerce/issues/2066))

--- a/CHANGELOG-3.3.1.md
+++ b/CHANGELOG-3.3.1.md
@@ -1,6 +1,6 @@
 # Release Notes for Craft Commerce
 
-### Unreleased 3.3.1
+## Unreleased 3.3.1
 
 ### Changed
 - Order condition forumlas now include serialized custom field values for use in formulas. ([#2066]https://github.com/craftcms/commerce/issues/2066))

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -1490,7 +1490,7 @@ class OrdersController extends Controller
                 } else {
                     $row['priceAsCurrency'] = Craft::$app->getFormatter()->asCurrency($row['price'], $baseCurrency, [], [], true);
                 }
-                $row['isAvailable'] = $purchasable->getIsAvailable();
+                $row['isAvailable'] = Plugin::getInstance()->getPurchasables()->isPurchasableAvailable($purchasable);
                 $row['detail'] = [
                     'title' => Craft::t('commerce', 'Information'),
                     'content' => $purchasable->getSnapshot(),

--- a/src/events/PurchasableAvailableEvent.php
+++ b/src/events/PurchasableAvailableEvent.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use craft\commerce\base\PurchasableInterface;
+use craft\commerce\elements\Order;
+use craft\elements\User;
+use yii\base\Event;
+
+/**
+ * Class PurchasableAvailableEvent
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 3.x
+ */
+class PurchasableAvailableEvent extends Event
+{
+    /**
+     * @var Order|null The order element.
+     */
+    public $order;
+
+    /**
+     * @var PurchasableInterface The purchasable element.
+     */
+    public $purchasable;
+
+    /**
+     * @var User|null The user performing the check.
+     */
+    public $currentUser;
+
+    /**
+     * @var bool Is this purchasable available to the order and current user. Default is: $event->purchasable->getIsAvailable()
+     */
+    public $isAvailable;
+}

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -634,7 +634,7 @@ class LineItem extends Model
 
         /* @var $purchasable Purchasable */
         $purchasable = $this->getPurchasable();
-        if (!$purchasable || !$purchasable->getIsAvailable()) {
+        if (!$purchasable || !Plugin::getInstance()->getPurchasables()->isPurchasableAvailable($purchasable, $this->getOrder())) {
             return false;
         }
 


### PR DESCRIPTION
### Description

Fixes #2106

As a developer I want to be able to control when a purchasable is available to be purchased in PHP, by using the context of the cart and the current user.

```php
use craft\commerce\events\PurchasableAvailableEvent;
use craft\commerce\services\Purchasables;
use yii\base\Event;
Event::on(
    Purchasables::class,
    Purchasables::EVENT_PURCHASABLE_AVAILABLE,
    function(PurchasableAvailableEvent $event) {
        if($order && $user = $order->getUser()){
            $event->isAvailable = $event->isAvailable && !$user->isInGroup(1); // Group ID 1 not allowed to have purchasable in the cart.
        }
    }
);
```

If the Purchasable becomes unavailable after being added to the cart, an order notice will be added to the order informing the customer.
