### PR TITLE
Also hardcode commerce version in "extra"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
   "extra": {
     "handle": "commerce",
     "name": "Craft Commerce",
+    "version": "3.3.4.1",
     "description": "Create beautifully bespoke ecommerce experiences",
     "developer": "Pixel & Tonic",
     "documentationUrl": "https://craftcms.com/docs/commerce/3.x/"


### PR DESCRIPTION
### Description

Because commerce uses a lot of "version_compare", this trick allows us to use forks. See this issue: https://github.com/craftcms/plugin-installer/issues/8


### Related issues

https://github.com/craftcms/plugin-installer/issues/8