### PR TITLE
Fix bug where `autoSetNewCartAddresses` was not working for new carts. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Example templates address forms now show plain text custom fields.
 
 ### Fixed
+- Fixed a bug where the `autoSetNewCartAddresses` setting did not work. ([#2804](https://github.com/craftcms/commerce/issues/2804))
 - Fixed a PHP error that occurred when making a payment on the Edit Order page. ([#2795](https://github.com/craftcms/commerce/issues/2795))
 - Fixed a bug when submitting a custom field on address namespace doesn't save the field. ([2809](https://github.com/craftcms/commerce/pull/2809))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Fixed a bug where the `autoSetNewCartAddresses` setting did not work. ([#2804](https://github.com/craftcms/commerce/issues/2804))
 - Fixed a PHP error that occurred when making a payment on the Edit Order page. ([#2795](https://github.com/craftcms/commerce/issues/2795))
+- Fixed a PHP error that occurred when duplicating addresses that are not owned by Users.
 - Fixed a bug when submitting a custom field on address namespace doesn't save the field. ([2809](https://github.com/craftcms/commerce/pull/2809))
 
 ## 4.0.0 - 2022-05-04

--- a/src/behaviors/CustomerAddressBehavior.php
+++ b/src/behaviors/CustomerAddressBehavior.php
@@ -54,6 +54,11 @@ class CustomerAddressBehavior extends Behavior
 
         /** @var User $user */
         $user = $this->owner->getOwner();
+
+        if($user === null || !$user instanceof User) {
+            return;
+        }
+
         $customersService = Plugin::getInstance()->getCustomers();
 
         $customer = $customersService->ensureCustomer($user);

--- a/src/behaviors/CustomerAddressBehavior.php
+++ b/src/behaviors/CustomerAddressBehavior.php
@@ -55,7 +55,7 @@ class CustomerAddressBehavior extends Behavior
         /** @var User $user */
         $user = $this->owner->getOwner();
 
-        if($user === null || !$user instanceof User) {
+        if ($user === null || !$user instanceof User) {
             return;
         }
 

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1443,30 +1443,26 @@ class Order extends Element
             return false;
         }
 
+        /** @var User|CustomerBehavior|null $user */
         $user = $this->getCustomer();
-        $autoSetOccurred = false;
-
-        if (!$this->_shippingAddress && $user) {
-            /** @var User|CustomerBehavior $user */
-            if ($primaryShippingAddressId = $user->getPrimaryShippingAddressId()) {
-                if ($userShippingAddress = Address::find()->id($primaryShippingAddressId)->ownerId($user->id)->one()) {
-                    $this->sourceShippingAddressId = $primaryShippingAddressId;
-                    $billingAddress = Craft::$app->getElements()->duplicateElement($userShippingAddress, ['ownerId' => $this->id]);
-                    $this->setShippingAddress($billingAddress);
-                    $autoSetOccurred = true;
-                }
-            }
+        if (!$user) {
+            return false;
         }
 
-        if (!$this->_billingAddress && $user) {
-            if ($primaryBillingAddressId = $user->getPrimaryBillingAddressId()) {
-                if ($userBillingAddress = Address::find()->id($primaryBillingAddressId)->ownerId($user->id)->one()) {
-                    $this->sourceBillingAddressId = $primaryBillingAddressId;
-                    $billingAddress = Craft::$app->getElements()->duplicateElement($userBillingAddress, ['ownerId' => $this->id]);
-                    $this->setBillingAddress($billingAddress);
-                    $autoSetOccurred = true;
-                }
-            }
+        $autoSetOccurred = false;
+
+        if (!$this->_shippingAddress && $primaryShippingAddress = $user->getPrimaryShippingAddress()) {
+            $this->sourceShippingAddressId = $primaryShippingAddress->id;
+            $shippingAddress = Craft::$app->getElements()->duplicateElement($primaryShippingAddress, ['ownerId' => $this->id]);
+            $this->setShippingAddress($shippingAddress);
+            $autoSetOccurred = true;
+        }
+
+        if (!$this->_billingAddress && $primaryBillingAddress = $user->getPrimaryBillingAddress()) {
+            $this->sourceBillingAddressId = $primaryBillingAddress->id;
+            $billingAddress = Craft::$app->getElements()->duplicateElement($primaryBillingAddress, ['ownerId' => $this->id]);
+            $this->setBillingAddress($billingAddress);
+            $autoSetOccurred = true;
         }
 
         return $autoSetOccurred;

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -121,7 +121,11 @@ class Carts extends Component
             if ($currentUser) {
                 $this->_cart->setCustomer($currentUser); // Will ensure the email is also set
             }
-            $this->_cart->autoSetAddresses();
+        }
+
+        if ($this->_cart->autoSetAddresses()) {
+            // If we are auto setting address on the cart, save the cart so addresses have an ID to belong to.
+            $forceSave = true;
         }
 
         // Ensure the session knows what the current cart is.


### PR DESCRIPTION
Fixes #2804


- Also fixed a PHP error in the `CustomerAddressBehavior` class when propagating/duplicating Addresses that did not belong to users.