### PR TITLE
Rounding error in payment controller results in "Partial payment not allowed." error

### DIFF
--- a/src/controllers/PaymentsController.php
+++ b/src/controllers/PaymentsController.php
@@ -425,7 +425,7 @@ class PaymentsController extends BaseFrontEndController
             $order->setPaymentAmount($paymentAmount);
         }
 
-        $paymentAmountInPrimaryCurrency = Plugin::getInstance()->getPaymentCurrencies()->convertCurrency($order->getPaymentAmount(), $order->paymentCurrency, $order->currency);
+        $paymentAmountInPrimaryCurrency = round(Plugin::getInstance()->getPaymentCurrencies()->convertCurrency($order->getPaymentAmount(), $order->paymentCurrency, $order->currency), 2);
 
         if (!$partialAllowed && $paymentAmountInPrimaryCurrency < $order->getOutstandingBalance()) {
             $error = Craft::t('commerce', 'Partial payment not allowed.');

--- a/src/controllers/PaymentsController.php
+++ b/src/controllers/PaymentsController.php
@@ -425,9 +425,9 @@ class PaymentsController extends BaseFrontEndController
             $order->setPaymentAmount($paymentAmount);
         }
 
-        $paymentAmountInPrimaryCurrency = round(Plugin::getInstance()->getPaymentCurrencies()->convertCurrency($order->getPaymentAmount(), $order->paymentCurrency, $order->currency), 2);
+        $paymentAmountInPrimaryCurrency = Plugin::getInstance()->getPaymentCurrencies()->convertCurrency($order->getPaymentAmount(), $order->paymentCurrency, $order->currency);
 
-        if (!$partialAllowed && $paymentAmountInPrimaryCurrency < $order->getOutstandingBalance()) {
+        if (!$partialAllowed && round($paymentAmountInPrimaryCurrency, 2) < $order->getOutstandingBalance()) {
             $error = Craft::t('commerce', 'Partial payment not allowed.');
             $this->setFailFlash($error);
             Craft::$app->getUrlManager()->setRouteParams(['paymentForm' => $paymentForm, $this->_cartVariableName => $order]);

--- a/src/controllers/PaymentsController.php
+++ b/src/controllers/PaymentsController.php
@@ -12,6 +12,7 @@ use craft\commerce\elements\Order;
 use craft\commerce\errors\CurrencyException;
 use craft\commerce\errors\PaymentException;
 use craft\commerce\errors\PaymentSourceException;
+use craft\commerce\helpers\Currency;
 use craft\commerce\models\PaymentSource;
 use craft\commerce\models\Transaction;
 use craft\commerce\Plugin;
@@ -427,7 +428,7 @@ class PaymentsController extends BaseFrontEndController
 
         $paymentAmountInPrimaryCurrency = Plugin::getInstance()->getPaymentCurrencies()->convertCurrency($order->getPaymentAmount(), $order->paymentCurrency, $order->currency);
 
-        if (!$partialAllowed && round($paymentAmountInPrimaryCurrency, 2) < $order->getOutstandingBalance()) {
+        if (!$partialAllowed && Currency::round($paymentAmountInPrimaryCurrency) < $order->getOutstandingBalance()) {
             $error = Craft::t('commerce', 'Partial payment not allowed.');
             $this->setFailFlash($error);
             Craft::$app->getUrlManager()->setRouteParams(['paymentForm' => $paymentForm, $this->_cartVariableName => $order]);


### PR DESCRIPTION
### Description
We are experiencing some issues in a shop where we have setup various currencies for customers to pay with.
We have setup the USD as primary currency and AUD, CAD, EUR and GBP as secondary currencies. When a customer tries to pay in a secondary currency, we sometimes get rounding issues in the pay action, and then receiving the error that the payment the customer is trying to do, is a partial payment, which is not allowed. After some debugging we found out that the amount the customer wants to pay is 94.2399999 while the outstanding balance is 94.24.

### Related issues
https://github.com/craftcms/commerce/issues/2222
