### PR TITLE
Prevent empty `commerce.yaml` file being created on project config rebuild events

### DIFF
--- a/src/helpers/ProjectConfigData.php
+++ b/src/helpers/ProjectConfigData.php
@@ -60,7 +60,7 @@ class ProjectConfigData
             ];
         }
 
-        return $output;
+        return array_filter($output);
     }
 
     /**


### PR DESCRIPTION
When running `./craft project-config/rebuild`, it'll often produce an empty `commerce.yaml` file. This is because not required, as commerce PC data is stored in its own folder, not a single YAML file.

For reference, whatever it's worth, I've added this fix on [Formie](https://github.com/verbb/formie/commit/5dfb3a43ed902258e37a8c3c7d30387eba869091) which had the same issue.