### PR TITLE
Remove duplicate Product Type ID assignment

### DIFF
--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -467,7 +467,6 @@ class ProductsController extends BaseController
                 $variables['product']->taxCategoryId = key($taxCategories);
                 $shippingCategories = $variables['productType']->getShippingCategories();
                 $variables['product']->shippingCategoryId = key($shippingCategories);
-                $variables['product']->typeId = $variables['productType']->id;
                 $variables['product']->enabled = true;
                 $variables['product']->siteId = $site->id;
                 $variables['product']->promotable = true;


### PR DESCRIPTION
### Description
typeId is already assigned at Line 465 and was repeated at Line 470 even though the value didn't change.

### Related issues
None
