### PR TITLE
Fix decimal for taxrate translations

### DIFF
--- a/src/translations/de/commerce.php
+++ b/src/translations/de/commerce.php
@@ -448,7 +448,7 @@ return [
     'End Date' => 'Enddatum',
     'Enter SKU' => 'Bestandseinheit (SKU) eingeben',
     'Enter a human-friendly name for this tax rate to be used in the control panel.' => 'Geben Sie einen verständlichen Namen für diesen Steuersatz ein, der im Control Panel verwendet werden soll.',
-    'Enter a percentage like `5%` or `10.5%`.' => 'Geben Sie einen Prozentsatz ein, z. B. 5 % oder 10,5 %.',
+    'Enter a percentage like `5%` or `10.5%`.' => 'Geben Sie einen Prozentsatz ein, z. B. 5 % oder 10.5 %.',
     'Enter coupon code' => 'Gutscheincode eingeben',
     'Enter price' => 'Preis angeben',
     'Enter reference' => 'Referenz eingeben',

--- a/src/translations/fr-CA/commerce.php
+++ b/src/translations/fr-CA/commerce.php
@@ -448,7 +448,7 @@ return [
     'End Date' => 'Date de fin',
     'Enter SKU' => 'Entrer SKU',
     'Enter a human-friendly name for this tax rate to be used in the control panel.' => 'Saisir un nom convivial pour ce taux d\'imposition, qui sera utilisé dans le panneau de configuration.',
-    'Enter a percentage like `5%` or `10.5%`.' => 'Entrer un pourcentage comme « 5 % » ou « 10,5 % ».',
+    'Enter a percentage like `5%` or `10.5%`.' => 'Entrer un pourcentage comme « 5 % » ou « 10.5 % ».',
     'Enter coupon code' => 'Entrer le code du coupon',
     'Enter price' => 'Entrer le prix',
     'Enter reference' => 'Entrer la référence',

--- a/src/translations/fr/commerce.php
+++ b/src/translations/fr/commerce.php
@@ -448,7 +448,7 @@ return [
     'End Date' => 'Date de fin',
     'Enter SKU' => 'Entrer le code article interne',
     'Enter a human-friendly name for this tax rate to be used in the control panel.' => 'Saisir un nom convivial pour ce taux d\'imposition, qui sera utilisé dans le panneau de configuration.',
-    'Enter a percentage like `5%` or `10.5%`.' => 'Entrer un pourcentage comme « 5 % » ou « 10,5 % ».',
+    'Enter a percentage like `5%` or `10.5%`.' => 'Entrer un pourcentage comme « 5 % » ou « 10.5 % ».',
     'Enter coupon code' => 'Entrer le code du coupon',
     'Enter price' => 'Entrer le prix',
     'Enter reference' => 'Entrer la référence',

--- a/src/translations/it/commerce.php
+++ b/src/translations/it/commerce.php
@@ -448,7 +448,7 @@ return [
     'End Date' => 'Data di fine',
     'Enter SKU' => 'Inserisci SKU',
     'Enter a human-friendly name for this tax rate to be used in the control panel.' => 'Inserisci un nome facilmente comprensibile per questa aliquota fiscale da usare nel pannello di controllo.',
-    'Enter a percentage like `5%` or `10.5%`.' => 'Inserisci una percentuale come `5%` o `10,5%`.',
+    'Enter a percentage like `5%` or `10.5%`.' => 'Inserisci una percentuale come `5%` o `10.5%`.',
     'Enter coupon code' => 'Inserisci il codice promozionale',
     'Enter price' => 'Inserisci prezzo',
     'Enter reference' => 'Inserisci riferimento',

--- a/src/translations/nb/commerce.php
+++ b/src/translations/nb/commerce.php
@@ -448,7 +448,7 @@ return [
     'End Date' => 'Sluttdato',
     'Enter SKU' => 'Angi SKU',
     'Enter a human-friendly name for this tax rate to be used in the control panel.' => 'Skriv et menneskevennlig navn for denne skattesatsen som skal brukes i kontrollpanelet.',
-    'Enter a percentage like `5%` or `10.5%`.' => 'Skriv inn en prosent, som 5 % eller 10,5 %.',
+    'Enter a percentage like `5%` or `10.5%`.' => 'Skriv inn en prosent, som 5 % eller 10.5 %.',
     'Enter coupon code' => 'Skriv inn kupongkode',
     'Enter price' => 'Angi pris',
     'Enter reference' => 'Skriv inn referanse',

--- a/src/translations/nl/commerce.php
+++ b/src/translations/nl/commerce.php
@@ -448,7 +448,7 @@ return [
     'End Date' => 'Einddatum',
     'Enter SKU' => 'Voer Artikelnummer in',
     'Enter a human-friendly name for this tax rate to be used in the control panel.' => 'Voeg een mensvriendelijke naam in voor dit belastingtarief voor gebruik in het configuratiescherm.',
-    'Enter a percentage like `5%` or `10.5%`.' => 'Voer een percentage in, bijvoorbeeld \'5%\' of \'10,5%\'.',
+    'Enter a percentage like `5%` or `10.5%`.' => 'Voer een percentage in, bijvoorbeeld \'5%\' of \'10.5%\'.',
     'Enter coupon code' => 'Couponcode invoeren',
     'Enter price' => 'Voer prijs in',
     'Enter reference' => 'Referentie invoeren',

--- a/src/translations/sk/commerce.php
+++ b/src/translations/sk/commerce.php
@@ -448,7 +448,7 @@ return [
     'End Date' => 'Dátum ukončenia',
     'Enter SKU' => 'Zadať SKU',
     'Enter a human-friendly name for this tax rate to be used in the control panel.' => 'Zadajte názov tejto daňovej sadzby, ktorý sa bude používať v ovládacom paneli.',
-    'Enter a percentage like `5%` or `10.5%`.' => 'Zadajte percentuálnu hodnotu, ako napr. „5 %“ alebo „10 %“.',
+    'Enter a percentage like `5%` or `10.5%`.' => 'Zadajte percentuálnu hodnotu, ako napr. „5 %“ alebo „10.5 %“.',
     'Enter coupon code' => 'Zadajte kód kupónu',
     'Enter price' => 'Zadať cenu',
     'Enter reference' => 'Zadajte referenciu',


### PR DESCRIPTION
### Description
Tax rates should have a point instead of a comma as decimal. The translations are inconsistent, which leads to confusion with clients as their rates are rounded off.