### PR TITLE
Fixes inability to remove an address on the edit order page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Line items are returned in a consistent order when eager loaded. ([#2740](https://github.com/craftcms/commerce/issues/2740))
+- Fixed a bug where it wasn't possible to remove an address on the Edit Order page. ([#2745](https://github.com/craftcms/commerce/issues/2745))
 
 ## 3.4.13 - 2022-03-24
 

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -121,6 +121,10 @@ class OrdersController extends Controller
         $order->setCustomer($customer);
         $order->origin = Order::ORIGIN_CP;
 
+        if ($customer && Plugin::getInstance()->getSettings()->autoSetNewCartAddresses) {
+            $order->autoSetAddresses();
+        }
+
         if (!Craft::$app->getElements()->saveElement($order)) {
             throw new Exception(Craft::t('commerce', 'Can not create a new order'));
         }

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1078,22 +1078,6 @@ class Order extends Element
      */
     public function init()
     {
-        // Set default addresseses
-        if (!$this->isCompleted && Plugin::getInstance()->getSettings()->autoSetNewCartAddresses) {
-            if (!$this->shippingAddressId) {
-                $hasPrimaryShippingAddress = $this->getCustomer() && $this->getCustomer()->primaryShippingAddressId;
-                if ($hasPrimaryShippingAddress && ($shippingAddress = Plugin::getInstance()->getAddresses()->getAddressByIdAndCustomerId($this->getCustomer()->primaryShippingAddressId, $this->customerId))) {
-                    $this->setShippingAddress($shippingAddress);
-                }
-            }
-            if (!$this->billingAddressId) {
-                $hasPrimaryBillingAddress = $this->getCustomer() && $this->getCustomer()->primaryBillingAddressId;
-                if ($hasPrimaryBillingAddress && ($billingAddress = Plugin::getInstance()->getAddresses()->getAddressByIdAndCustomerId($this->getCustomer()->primaryBillingAddressId, $this->customerId))) {
-                    $this->setBillingAddress($billingAddress);
-                }
-            }
-        }
-
         if ($this->orderLanguage === null) {
             $this->orderLanguage = Craft::$app->language;
         }
@@ -1441,6 +1425,34 @@ class Order extends Element
             [['paymentSourceId'], 'validatePaymentSourceId'],
             [['email'], 'email'],
         ]);
+    }
+
+    /**
+     * Automatically set addresses on the order if it's a cart and `autoSetNewCartAddresses` is `true`.
+     *
+     * @return void
+     * @since 3.4.14
+     */
+    public function autoSetAddresses(): void
+    {
+        if ($this->isCompleted || !Plugin::getInstance()->getSettings()->autoSetNewCartAddresses) {
+            return;
+        }
+
+        // Set default addresses
+        if (!$this->getShippingAddress()) {
+            $hasPrimaryShippingAddress = $this->getCustomer() && $this->getCustomer()->primaryShippingAddressId;
+            if ($hasPrimaryShippingAddress && ($shippingAddress = Plugin::getInstance()->getAddresses()->getAddressByIdAndCustomerId($this->getCustomer()->primaryShippingAddressId, $this->customerId))) {
+                $this->setShippingAddress($shippingAddress);
+            }
+        }
+
+        if (!$this->getBillingAddress()) {
+            $hasPrimaryBillingAddress = $this->getCustomer() && $this->getCustomer()->primaryBillingAddressId;
+            if ($hasPrimaryBillingAddress && ($billingAddress = Plugin::getInstance()->getAddresses()->getAddressByIdAndCustomerId($this->getCustomer()->primaryBillingAddressId, $this->customerId))) {
+                $this->setBillingAddress($billingAddress);
+            }
+        }
     }
 
     /**

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -71,6 +71,7 @@ class Carts extends Component
         if (null === $this->_cart && !$this->_cart = $this->_getCart()) {
             $this->_cart = new Order(['customer' => $customer]);
             $this->_cart->number = $this->getSessionCartNumber();
+            $this->_cart->autoSetAddresses();
         }
 
         // Ensure the session knows what the current cart is.


### PR DESCRIPTION
### Description
There is a bug that exists on the edit order page if the project has the `autoSetNewCartAddresses` set to `true`. In some instances, addresses that are removed are still showing even though the data in the DB is correct.

### Related issues
#2745 