### PR TITLE
Fixed a bug where submitting a blank line item quantity throws "Unsupported operand types: int + string" error in PHP 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Craft Commerce
 
+### Fixed
+- Fixed a bug where submitting a blank line item quantity throws "Unsupported operand types: int + string" error in PHP 8. ([#2125](https://github.com/craftcms/commerce/issues/2125))
+
 ##  3.3.1.1 - 2021-05-09
 
 ### Fixed

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -132,7 +132,7 @@ class CartController extends BaseFrontEndController
                 $purchasable['id'] = $purchasableId;
                 $purchasable['options'] = $options;
                 $purchasable['note'] = $note;
-                $purchasable['qty'] = $qty;
+                $purchasable['qty'] = (int) $qty;
 
                 $key = $purchasableId . '-' . LineItemHelper::generateOptionsSignature($options);
                 if (isset($purchasablesByKey[$key])) {
@@ -169,7 +169,7 @@ class CartController extends BaseFrontEndController
             foreach ($lineItems as $key => $lineItem) {
                 $lineItem = $this->_getCartLineItemById($key);
                 if ($lineItem) {
-                    $lineItem->qty = $this->request->getParam("lineItems.{$key}.qty", $lineItem->qty);
+                    $lineItem->qty = (int) $this->request->getParam("lineItems.{$key}.qty", $lineItem->qty);
                     $lineItem->note = $note = $this->request->getParam("lineItems.{$key}.note", $lineItem->note);
                     $lineItem->setOptions($this->request->getParam("lineItems.{$key}.options", $lineItem->getOptions()));
 


### PR DESCRIPTION
Fixed (#2125)