### PR TITLE
Fixed not copying addresses for new guest customers in the CP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Fixed a bug where long subscription references would break the meta layout on the Edit Subscription page. ([#2211](https://github.com/craftcms/commerce/issues/2211))
 - Fixed a bug where non-promotable purchasables were having order level discounts applied. ([#2180](https://github.com/craftcms/commerce/issues/2180))
+- Fixed a bug where primary addresses weren’t being copied to a brand new guest customer’s address book. ([#2224](https://github.com/craftcms/commerce/issues/2224))
 
 ## 3.3.4.1 - 2021-06-16
 

--- a/src/services/Customers.php
+++ b/src/services/Customers.php
@@ -556,6 +556,38 @@ class Customers extends Component
             // We don't need to update search indexes since the address contents are the same.
             Craft::$app->getElements()->saveElement($order, false, false, false);
         }
+
+        // Copy address to guest customer's address book if they have no addresses
+        $customer = $order->getCustomer();
+        if ($customer && !$customer->userId && empty($customer->getAddresses()) && ($order->billingAddressId || $order->shippingAddressId)) {
+            $addressesUpdated = false;
+            if ($order->billingAddressId && $billingAddress = $order->getBillingAddress()) {
+                $billingAddress->id = null;
+                if ($this->saveAddress($billingAddress, $customer, false)) {
+                    $customer->primaryBillingAddressId = $billingAddress->id;
+                    $addressesUpdated = true;
+                }
+            }
+
+            if ($order->shippingAddressId) {
+                $shippingAddress = $order->getShippingAddress();
+                if ($shippingAddress && $shippingAddress->sameAs($order->getBillingAddress())) {
+                    // Don't create two addresses in the address book if they are the same
+                    $customer->primaryShippingAddressId = $customer->primaryBillingAddressId;
+                    $addressesUpdated = true;
+                } else if ($shippingAddress) {
+                    $shippingAddress->id = null;
+                    if ($this->saveAddress($shippingAddress, $customer, false)) {
+                        $customer->primaryShippingAddressId = $shippingAddress->id;
+                        $addressesUpdated = true;
+                    }
+                }
+            }
+
+            if ($addressesUpdated) {
+                $this->saveCustomer($customer);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Description
Primary billing and shipping IDs were being incorrectly set on brand new guest customers when creating an order in the control panel.

This PR updates the functionality to work more like it does in a front-end process.

Worth noting that it will only copy the addresses to a guest customer if this is their first order. Otherwise, the behaviour is unchanged, meaning that addresses on the order edit screen are independent of the customer's address book.

Fixes #2224 

