### PR TITLE
Define GQL complexity values

### DIFF
--- a/src/fields/Products.php
+++ b/src/fields/Products.php
@@ -15,6 +15,8 @@ use craft\commerce\gql\interfaces\elements\Product as ProductInterface;
 use craft\commerce\gql\resolvers\elements\Product as ProductResolver;
 use craft\commerce\web\assets\editproduct\EditProductAsset;
 use craft\fields\BaseRelationField;
+use craft\helpers\Gql as GqlHelper;
+use craft\services\Gql as GqlService;
 use GraphQL\Type\Definition\Type;
 
 /**
@@ -65,6 +67,7 @@ class Products extends BaseRelationField
             'type' => Type::listOf(ProductInterface::getType()),
             'args' => ProductArguments::getArguments(),
             'resolve' => ProductResolver::class . '::resolve',
+            'complexity' => GqlHelper::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
         ];
     }
 

--- a/src/fields/Variants.php
+++ b/src/fields/Variants.php
@@ -13,6 +13,8 @@ use craft\commerce\gql\arguments\elements\Variant as VariantArguments;
 use craft\commerce\gql\interfaces\elements\Variant as VariantInterface;
 use craft\commerce\gql\resolvers\elements\Variant as VariantResolver;
 use craft\fields\BaseRelationField;
+use craft\helpers\Gql as GqlHelper;
+use craft\services\Gql as GqlService;
 use GraphQL\Type\Definition\Type;
 
 /**
@@ -50,6 +52,7 @@ class Variants extends BaseRelationField
             'type' => Type::listOf(VariantInterface::getType()),
             'args' => VariantArguments::getArguments(),
             'resolve' => VariantResolver::class . '::resolve',
+            'complexity' => GqlHelper::relatedArgumentComplexity(GqlService::GRAPHQL_COMPLEXITY_EAGER_LOAD),
         ];
     }
 


### PR DESCRIPTION
### Description

Specifies GraphQL field complexity values for Products and Variants fields, exactly [how Craft does with Entries fields](https://github.com/craftcms/cms/blob/e50f1990c28c3b6429ec461e87e710c4b44f44ed/src/fields/Entries.php#L83-L83).

These help quantify the compute resources needed to execute a query, limited by Craft’s [maxGraphqlComplexity](https://craftcms.com/docs/3.x/config/config-settings.html#maxgraphqlcomplexity) setting as a safety feature.

Covered soon by the [Extending GraphQL](https://github.com/craftcms/docs/blob/draft/extending-graphql/docs/3.x/extend/graphql.md) docs. :)