### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @craftcms/commerce

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @craftcms/commerce
+CHANGELOG.md @brandonkelly


### PR DESCRIPTION
### Description

Adds a GitHub [code owners file](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners) that determines who will automatically get selected to review pull requests.

Since GitHub already has a @craftcms/commerce team, that seemed to make sense here—but you can further specify different patterns/areas to one or more people like I [suggested for craftcms/cms](https://github.com/craftcms/cms/pull/9628).