### PR TITLE
Cart variable name in payments controller should be consistent if it is an order or cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Beta Unreleased
 
+### Changed
+- Changed `cartVariableName` to`order` if completed otherwise config setting `cartVariableName`.
+
 ### Fixed 
 - Fixed a bug where custom shipping methods options were not being returned from `Order::getAvailableShippingMethodOptions()`.
 - Fixed a bug where the "New Order" button was not visible.

--- a/src/controllers/PaymentsController.php
+++ b/src/controllers/PaymentsController.php
@@ -98,10 +98,14 @@ class PaymentsController extends BaseFrontEndController
                 return null;
             }
 
-            // TODO Fix this in Commerce 4. `order` if completed, `cartVariableName` if no completed. #COM-36
-            $this->_cartVariableName = 'order'; // can not override the name of the order cart in json responses for orders
         } else {
             $order = $plugin->getCarts()->getCart();
+        }
+
+        $isCompleted = filter_var($order->isCompleted, FILTER_VALIDATE_BOOLEAN);
+
+        if ($isCompleted === true) {
+            $this->_cartVariableName = 'order'; // can not override the name of the order cart in json responses for orders
         }
 
         /**


### PR DESCRIPTION

### Description

Changed `cartVariableName` to `order` if completed otherwise config setting `cartVariableName`.
