### PR TITLE
Address example template checkout issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - It’s now possible to disable the default variant on the Edit Product page.
 
+### Fixed
+- Fixed an issue on address page example templates where adding required attribute to input elements in form throws an error of "field is not focusable".
+
 ## 3.4.14 - 2022-04-06
 
 ### Fixed

--- a/example-templates/dist/shop/checkout/addresses.twig
+++ b/example-templates/dist/shop/checkout/addresses.twig
@@ -147,6 +147,12 @@ Outputs a form for collecting an order’s shipping and billing address.
     $billingSameAs.addEventListener('change', function(ev) {
       var $billingFieldSet = document.querySelector('.js-address-fieldset.BillingAddress');
       $billingFieldSet.classList.toggle('hidden');
+
+      for (let input of document.querySelector('.js-address-fieldset.BillingAddress').querySelectorAll('input')) {
+        if (input.hasAttribute('required')) {
+          input.removeAttribute('required');
+        }
+      }
     });
   }
   {% endjs %}

--- a/example-templates/src/shop/checkout/addresses.twig
+++ b/example-templates/src/shop/checkout/addresses.twig
@@ -147,6 +147,12 @@ Outputs a form for collecting an order’s shipping and billing address.
     $billingSameAs.addEventListener('change', function(ev) {
       var $billingFieldSet = document.querySelector('.js-address-fieldset.BillingAddress');
       $billingFieldSet.classList.toggle('hidden');
+
+      for (let input of document.querySelector('.js-address-fieldset.BillingAddress').querySelectorAll('input')) {
+        if (input.hasAttribute('required')) {
+          input.removeAttribute('required');
+        }
+      }
     });
   }
   {% endjs %}


### PR DESCRIPTION
- Fixed an issue on address page example templates where adding required attribute to input elements in form throws an error of "field is not focusable".
### Description



### Related issues

