### PR TITLE
Add prefix to address handle defaults

### DIFF
--- a/src/console/controllers/UpgradeController.php
+++ b/src/console/controllers/UpgradeController.php
@@ -32,6 +32,7 @@ use craft\helpers\Console;
 use craft\helpers\DateTimeHelper;
 use craft\helpers\Db;
 use craft\helpers\MigrationHelper;
+use craft\helpers\StringHelper;
 use craft\models\FieldLayout;
 use craft\validators\HandleValidator;
 use Throwable;
@@ -324,7 +325,7 @@ EOL
             );
 
             foreach ($this->neededCustomAddressFields as $oldAttribute => $label) {
-                $field = $this->_customField($oldAttribute, $label);
+                $field = $this->_customField($oldAttribute, $label, 'address');
                 $this->_oldAddressFieldToNewCustomFieldHandle[$oldAttribute] = $field->handle;
                 if ($this->_allowAdminChanges && !$this->_addressFieldLayout->getFieldByHandle($field->handle)) {
                     $layoutElements[] = new CustomField($field);
@@ -345,7 +346,7 @@ EOL
      * @throws OperationAbortedException
      * @throws Throwable
      */
-    private function _customField(string $oldAttribute, string $label): FieldInterface
+    private function _customField(string $oldAttribute, string $label, ?string $prefix = null): FieldInterface
     {
         $fieldsService = Craft::$app->getFields();
         $handlePattern = sprintf('/^%s$/', HandleValidator::$handlePattern);
@@ -375,7 +376,7 @@ EOL
                     }
                     return true;
                 },
-                'default' => $fieldsService->getFieldByHandle($oldAttribute) === null ? $oldAttribute : null,
+                'default' => $fieldsService->getFieldByHandle($oldAttribute) === null ? StringHelper::toCamelCase("$prefix $oldAttribute") : null,
             ]);
             $field->name = $this->prompt('Field name:', [
                 'required' => true,


### PR DESCRIPTION
Adds a prefix to handle defaults for the upgrade script, otherwise `title` will always throw an error.
