### PR TITLE
Don't log an error when deliberately canceling sending order mail

### DIFF
--- a/src/services/Emails.php
+++ b/src/services/Emails.php
@@ -791,12 +791,12 @@ class Emails extends Component
             $this->trigger(self::EVENT_BEFORE_SEND_MAIL, $event);
 
             if (!$event->isValid) {
-                $error = Craft::t('commerce', 'Email “{email}” for order {order} was cancelled.', [
+                $notice = Craft::t('commerce', 'Email “{email}” for order {order} was cancelled.', [
                     'email' => $email->name,
                     'order' => $order->getShortNumber()
                 ]);
 
-                Craft::error($error, __METHOD__);
+                Craft::info($notice, __METHOD__);
 
                 Craft::$app->language = $originalLanguage;
                 $view->setTemplateMode($oldTemplateMode);


### PR DESCRIPTION
### Description

Cancelling an order mail now logs an error. In my case this clogs up Sentry, while technically this is deliberate, not an error.

