### PR TITLE
Fixing a Twig Syntax Error

### DIFF
--- a/example-templates/build/shop/plans/update-billing-details.twig
+++ b/example-templates/build/shop/plans/update-billing-details.twig
@@ -1,4 +1,3 @@
-<!-- Template: {{ _self }}.twig -->
 {% extends 'shop/_private/layouts' %}
 {% block main %}
     <!-- Template: {{ _self }}.twig -->

--- a/example-templates/src/shop/plans/update-billing-details.twig
+++ b/example-templates/src/shop/plans/update-billing-details.twig
@@ -1,4 +1,3 @@
-<!-- Template: {{ _self }}.twig -->
 {% extends '[[folderName]]/_private/layouts' %}
 {% block main %}
     <!-- Template: {{ _self }}.twig -->


### PR DESCRIPTION
```
A template that extends another one cannot include content outside Twig blocks. Did you forget to put the content inside a {% block %} tag?
```

error was raised, removing that line fixes that.

### Description



### Related issues

