### PR TITLE
parent::behaviors() to `\craft\commerce\models\ProductType::behaviors()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Added support for PHP 8.1.
+- Added parent::behaviors() to `\craft\commerce\models\ProductType::behaviors()` to be able to add additional behaviors. ([#2715](https://github.com/craftcms/commerce/issues/2715))
 
 ### Fixed
 - Fixed a bug where collapsed variant blocks weren’t showing the correct preview text on the Edit Product page.

--- a/src/models/ProductType.php
+++ b/src/models/ProductType.php
@@ -404,17 +404,19 @@ class ProductType extends Model
      */
     public function behaviors(): array
     {
-        return [
-            'productFieldLayout' => [
+        $behaviors = parent::behaviors();
+        $behaviors['productFieldLayout'] = [
                 'class' => FieldLayoutBehavior::class,
                 'elementType' => Product::class,
                 'idAttribute' => 'fieldLayoutId',
-            ],
-            'variantFieldLayout' => [
+            ];
+
+        $behaviors['variantFieldLayout'] = [
                 'class' => FieldLayoutBehavior::class,
                 'elementType' => Variant::class,
                 'idAttribute' => 'variantFieldLayoutId',
-            ],
-        ];
+            ];
+
+        return $behaviors;
     }
 }


### PR DESCRIPTION
- Added parent::behaviors() to `\craft\commerce\models\ProductType::behaviors()` to be able to add additional behaviors.

### Description

Fixed (#2715)


### Related issues

