### PR TITLE
Updated `validateDatabaseTimezoneSupport` to `supportsTimeZones`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "rss": "https://github.com/craftcms/commerce/releases.atom"
   },
   "require": {
-    "craftcms/cms": "^3.7.0-beta.1",
+    "craftcms/cms": "^3.7.0-beta.5",
     "dompdf/dompdf": "^1.0.2",
     "moneyphp/money": "^3.3.1",
     "ibericode/vat": "^1.1.2",

--- a/src/base/Stat.php
+++ b/src/base/Stat.php
@@ -376,13 +376,10 @@ abstract class Stat implements StatInterface
             // The fallback if timezone can't happen in sql is simply just extract the information from the UTC date stored in `dateOrdered`.
             $timezoneConversionSql = "[[dateOrdered]]";
 
-            // @TODO remove the method_exists() check at next breaking change release
-            if (method_exists(Db::class, 'validateDatabaseTimezoneSupport')) {
-                if (Db::validateDatabaseTimezoneSupport()) {
-                    $timezoneConversionSql = "CONVERT_TZ([[dateOrdered]], 'UTC', '" . Craft::$app->getTimeZone() . "')";
-                } else {
-                    Craft::getLogger()->log('For accurate Commerce statistics it is recommend to make sure you have the timezones table populated. https://craftcms.com/knowledge-base/populating-mysql-mariadb-timezone-tables', Craft::getLogger()::LEVEL_WARNING, 'commerce');
-                }
+            if (Db::supportsTimeZones()) {
+                $timezoneConversionSql = "CONVERT_TZ([[dateOrdered]], 'UTC', '" . Craft::$app->getTimeZone() . "')";
+            } else {
+                Craft::getLogger()->log('For accurate Commerce statistics it is recommend to make sure you have the timezones table populated. https://craftcms.com/knowledge-base/populating-mysql-mariadb-timezone-tables', Craft::getLogger()::LEVEL_WARNING, 'commerce');
             }
         } else {
             $timezoneConversionSql = "(([[dateOrdered]] AT TIME ZONE 'UTC') AT TIME ZONE '" . Craft::$app->getTimeZone() . "')";


### PR DESCRIPTION
Method was renamed in cms 3.7 beta 5.

Removed version check as we are increasing the CMS requirement.