### PR TITLE
Fixed a bug with stats if mysql timezones aren’t populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Fixed a bug where it was not possible to use the `DefineAttributeKeywordsEvent` event for Product SKU’s. ([#2142](https://github.com/craftcms/commerce/issues/2142))
+- Fixed an error that occurred when MySQL timezones are not populated.
 
 ## 3.3.2 - 2021-05-18
 

--- a/src/base/Stat.php
+++ b/src/base/Stat.php
@@ -372,7 +372,19 @@ abstract class Stat implements StatInterface
      */
     public function getChartQueryOptionsByInterval(string $interval)
     {
-        $timezoneConversionSql = "CONVERT_TZ([[dateOrdered]], 'UTC', '" . Craft::$app->getTimeZone() . "')";
+        // The fallback if timezone can't happen in sql is simply just extract the information from the UTC date stored in `dateOrdered`.
+        $timezoneConversionSql = "[[dateOrdered]]";
+
+        // @TODO remove version compare at next breaking change release
+        if (version_compare(Craft::$app->getInfo()->version, '3.6.16', '>=') && method_exists(Db::class, 'validateDatabaseTimezoneSupport') && Db::validateDatabaseTimezoneSupport()) {
+            $timezoneConversionSql = "CONVERT_TZ([[dateOrdered]], 'UTC', '" . Craft::$app->getTimeZone() . "')";
+        }
+
+        // @TODO remove version compare at next breaking change release
+        if (version_compare(Craft::$app->getInfo()->version, '3.6.16', '>=') && method_exists(Db::class, 'validateDatabaseTimezoneSupport') && !Db::validateDatabaseTimezoneSupport()) {
+            // @TODO insert link to documentation information
+            Craft::getLogger()->log('For accurate Commerce statistics it is recommend to make sure you have the timezones table populated. {link}', Craft::getLogger()::LEVEL_WARNING, 'commerce');
+        }
 
         if (Craft::$app->getDb()->getIsPgsql()) {
             $timezoneConversionSql = "(([[dateOrdered]] AT TIME ZONE 'UTC') AT TIME ZONE '" . Craft::$app->getTimeZone() . "')";


### PR DESCRIPTION
### Description
There is a bug that exists in the Stats (and therefore the reporting widgets) that occurs when the timezones tables in the `mysql` database are not populated. It appears that by default MariaDB does not populate this table: https://mariadb.com/kb/en/time-zones/#mysql-time-zone-tables

This means the code could fail later on due to `null` being returned in an SQL query. To fix this a fallback SQL statement has been added that will at least provide a date. Unfortunately, if this fallback statement is used then there is a chance for some slightly skewed graph/chart data due to timezone issues.

Therefore it is recommended that the timezones information is installed/populated to make sure that data is correct.

Craft is adding support for checking whether the timezone data exists. This is being added in Craft version `3.6.16`. 

- https://github.com/craftcms/server-check/commit/a466369f763dfbe8546446cfb3b3bff3271506bc
- https://github.com/craftcms/cms/commit/ff4f0e7b7eb9d7495668ef80d430cfc19080b6ea
- https://github.com/craftcms/cms/commit/08039089129b448d881e895817a2850f89eaacd9

There may be questions around why this cannot simply be fixed by processing the data in PHP. Currently Commerce does not have a concept of aggregate tables or anything for reporting. Therefore to make sure site performance is not hindered we are really on the DB querying to deal with the calculations. This is a lot more performant, due to the fact that the stats are referencing orders and line items of which there could be serval million rows. Instantiating all that data in the PHP application would cause significant overheads.

As Commerce looks to improve its reporting features this will be revisited to make improvements and implement more robust methods of calculating and interpreting statistical data.

### Related Issues
- Closes #2163 