### PR TITLE
Fix errors when saving inactive users

### DIFF
--- a/src/services/Customers.php
+++ b/src/services/Customers.php
@@ -977,9 +977,8 @@ class Customers extends Component
         // Update the email address in the DB for this customer
         if ($email) {
             $this->_updatePreviousOrderEmails($customer->id, $email);
+            $this->consolidateGuestOrdersByEmail($email);
         }
-
-        $this->consolidateGuestOrdersByEmail($email);
     }
 
     /**


### PR DESCRIPTION
Since `User::email` can now be null with un-credentialed users, this prevents errors on save:

```
Exception: Argument 1 passed to craft\commerce\services\Customers::consolidateGuestOrdersByEmail() must be of the type string, null given, called in /app/vendor/craftcms/commerce/src/services/Customers.php on line 982 (/app/vendor/craftcms/commerce/src/services/Customers.php:723)
```