### PR TITLE
Call `getIsEditable()` / `getIsDeletable()` from controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,16 @@
 ## Unreleased
 
 ### Added
-- Added `craft\commerce\elements\Product::isDeletable()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
-- Added `craft\commerce\controllers\ProductsController::enforceEditProductPermissions()` and `enforceDeleteProductPermissions()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
+- Added `craft\commerce\controllers\ProductsController::enforceEditProductPermissions()`.
+- Added `craft\commerce\controllers\ProductsController::enforceDeleteProductPermissions()`.
 - Added `craft\commerce\controllers\ProductsPreviewController::enforceEditProductPermissions()`.
-- Added `craft\commerce\elements\Subscription::isEditable()`.
 - Added `craft\commerce\controllers\SubscriptionsController::enforceEditSubscriptionPermissions()`.
 
 ### Changed
 - Improved the performance of order saving.
 - Improved the performance of forumla condition evaluation with result caching.
+- Products now support `EVENT_DEFINE_IS_EDITABLE` and `EVENT_DEFINE_IS_DELETABLE`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
+- Subscriptions now support `EVENT_DEFINE_IS_EDITABLE`.
 
 ## Deprecated
 - Deprecated `craft\commerce\controllers\ProductsController::enforceProductPermissions()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,18 @@
 
 ## Unreleased
 
+### Added
+- Added `craft\commerce\elements\Product::isDeletable()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
+- Added `craft\commerce\controllers\ProductsController::enforceEditProductPermissions()` and `enforceDeleteProductPermissions()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
+
 ### Changed
 - Improved the performance of order saving.
 - Improved the performance of forumla condition evaluation with result caching.
+
+## Deprecated
+- Deprecated `craft\commerce\controllers\ProductsController::enforceProductPermissions()`.
+- Deprecated `craft\commerce\controllers\ProductsPreviewController::enforceEditProductPermissions()`.
+- Deprecated `craft\commerce\controllers\ProductsPreviewController::actionSaveProduct()`.
 
 ### Fixed
 - Fixed a bug where inactive carts query did not respect time zones. ([#2601](https://github.com/craftcms/commerce/issues/2601))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added `craft\commerce\elements\Product::isDeletable()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
 - Added `craft\commerce\controllers\ProductsController::enforceEditProductPermissions()` and `enforceDeleteProductPermissions()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
+- Added `craft\commerce\controllers\ProductsPreviewController::enforceEditProductPermissions()`.
 
 ### Changed
 - Improved the performance of order saving.
@@ -12,7 +13,7 @@
 
 ## Deprecated
 - Deprecated `craft\commerce\controllers\ProductsController::enforceProductPermissions()`.
-- Deprecated `craft\commerce\controllers\ProductsPreviewController::enforceEditProductPermissions()`.
+- Deprecated `craft\commerce\controllers\ProductsPreviewController::enforceProductPermissions()`.
 - Deprecated `craft\commerce\controllers\ProductsPreviewController::actionSaveProduct()`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added `craft\commerce\elements\Product::isDeletable()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
 - Added `craft\commerce\controllers\ProductsController::enforceEditProductPermissions()` and `enforceDeleteProductPermissions()`. ([#2606](https://github.com/craftcms/commerce/issues/2606))
 - Added `craft\commerce\controllers\ProductsPreviewController::enforceEditProductPermissions()`.
+- Added `craft\commerce\elements\Subscription::isEditable()`.
+- Added `craft\commerce\controllers\SubscriptionsController::enforceEditSubscriptionPermissions()`.
 
 ### Changed
 - Improved the performance of order saving.

--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -194,7 +194,7 @@ class ProductsController extends BaseController
                 ['id' => $productId]));
         }
 
-        $this->enforceProductPermissions($product);
+        $this->enforceDeleteProductPermissions($product);
 
         if (!Craft::$app->getElements()->deleteElement($product)) {
             if (Craft::$app->getRequest()->getAcceptsJson()) {
@@ -235,7 +235,7 @@ class ProductsController extends BaseController
         $request = Craft::$app->getRequest();
         $oldProduct = ProductHelper::productFromPost($request);
         $variants = $request->getBodyParam('variants') ?: [];
-        $this->enforceProductPermissions($oldProduct);
+        $this->enforceEditProductPermissions($oldProduct);
         $elementsService = Craft::$app->getElements();
 
         $transaction = Craft::$app->getDb()->beginTransaction();
@@ -367,10 +367,35 @@ class ProductsController extends BaseController
      * @throws HttpException
      * @throws ForbiddenHttpException
      */
-    protected function enforceProductPermissions(Product $product)
+    protected function enforceEditProductPermissions(Product $product)
     {
         if (!$product->getIsEditable()) {
             throw new ForbiddenHttpException('User is not permitted to edit this product');
+        }
+    }
+
+    /**
+     * @param Product $product
+     * @throws HttpException
+     * @throws ForbiddenHttpException
+     */
+    protected function enforceDeleteProductPermissions(Product $product)
+    {
+        if (!$product->getIsDeletable()) {
+            throw new ForbiddenHttpException('User is not permitted to delete this product');
+        }
+    }
+
+    /**
+     * @param Product $product
+     * @throws HttpException
+     * @throws ForbiddenHttpException
+     * @deprecated in 3.4.0. Use [[enforceEditProductPermissions()]] and [[enforceDeleteProductPermissions()]] instead.
+     */
+    protected function enforceProductPermissions(Product $product)
+    {
+        if (!$product->getIsEditable() || !$product->getIsDeletable()) {
+            throw new ForbiddenHttpException('User is not permitted to modify this product');
         }
     }
 
@@ -478,7 +503,7 @@ class ProductsController extends BaseController
         }
 
         if ($variables['product']->id) {
-            $this->enforceProductPermissions($variables['product']);
+            $this->enforceEditProductPermissions($variables['product']);
             $variables['enabledSiteIds'] = Craft::$app->getElements()->getEnabledSiteIdsForElement($variables['product']->id);
         } else {
             $variables['enabledSiteIds'] = [];

--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -365,11 +365,13 @@ class ProductsController extends BaseController
     /**
      * @param Product $product
      * @throws HttpException
-     * @throws InvalidConfigException
+     * @throws ForbiddenHttpException
      */
     protected function enforceProductPermissions(Product $product)
     {
-        $this->requirePermission('commerce-manageProductType:' . $product->getType()->uid);
+        if (!$product->getIsEditable()) {
+            throw new ForbiddenHttpException('User is not permitted to edit this product');
+        }
     }
 
 

--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -399,7 +399,6 @@ class ProductsController extends BaseController
         }
     }
 
-
     /**
      * @param array $variables
      * @throws InvalidConfigException

--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -364,10 +364,10 @@ class ProductsController extends BaseController
 
     /**
      * @param Product $product
-     * @throws HttpException
      * @throws ForbiddenHttpException
+     * @since 3.4.8
      */
-    protected function enforceEditProductPermissions(Product $product)
+    protected function enforceEditProductPermissions(Product $product): void
     {
         if (!$product->getIsEditable()){
             throw new ForbiddenHttpException('User is not permitted to edit this product');
@@ -376,10 +376,10 @@ class ProductsController extends BaseController
 
     /**
      * @param Product $product
-     * @throws HttpException
      * @throws ForbiddenHttpException
+     * @since 3.4.8
      */
-    protected function enforceDeleteProductPermissions(Product $product)
+    protected function enforceDeleteProductPermissions(Product $product): void
     {
         if (!$product->getIsDeletable()) {
             throw new ForbiddenHttpException('User is not permitted to delete this product');
@@ -388,15 +388,13 @@ class ProductsController extends BaseController
 
     /**
      * @param Product $product
-     * @throws HttpException
      * @throws ForbiddenHttpException
-     * @deprecated in 3.4.8. Use [[enforceEditProductPermissions()]] and [[enforceDeleteProductPermissions()]] instead.
+     * @deprecated in 3.4.8. Use [[enforceEditProductPermissions()]] or [[enforceDeleteProductPermissions()]] instead.
      */
     protected function enforceProductPermissions(Product $product)
     {
-        if (!$product->getIsEditable() || !$product->getIsDeletable()) {
-            throw new ForbiddenHttpException('User is not permitted to modify this product');
-        }
+        $this->enforceEditProductPermissions($product);
+        $this->enforceDeleteProductPermissions($product);
     }
 
     /**

--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -369,7 +369,7 @@ class ProductsController extends BaseController
      */
     protected function enforceEditProductPermissions(Product $product)
     {
-        if (!$product->getIsEditable()) {
+        if (!$product->getIsEditable()){
             throw new ForbiddenHttpException('User is not permitted to edit this product');
         }
     }

--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -390,7 +390,7 @@ class ProductsController extends BaseController
      * @param Product $product
      * @throws HttpException
      * @throws ForbiddenHttpException
-     * @deprecated in 3.4.0. Use [[enforceEditProductPermissions()]] and [[enforceDeleteProductPermissions()]] instead.
+     * @deprecated in 3.4.8. Use [[enforceEditProductPermissions()]] and [[enforceDeleteProductPermissions()]] instead.
      */
     protected function enforceProductPermissions(Product $product)
     {

--- a/src/controllers/ProductsPreviewController.php
+++ b/src/controllers/ProductsPreviewController.php
@@ -20,6 +20,7 @@ use Throwable;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 use yii\web\BadRequestHttpException;
+use yii\web\ForbiddenHttpException;
 use yii\web\HttpException;
 use yii\web\Response;
 use yii\web\ServerErrorHttpException;
@@ -175,11 +176,13 @@ class ProductsPreviewController extends Controller
 
     /**
      * @param Product $product
-     * @throws HttpException
+     * @throws ForbiddenHttpException
      */
     protected function enforceProductPermissions(Product $product)
     {
-        $this->requirePermission('commerce-manageProductType:' . $product->getType()->uid);
+        if (!$product->getIsEditable()) {
+            throw new ForbiddenHttpException('User is not permitted to edit this product');
+        }
     }
 
     /**

--- a/src/controllers/ProductsPreviewController.php
+++ b/src/controllers/ProductsPreviewController.php
@@ -177,8 +177,9 @@ class ProductsPreviewController extends Controller
     /**
      * @param Product $product
      * @throws ForbiddenHttpException
+     * @since 3.4.8
      */
-    protected function enforceEditProductPermissions(Product $product)
+    protected function enforceEditProductPermissions(Product $product): void
     {
         if (!$product->getIsEditable()) {
             throw new ForbiddenHttpException('User is not permitted to edit this product');
@@ -192,9 +193,7 @@ class ProductsPreviewController extends Controller
      */
     protected function enforceProductPermissions(Product $product)
     {
-        if (!$product->getIsEditable()) {
-            throw new ForbiddenHttpException('User is not permitted to edit this product');
-        }
+        $this->enforceEditProductPermissions($product);
     }
 
     /**

--- a/src/controllers/ProductsPreviewController.php
+++ b/src/controllers/ProductsPreviewController.php
@@ -38,7 +38,6 @@ class ProductsPreviewController extends Controller
      */
     protected $allowAnonymous = true;
 
-
     /**
      * Previews a product.
      *
@@ -50,7 +49,7 @@ class ProductsPreviewController extends Controller
 
         $product = ProductHelper::populateProductFromPost();
 
-        $this->enforceProductPermissions($product);
+        $this->enforceEditProductPermissions($product);
 
         return $this->_showProduct($product);
     }
@@ -73,7 +72,7 @@ class ProductsPreviewController extends Controller
             throw new HttpException(404);
         }
 
-        $this->enforceProductPermissions($product);
+        $this->enforceEditProductPermissions($product);
 
         // Make sure the product actually can be viewed
         if (!Plugin::getInstance()->getProductTypes()->isProductTypeTemplateValid($product->getType(), $product->siteId)) {
@@ -91,7 +90,7 @@ class ProductsPreviewController extends Controller
     }
 
     /**
-     * Shows an product/draft/version based on a token.
+     * Shows a product/draft/version based on a token.
      *
      * @param mixed $productId
      * @param mixed $site
@@ -123,6 +122,8 @@ class ProductsPreviewController extends Controller
      * @throws ElementNotFoundException
      * @throws MissingComponentException
      * @throws BadRequestHttpException
+     * @deprecated in 3.4.8. Use [[\craft\commerce\controllers\ProductsController::actionSaveProduct()]] instead.
+     * @todo Remove in 4.0
      */
     public function actionSaveProduct()
     {
@@ -132,7 +133,7 @@ class ProductsPreviewController extends Controller
 
         $product = ProductHelper::populateProductFromPost();
 
-        $this->enforceProductPermissions($product);
+        $this->enforceEditProductPermissions($product);
 
         // Save the entry (finally!)
         if ($product->enabled && $product->enabledForSite) {
@@ -173,10 +174,21 @@ class ProductsPreviewController extends Controller
         return $this->redirectToPostedUrl($product);
     }
 
+    /**
+     * @param Product $product
+     * @throws ForbiddenHttpException
+     */
+    protected function enforceEditProductPermissions(Product $product)
+    {
+        if (!$product->getIsEditable()) {
+            throw new ForbiddenHttpException('User is not permitted to edit this product');
+        }
+    }
 
     /**
      * @param Product $product
      * @throws ForbiddenHttpException
+     * @deprecated in 3.4.8. Use [[enforceEditProductPermissions()]] instead.
      */
     protected function enforceProductPermissions(Product $product)
     {

--- a/src/controllers/SubscriptionsController.php
+++ b/src/controllers/SubscriptionsController.php
@@ -43,6 +43,19 @@ class SubscriptionsController extends BaseController
         return $this->renderTemplate('commerce/subscriptions/_index');
     }
 
+
+    /**
+     * @param Subscription $subscription
+     * @throws HttpException
+     * @throws ForbiddenHttpException
+     */
+    protected function enforceEditSubscriptionPermissions(Subscription $subscription)
+    {
+        if (!$subscription->getIsEditable()){
+            throw new ForbiddenHttpException('User is not permitted to edit this subscription');
+        }
+    }
+
     /**
      * @param int|null $subscriptionId
      * @param Subscription|null $subscription

--- a/src/controllers/SubscriptionsController.php
+++ b/src/controllers/SubscriptionsController.php
@@ -46,10 +46,10 @@ class SubscriptionsController extends BaseController
 
     /**
      * @param Subscription $subscription
-     * @throws HttpException
      * @throws ForbiddenHttpException
+     * @since 3.4.8
      */
-    protected function enforceEditSubscriptionPermissions(Subscription $subscription)
+    protected function enforceEditSubscriptionPermissions(Subscription $subscription): void
     {
         if (!$subscription->getIsEditable()){
             throw new ForbiddenHttpException('User is not permitted to edit this subscription');

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -301,9 +301,19 @@ class Product extends Element
     protected function isEditable(): bool
     {
         if ($this->getType()) {
-            $uid = $this->getType()->uid;
+            return Craft::$app->getUser()->checkPermission('commerce-manageProductType:' . $this->getType()->uid);
+        }
 
-            return Craft::$app->getUser()->checkPermission('commerce-manageProductType:' . $uid);
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function isDeletable(): bool
+    {
+        if ($this->getType()) {
+            return Craft::$app->getUser()->checkPermission('commerce-manageProductType:' . $this->getType()->uid); // TODO: Change this to a real delete permission in 4.0
         }
 
         return false;

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -300,11 +300,7 @@ class Product extends Element
      */
     protected function isEditable(): bool
     {
-        if ($this->getType()) {
-            return Craft::$app->getUser()->checkPermission('commerce-manageProductType:' . $this->getType()->uid);
-        }
-
-        return false;
+        return Craft::$app->getUser()->checkPermission('commerce-manageProductType:' . $this->getType()->uid);
     }
 
     /**
@@ -312,11 +308,8 @@ class Product extends Element
      */
     protected function isDeletable(): bool
     {
-        if ($this->getType()) {
-            return Craft::$app->getUser()->checkPermission('commerce-manageProductType:' . $this->getType()->uid); // TODO: Change this to a real delete permission in 4.0
-        }
-
-        return false;
+        // TODO: Change this to a real delete permission in 4.0
+        return Craft::$app->getUser()->checkPermission('commerce-manageProductType:' . $this->getType()->uid);
     }
 
     /**

--- a/src/elements/Subscription.php
+++ b/src/elements/Subscription.php
@@ -209,14 +209,14 @@ class Subscription extends Element
     {
         $user = Craft::$app->getUser()->getIdentity();
 
-        if(!$user) {
+        if (!$user) {
             return false;
         }
 
-        $userOwnsSubscription = $this->userId && ($this->userId == $user->id);
-        $allowed = Craft::$app->getUser()->checkPermission('commerce-manageSubscriptions');
-
-        return $userOwnsSubscription || $allowed;
+        return (
+            ($this->userId && $this->userId == $user->id) ||
+            $user->can('commerce-manageSubscriptions')
+        );
     }
 
     /**

--- a/src/elements/Subscription.php
+++ b/src/elements/Subscription.php
@@ -203,6 +203,23 @@ class Subscription extends Element
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function isEditable(): bool
+    {
+        $user = Craft::$app->getUser()->getIdentity();
+
+        if(!$user) {
+            return false;
+        }
+
+        $userOwnsSubscription = $this->userId && ($this->userId == $user->id);
+        $allowed = Craft::$app->getUser()->checkPermission('commerce-manageSubscriptions');
+
+        return $userOwnsSubscription || $allowed;
+    }
+
+    /**
      * Returns whether this subscription can be reactivated.
      *
      * @return bool


### PR DESCRIPTION
Controllers should be calling elements’ `getIsEditable()` and `getIsDeletable()` methods rather than doing their own permission checks directly.

## Products
- [x] Ensure `Product::isEditable()` is implemented
- [x] Ensure `Product::isDeletable()` is implemented
- [x] Call `Product::getIsEditable()` from controllers
- [x] Call `Product::getIsDeletable()` from controllers

## Subscriptions
- [x] Ensure `Subscription::isEditable()` is implemented
- [x] Call `Subscription::getIsEditable()` from controllers