### PR TITLE
Two-space Twig docblock indent

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -927,12 +927,12 @@ class Order extends Element
      * ---
      * ```php
      * if ($order->shippingAddress) {
-     * echo $order->shippingAddress->firstName;
+     *     echo $order->shippingAddress->firstName;
      * }
      * ```
      * ```twig
      * {% if order.shippingAddress %}
-     * {{ order.shippingAddress.firstName }}
+     *   {{ order.shippingAddress.firstName }}
      * {% endif %}
      * ```
      */
@@ -945,12 +945,12 @@ class Order extends Element
      * ---
      * ```php
      * if ($order->billingAddress) {
-     * echo $order->billingAddress->firstName;
+     *     echo $order->billingAddress->firstName;
      * }
      * ```
      * ```twig
      * {% if order.billingAddress %}
-     * {{ order.billingAddress.firstName }}
+     *   {{ order.billingAddress.firstName }}
      * {% endif %}
      * ```
      */
@@ -975,12 +975,12 @@ class Order extends Element
      * ---
      * ```php
      * foreach ($order->getLineItems() as $lineItem) {
-     * echo $lineItem->description';
+     *     echo $lineItem->description';
      * }
      * ```
      * ```twig
      * {% for lineItem in order.lineItems %}
-     * {{ lineItem.description }}
+     *   {{ lineItem.description }}
      * {% endfor %}
      * ```
      */
@@ -993,12 +993,12 @@ class Order extends Element
      * ---
      * ```php
      * foreach ($order->getAdjustments() as $adjustment) {
-     * echo $adjustment->amount';
+     *     echo $adjustment->amount';
      * }
      * ```
      * ```twig
      * {% for adjustment in order.adjustments %}
-     * {{ adjustment.amount }}
+     *   {{ adjustment.amount }}
      * {% endfor %}
      * ```
      */

--- a/src/elements/db/DonationQuery.php
+++ b/src/elements/db/DonationQuery.php
@@ -24,12 +24,12 @@ use yii\db\Connection;
 class DonationQuery extends ElementQuery
 {
     /**
-     * @var string The sku of the donation purchasable
+     * @var string The SKU of the donation purchasable.
      */
     public $sku;
 
     /**
-     * Narrows the query results based on the sku.
+     * Narrows the query results based on the SKU.
      *
      * Possible values include:
      *
@@ -43,8 +43,8 @@ class DonationQuery extends ElementQuery
      * {# Fetch the requested {element} #}
      * {% set sku = craft.app.request.getQueryParam('sku') %}
      * {% set {element-var} = {twig-method}
-     *     .sku(sku)
-     *     .one() %}
+     *   .sku(sku)
+     *   .one() %}
      * ```
      *
      * ```php

--- a/src/elements/db/OrderQuery.php
+++ b/src/elements/db/OrderQuery.php
@@ -205,8 +205,8 @@ class OrderQuery extends ElementQuery
      * {# Fetch the requested {element} #}
      * {% set orderNumber = craft.app.request.getQueryParam('number') %}
      * {% set {element-var} = {twig-method}
-     *     .number(orderNumber)
-     *     .one() %}
+     *   .number(orderNumber)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -241,8 +241,8 @@ class OrderQuery extends ElementQuery
      * {# Fetch the requested {element} #}
      * {% set orderNumber = craft.app.request.getQueryParam('shortNumber') %}
      * {% set {element-var} = {twig-method}
-     *     .shortNumber(orderNumber)
-     *     .one() %}
+     *   .shortNumber(orderNumber)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -278,8 +278,8 @@ class OrderQuery extends ElementQuery
      * {# Fetch the requested {element} #}
      * {% set orderReference = craft.app.request.getQueryParam('ref') %}
      * {% set {element-var} = {twig-method}
-     *     .reference(orderReference)
-     *     .one() %}
+     *   .reference(orderReference)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -315,8 +315,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch orders from customers with a .co.uk domain on their email address #}
      * {% set {elements-var} = {twig-method}
-     *     .email('*.co.uk')
-     *     .all() %}
+     *   .email('*.co.uk')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -343,8 +343,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch completed orders #}
      * {% set {elements-var} = {twig-function}
-     *     .isCompleted()
-     *     .all() %}
+     *   .isCompleted()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -381,8 +381,8 @@ class OrderQuery extends ElementQuery
      * {% set aWeekAgo = date('7 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateOrdered(">= #{aWeekAgo}")
-     *     .all() %}
+     *   .dateOrdered(">= #{aWeekAgo}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -421,8 +421,8 @@ class OrderQuery extends ElementQuery
      * {% set aWeekAgo = date('7 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .datePaid(">= #{aWeekAgo}")
-     *     .all() %}
+     *   .datePaid(">= #{aWeekAgo}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -461,8 +461,8 @@ class OrderQuery extends ElementQuery
      * {% set aWeekAgo = date('7 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateAuthorized(">= #{aWeekAgo}")
-     *     .all() %}
+     *   .dateAuthorized(">= #{aWeekAgo}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -501,8 +501,8 @@ class OrderQuery extends ElementQuery
      * {% set nextMonth = date('first day of next month')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .expiryDate("< #{nextMonth}")
-     *     .all() %}
+     *   .expiryDate("< #{nextMonth}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -541,8 +541,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch shipped {elements} #}
      * {% set {elements-var} = {twig-method}
-     *     .orderStatus('shipped')
-     *     .all() %}
+     *   .orderStatus('shipped')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -589,8 +589,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} with an order status with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .orderStatusId(1)
-     *     .all() %}
+     *   .orderStatusId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -626,8 +626,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} with an order status with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .orderLanguage('en')
-     *     .all() %}
+     *   .orderLanguage('en')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -663,8 +663,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} with an order site ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .orderSiteId(1)
-     *     .all() %}
+     *   .orderSiteId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -700,8 +700,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch shipped {elements} #}
      * {% set {elements-var} = {twig-method}
-     *     .origin('web')
-     *     .all() %}
+     *   .origin('web')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -735,8 +735,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch the current user's orders #}
      * {% set {elements-var} = {twig-method}
-     *     .customer(currentUser.customerFieldHandle)
-     *     .all() %}
+     *   .customer(currentUser.customerFieldHandle)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -778,8 +778,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch the current user's orders #}
      * {% set {elements-var} = {twig-method}
-     *     .customerId(currentUser.customerFieldHandle.id)
-     *     .all() %}
+     *   .customerId(currentUser.customerFieldHandle.id)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -859,8 +859,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch the current user's orders #}
      * {% set {elements-var} = {twig-method}
-     *     .user(currentUser)
-     *     .all() %}
+     *   .user(currentUser)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -897,8 +897,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch paid orders #}
      * {% set {elements-var} = {twig-function}
-     *     .isPaid()
-     *     .all() %}
+     *   .isPaid()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -925,8 +925,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch unpaid orders #}
      * {% set {elements-var} = {twig-function}
-     *     .isUnpaid()
-     *     .all() %}
+     *   .isUnpaid()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -953,8 +953,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch orders that do or do not have line items #}
      * {% set {elements-var} = {twig-function}
-     *     .hasLineItems()
-     *     .all() %}
+     *   .hasLineItems()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -981,8 +981,8 @@ class OrderQuery extends ElementQuery
      * ```twig
      * {# Fetch carts that have attempted payments #}
      * {% set {elements-var} = {twig-function}
-     *     .hasTransactions()
-     *     .all() %}
+     *   .hasTransactions()
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/ProductQuery.php
+++ b/src/elements/db/ProductQuery.php
@@ -173,8 +173,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} of the product type with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .defaultPrice(1)
-     *     .all() %}
+     *   .defaultPrice(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -211,8 +211,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} of the product default dimention of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .defaultHeight(1)
-     *     .all() %}
+     *   .defaultHeight(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -249,8 +249,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} of the product default dimention of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .defaulLength(1)
-     *     .all() %}
+     *   .defaulLength(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -287,8 +287,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} of the product default dimention of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .defaultWidth(1)
-     *     .all() %}
+     *   .defaultWidth(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -325,8 +325,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} of the product default dimention of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .defaultWeight(1)
-     *     .all() %}
+     *   .defaultWeight(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -363,8 +363,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} of the product defaukt SKU of `xxx-001` #}
      * {% set {elements-var} = {twig-method}
-     *     .defaultSku('xxx-001')
-     *     .all() %}
+     *   .defaultSku('xxx-001')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -402,8 +402,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} with a Foo product type #}
      * {% set {elements-var} = {twig-method}
-     *     .type('foo')
-     *     .all() %}
+     *   .type('foo')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -450,8 +450,8 @@ class ProductQuery extends ElementQuery
      * {% set firstDayOfMonth = date('first day of this month') %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .before(firstDayOfMonth)
-     *     .all() %}
+     *   .before(firstDayOfMonth)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -495,8 +495,8 @@ class ProductQuery extends ElementQuery
      * {% set firstDayOfMonth = date('first day of this month') %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .after(firstDayOfMonth)
-     *     .all() %}
+     *   .after(firstDayOfMonth)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -552,8 +552,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch {elements} of the product type with an ID of 1 #}
      * {% set {elements-var} = {twig-method}
-     *     .typeId(1)
-     *     .all() %}
+     *   .typeId(1)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -609,8 +609,8 @@ class ProductQuery extends ElementQuery
      * {% set end = date('first day of this month')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .postDate(['and', ">= #{start}", "< #{end}"])
-     *     .all() %}
+     *   .postDate(['and', ">= #{start}", "< #{end}"])
+     *   .all() %}
      * ```
      *
      * ```php
@@ -650,8 +650,8 @@ class ProductQuery extends ElementQuery
      * {% set nextMonth = date('first day of next month')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .expiryDate("< #{nextMonth}")
-     *     .all() %}
+     *   .expiryDate("< #{nextMonth}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -680,8 +680,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch products that are available for purchase #}
      * {% set {elements-var} = {twig-function}
-     *     .availableForPurchase()
-     *     .all() %}
+     *   .availableForPurchase()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -718,8 +718,8 @@ class ProductQuery extends ElementQuery
      * ```twig
      * {# Fetch disabled {elements} #}
      * {% set {elements-var} = {twig-function}
-     *     .status('disabled')
-     *     .all() %}
+     *   .status('disabled')
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/SubscriptionQuery.php
+++ b/src/elements/db/SubscriptionQuery.php
@@ -166,8 +166,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch the current user's subscriptions #}
      * {% set {elements-var} = {twig-method}
-     *     .user(currentUser)
-     *     .all() %}
+     *   .user(currentUser)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -214,8 +214,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch Supporter plan subscriptions #}
      * {% set {elements-var} = {twig-method}
-     *     .plan('supporter')
-     *     .all() %}
+     *   .plan('supporter')
+     *   .all() %}
      * ```
      *
      * ```php
@@ -261,8 +261,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch the current user's subscriptions #}
      * {% set {elements-var} = {twig-method}
-     *     .userId(currentUser.id)
-     *     .all() %}
+     *   .userId(currentUser.id)
+     *   .all() %}
      * ```
      *
      * ```php
@@ -376,8 +376,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch trialed subscriptions #}
      * {% set {elements-var} = {twig-function}
-     *     .onTrial()
-     *     .all() %}
+     *   .onTrial()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -414,8 +414,8 @@ class SubscriptionQuery extends ElementQuery
      * {% set aWeekFromNow = date('+7 days')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .nextPaymentDate("< #{aWeekFromNow}")
-     *     .all() %}
+     *   .nextPaymentDate("< #{aWeekFromNow}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -444,8 +444,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch canceled subscriptions #}
      * {% set {elements-var} = {twig-function}
-     *     .isCanceled()
-     *     .all() %}
+     *   .isCanceled()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -482,8 +482,8 @@ class SubscriptionQuery extends ElementQuery
      * {% set aWeekAgo = date('7 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateCanceled(">= #{aWeekAgo}")
-     *     .all() %}
+     *   .dateCanceled(">= #{aWeekAgo}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -512,8 +512,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch started subscriptions #}
      * {% set {elements-var} = {twig-function}
-     *     .hasStarted()
-     *     .all() %}
+     *   .hasStarted()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -540,8 +540,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch suspended subscriptions #}
      * {% set {elements-var} = {twig-function}
-     *     .isSuspended()
-     *     .all() %}
+     *   .isSuspended()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -577,8 +577,8 @@ class SubscriptionQuery extends ElementQuery
      * {% set aWeekAgo = date('7 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateSuspended(">= #{aWeekAgo}")
-     *     .all() %}
+     *   .dateSuspended(">= #{aWeekAgo}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -607,8 +607,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch expired subscriptions #}
      * {% set {elements-var} = {twig-function}
-     *     .isExpired()
-     *     .all() %}
+     *   .isExpired()
+     *   .all() %}
      * ```
      *
      * ```php
@@ -646,8 +646,8 @@ class SubscriptionQuery extends ElementQuery
      * {% set aWeekAgo = date('7 days ago')|atom %}
      *
      * {% set {elements-var} = {twig-method}
-     *     .dateExpired(">= #{aWeekAgo}")
-     *     .all() %}
+     *   .dateExpired(">= #{aWeekAgo}")
+     *   .all() %}
      * ```
      *
      * ```php
@@ -684,8 +684,8 @@ class SubscriptionQuery extends ElementQuery
      * ```twig
      * {# Fetch expired {elements} #}
      * {% set {elements-var} = {twig-function}
-     *     .status('expired')
-     *     .all() %}
+     *   .status('expired')
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/elements/db/VariantQuery.php
+++ b/src/elements/db/VariantQuery.php
@@ -189,8 +189,8 @@ class VariantQuery extends ElementQuery
      *
      * {# Fetch the {element} with that slug #}
      * {% set {element-var} = {twig-method}
-     *     .sku(requestedSlug|literal)
-     *     .one() %}
+     *   .sku(requestedSlug|literal)
+     *   .one() %}
      * ```
      *
      * ```php
@@ -282,8 +282,8 @@ class VariantQuery extends ElementQuery
      * ```twig
      * {# Fetch default variants #}
      * {% set {elements-var} = {twig-function}
-     *     .isDefault()
-     *     .all() %}
+     *   .isDefault()
+     *   .all() %}
      * ```
      *
      * ```php

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -171,16 +171,16 @@ class Settings extends Model
      * <!DOCTYPE html>
      * <html>
      * <head>
-     *     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-     *     <title>Redirecting...</title>
+     *   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+     *   <title>Redirecting...</title>
      * </head>
      * <body onload="document.forms[0].submit();">
      * <form action="{{ actionUrl }}" method="post">
-     *     <p>Redirecting to payment page...</p>
-     *     <p>
-     *         {{ inputs|raw }}
-     *         <input type="submit" value="Continue">
-     *     </p>
+     *   <p>Redirecting to payment page...</p>
+     *   <p>
+     *     {{ inputs|raw }}
+     *     <input type="submit" value="Continue">
+     *   </p>
      * </form>
      * </body>
      * </html>


### PR DESCRIPTION
### Description

Updates docblock fenced Twig and HTML chunks to use two-space indents instead of four. Coincides with a similar effort [in the docs](https://github.com/craftcms/docs/commit/6d824aa27e8710df16cc88ba3d50c2563e876901) and [Craft CMS](https://github.com/craftcms/cms/pull/9866).