### PR TITLE
Reduce Store Location heading top padding

### DIFF
--- a/src/templates/store-settings/store/index.twig
+++ b/src/templates/store-settings/store/index.twig
@@ -9,7 +9,7 @@
     {{ hiddenInput('id', store.id) }}
     {{ hiddenInput('locationAddressId', store.locationAddress.id) }}
 
-    <h2>{{ "Store Location"|t('commerce') }}</h2>
+    <h2 class="first">{{ "Store Location"|t('commerce') }}</h2>
     <p>{{ 'This is the address where your store is located. It may be used by various plugins to determine things like shipping and taxes. It could also be used in PDF receipts.'|t('commerce') }}</p>
 
     {{ locationField|raw }}


### PR DESCRIPTION
### Description

Reduces the amount of padding above the _Store Location_ heading in the control panel.

Before:
![before](https://user-images.githubusercontent.com/2488775/158256173-f1a67709-1116-469d-baad-d09e76451725.png)

After:
![after](https://user-images.githubusercontent.com/2488775/158256190-006ac5bf-18c8-4c72-a5a0-8ca7733286d0.png)

