### PR TITLE
Changed return and cancel url column type to text in `commerce_orders` table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Craft Commerce
 
+### Changed
+- Changed return and cancel url column type to text in `commerce_orders` table.
+
 ## 3.3.3 - 2021-06-01
 
 ### Added

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -130,7 +130,7 @@ class Plugin extends BasePlugin
     /**
      * @inheritDoc
      */
-    public $schemaVersion = '3.3.2';
+    public $schemaVersion = '3.3.3';
 
     /**
      * @inheritdoc

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -130,7 +130,7 @@ class Plugin extends BasePlugin
     /**
      * @inheritDoc
      */
-    public $schemaVersion = '3.3.3';
+    public $schemaVersion = '3.4.0';
 
     /**
      * @inheritdoc

--- a/src/migrations/m210608_071647_change_return_cancel_url_column_type.php
+++ b/src/migrations/m210608_071647_change_return_cancel_url_column_type.php
@@ -18,8 +18,8 @@ class m210608_071647_change_return_cancel_url_column_type extends Migration
         if ($this->db->getIsPgsql()) {
             // Manually construct the SQL for Postgres
             // (see https://github.com/yiisoft/yii2/issues/12077)
-            $this->execute('alter table {{%commerce_orders} alter column [[returnUrl]] DROP NOT NULL');
-            $this->execute('alter table {{%commerce_orders}} alter column [[cancelUrl]] DROP NOT NULL');
+            $this->execute('alter table {{%commerce_orders}} alter column [[returnUrl]] TYPE TEXT');
+            $this->execute('alter table {{%commerce_orders}} alter column [[cancelUrl]] TYPE TEXT');
         } else {
             $this->alterColumn('{{%commerce_orders}}', 'returnUrl', $this->text());
             $this->alterColumn('{{%commerce_orders}}', 'cancelUrl', $this->text());

--- a/src/migrations/m210608_071647_change_return_cancel_url_column_type.php
+++ b/src/migrations/m210608_071647_change_return_cancel_url_column_type.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace craft\commerce\migrations;
+
+use Craft;
+use craft\db\Migration;
+
+/**
+ * m210608_071647_change_return_cancel_url_column_type migration.
+ */
+class m210608_071647_change_return_cancel_url_column_type extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        if ($this->db->getIsPgsql()) {
+            // Manually construct the SQL for Postgres
+            // (see https://github.com/yiisoft/yii2/issues/12077)
+            $this->execute('alter table {{%commerce_orders} alter column [[returnUrl]] DROP NOT NULL');
+            $this->execute('alter table {{%commerce_orders}} alter column [[cancelUrl]] DROP NOT NULL');
+        } else {
+            $this->alterColumn('{{%commerce_orders}}', 'returnUrl', $this->text());
+            $this->alterColumn('{{%commerce_orders}}', 'cancelUrl', $this->text());
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m210608_071647_change_return_cancel_url_column_type cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
This will resolve issue with very long url which throws `Data too long for column 'returnUrl'` error