### PR TITLE
Add ability to set the primary billing and shipping address ID for customer

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -20,6 +20,7 @@ use craft\commerce\exports\OrderExport;
 use craft\commerce\fieldlayoutelements\ProductTitleField;
 use craft\commerce\fieldlayoutelements\VariantsField;
 use craft\commerce\fieldlayoutelements\VariantTitleField;
+use craft\commerce\fields\CustomerPreferences;
 use craft\commerce\fields\Products;
 use craft\commerce\fields\Variants;
 use craft\commerce\gql\interfaces\elements\Product as GqlProductInterface;
@@ -477,6 +478,7 @@ class Plugin extends BasePlugin
         Event::on(Fields::class, Fields::EVENT_REGISTER_FIELD_TYPES, function(RegisterComponentTypesEvent $event) {
             $event->types[] = Products::class;
             $event->types[] = Variants::class;
+            $event->types[] = CustomerPreferences::class;
         });
     }
 

--- a/src/fields/CustomerPreferences.php
+++ b/src/fields/CustomerPreferences.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\fields;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\base\Field;
+use craft\commerce\behaviors\CustomerBehavior;
+use craft\commerce\Plugin;
+use craft\elements\User;
+use craft\helpers\ArrayHelper;
+use craft\helpers\Cp;
+use craft\helpers\Html;
+use Illuminate\Support\Collection;
+
+/**
+ * Customer preferences field
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.0
+ *
+ * @property-read array $contentGqlType
+ */
+class CustomerPreferences extends Field
+{
+    public static function displayName(): string
+    {
+        return Craft::t('commerce', 'Commerce Customer Preference');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function hasContentColumn(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function afterElementSave(ElementInterface $element, bool $isNew): void
+    {
+        // TODO, get values and save them to customer
+        //        Plugin::getInstance()->getCustomers()->savePrimaryBillingAddressId($element. $addressId )
+        //        Plugin::getInstance()->getCustomers()->savePrimaryShippingAddressId($element. $addressId )
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function normalizeValue(mixed $value, ?ElementInterface $element = null): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * @inerhitdoc
+     */
+    protected function inputHtml(mixed $value, ?ElementInterface $element = null): string
+    {
+        $view = Craft::$app->getView();
+
+        $options = Collection::make($element->getAddresses())->mapWithKeys(function($item) {
+            return [$item->id => $item->title];
+        })->toArray();
+
+        $handle = $this->handle;
+        return $view->namespaceInputs(function() use ($view, $handle, $options) {
+        /** @var User|CustomerBehavior $element */
+        $primaryBillingAddressIdSelectField = Cp::selectFieldHtml([
+            'instructions' => Craft::t('commerce', 'Primary billing address'),
+            'name' => 'primaryBillingAddressId',
+            'options' => $options,
+            'value' => $element->primaryBillingAddressId ?? ArrayHelper::firstKey($options),
+        ]);
+
+        $primaryShippingAddressIdSelectField = Cp::selectFieldHtml([
+            'instructions' => Craft::t('commerce', 'Primary shipping address'),
+            'name' => 'primaryBillingAddressId',
+            'options' => $options,
+            'value' => $element->primaryShippingAddressId ?? ArrayHelper::firstKey($options),
+        ]);
+
+        return Html::beginTag('div', ['class' => '']) .
+            Html::beginTag('div', ['class' => '']) .
+            $primaryShippingAddressIdSelectField .
+            Html::endTag('div') .
+            Html::beginTag('div', ['class' => '']) .
+            $primaryBillingAddressIdSelectField .
+            Html::endTag('div') .
+            Html::endTag('div');
+        });
+    }
+}


### PR DESCRIPTION
- [ ] Save address element (when saving with an owner ID that is a User element) should have a `makePrimaryBillingAddress`  and `makePrimaryBillingAddress` params

- [ ] Saving a customer (User element) should use the `primaryBillingAddressId` and `primaryShippingAddressId` properties (that come from the CustomerBehaviour) to set them.

https://linear.app/craftcms/issue/COM-185/add-ability-to-set-the-primary-billing-and-shipping-address-id-for