### PR TITLE
Add ability to see if order addresses match each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Added `craft\commerce\elements\Order::hasMatchingAddresses()`.
 
+### Fixed
+- Fixed a bug where it was possible to save an order with the same address IDs. ([#2841](https://github.com/craftcms/commerce/issues/2841)) 
+
 ## 4.0.3 - 2022-06-09
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+### Added
+- Added `craft\commerce\elements\Order::hasMatchingAddresses()`.
+
 ## 4.0.3 - 2022-06-09
 
 ### Deprecated

--- a/example-templates/dist/shop/checkout/addresses.twig
+++ b/example-templates/dist/shop/checkout/addresses.twig
@@ -168,7 +168,7 @@ Outputs a form for collecting an order’s shipping and billing address.
   {% endjs %}
 
   {% js %}
-    {% if (cart.billingAddressId and cart.billingAddress and cart.billingAddress.hasErrors()) or (cart.billingAddressId != cart.shippingAddressId) %}
+    {% if (cart.billingAddress and cart.billingAddress.hasErrors()) or not cart.hasMatchingAddresses() %}
       $billingSameAs.click();
     {% endif %}
   {% endjs %}

--- a/example-templates/src/shop/checkout/addresses.twig
+++ b/example-templates/src/shop/checkout/addresses.twig
@@ -168,7 +168,7 @@ Outputs a form for collecting an order’s shipping and billing address.
   {% endjs %}
 
   {% js %}
-    {% if (cart.billingAddressId and cart.billingAddress and cart.billingAddress.hasErrors()) or (cart.billingAddressId != cart.shippingAddressId) %}
+    {% if (cart.billingAddress and cart.billingAddress.hasErrors()) or not cart.hasMatchingAddresses() %}
       $billingSameAs.click();
     {% endif %}
   {% endjs %}

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -518,9 +518,14 @@ class CartController extends BaseFrontEndController
             if ($userShippingAddress) {
                 $this->_cart->sourceShippingAddressId = $shippingAddressId;
 
-                /** @var Address $userShippingAddress */
-                $userShippingAddress = Craft::$app->getElements()->duplicateElement($userShippingAddress, ['ownerId' => $this->_cart->id]);
-                $this->_cart->setShippingAddress($userShippingAddress);
+                /** @var Address $cartShippingAddress */
+                $cartShippingAddress = Craft::$app->getElements()->duplicateElement($userShippingAddress, ['ownerId' => $this->_cart->id]);
+                $this->_cart->setShippingAddress($cartShippingAddress);
+
+                if($billingIsShipping){
+                    $this->_cart->sourceBillingAddressId = $userShippingAddress->id;
+                    $this->_cart->setBillingAddress($cartShippingAddress);
+                }
             }
         } elseif ($shippingAddress && !$shippingIsBilling) {
             $this->_cart->sourceShippingAddressId = null;
@@ -528,6 +533,11 @@ class CartController extends BaseFrontEndController
 
             if (!empty($shippingAddress['fields']) && $this->_cart->getShippingAddress()) {
                 $this->_cart->getShippingAddress()->setFieldValues($shippingAddress['fields']);
+            }
+
+            if($billingIsShipping){
+                $this->_cart->sourceBillingAddressId = null;
+                $this->_cart->setBillingAddress($this->_cart->getShippingAddress());
             }
         }
 
@@ -540,9 +550,14 @@ class CartController extends BaseFrontEndController
             if ($userBillingAddress) {
                 $this->_cart->sourceBillingAddressId = $billingAddressId;
 
-                /** @var Address $userBillingAddress */
-                $userBillingAddress = Craft::$app->getElements()->duplicateElement($userBillingAddress, ['ownerId' => $this->_cart->id]);
-                $this->_cart->setBillingAddress($userBillingAddress);
+                /** @var Address $cartBillingAddress */
+                $cartBillingAddress = Craft::$app->getElements()->duplicateElement($userBillingAddress, ['ownerId' => $this->_cart->id]);
+                $this->_cart->setBillingAddress($cartBillingAddress);
+
+                if($shippingIsBilling){
+                    $this->_cart->sourceShippingAddressId = $userBillingAddress->id;
+                    $this->_cart->setShippingAddress($cartBillingAddress);
+                }
             }
         } elseif ($billingAddress && !$billingIsShipping) {
             $this->_cart->sourceBillingAddressId = null;
@@ -550,6 +565,11 @@ class CartController extends BaseFrontEndController
 
             if (!empty($billingAddress['fields']) && $this->_cart->getBillingAddress()) {
                 $this->_cart->getBillingAddress()->setFieldValues($billingAddress['fields']);
+            }
+
+            if($shippingIsBilling){
+                $this->_cart->sourceShippingAddressId = null;
+                $this->_cart->setShippingAddress($this->_cart->getBillingAddress());
             }
         }
 
@@ -588,18 +608,6 @@ class CartController extends BaseFrontEndController
 
         if ($this->request->getBodyParam('makePrimaryBillingAddress')) {
             $this->_cart->makePrimaryBillingAddress = true;
-        }
-
-        // Shipping
-        if ($shippingAddressId && !$shippingIsBilling && $billingIsShipping) {
-            $this->_cart->sourceBillingAddressId = $this->_cart->sourceShippingAddressId;
-            $this->_cart->billingAddressId = $shippingAddressId;
-        }
-
-        // Billing
-        if ($billingAddressId && !$billingIsShipping && $shippingIsBilling) {
-            $this->_cart->sourceShippingAddressId = $this->_cart->sourceBillingAddressId;
-            $this->_cart->shippingAddressId = $billingAddressId;
         }
     }
 }

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -522,7 +522,7 @@ class CartController extends BaseFrontEndController
                 $cartShippingAddress = Craft::$app->getElements()->duplicateElement($userShippingAddress, ['ownerId' => $this->_cart->id]);
                 $this->_cart->setShippingAddress($cartShippingAddress);
 
-                if($billingIsShipping){
+                if ($billingIsShipping) {
                     $this->_cart->sourceBillingAddressId = $userShippingAddress->id;
                     $this->_cart->setBillingAddress($cartShippingAddress);
                 }
@@ -535,7 +535,7 @@ class CartController extends BaseFrontEndController
                 $this->_cart->getShippingAddress()->setFieldValues($shippingAddress['fields']);
             }
 
-            if($billingIsShipping){
+            if ($billingIsShipping) {
                 $this->_cart->sourceBillingAddressId = null;
                 $this->_cart->setBillingAddress($this->_cart->getShippingAddress());
             }
@@ -554,7 +554,7 @@ class CartController extends BaseFrontEndController
                 $cartBillingAddress = Craft::$app->getElements()->duplicateElement($userBillingAddress, ['ownerId' => $this->_cart->id]);
                 $this->_cart->setBillingAddress($cartBillingAddress);
 
-                if($shippingIsBilling){
+                if ($shippingIsBilling) {
                     $this->_cart->sourceShippingAddressId = $userBillingAddress->id;
                     $this->_cart->setShippingAddress($cartBillingAddress);
                 }
@@ -567,7 +567,7 @@ class CartController extends BaseFrontEndController
                 $this->_cart->getBillingAddress()->setFieldValues($billingAddress['fields']);
             }
 
-            if($shippingIsBilling){
+            if ($shippingIsBilling) {
                 $this->_cart->sourceShippingAddressId = null;
                 $this->_cart->setShippingAddress($this->_cart->getBillingAddress());
             }


### PR DESCRIPTION
### Description
Now that Addresses are elements Commerce requires a way to simply check if the addresses on the cart match each other as they should always be stored as separate IDs on the order. This is useful when building a checkout flow.
