### PR TITLE
fix(gql): resolve product type id

### DIFF
--- a/src/gql/types/elements/Product.php
+++ b/src/gql/types/elements/Product.php
@@ -43,6 +43,8 @@ class Product extends ElementType
         switch ($fieldName) {
             case 'productTypeHandle':
                 return $source->getType()->handle;
+            case 'productTypeId':
+                return $source->getType()->id;
         }
 
         return parent::resolve($source, $arguments, $context, $resolveInfo);


### PR DESCRIPTION
### Description
Fixes an issue where `productTypeId` doesn't resolve via GraphQL.

<img width="598" alt="Screen Shot 2021-07-07 at 9 38 07 PM" src="https://user-images.githubusercontent.com/5515179/124740671-1e70b980-df6f-11eb-8d5c-2d6b08ab25f1.png">

I updated the `productResolverTest` but am not 100% how to get them running so have left it out for now.