### PR TITLE
Throwing a detailed gateway error when hitting reload after submission.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed an error that could occur when using a discount with a coupon code.
 - Fixed a bug where it wasn’t possible to subscribe and create a payment source simultaneously. ([#2834](https://github.com/craftcms/commerce/pull/2834))
 - Fixed errors that could occur when expiring, cancelling or suspending a subscription. ([#2831](https://github.com/craftcms/commerce/issues/2831))
+- Fixed a bug where reloading after the payment form is submitted re-submits the form in payment.twig example templates.
 
 ## 4.0.3 - 2022-06-09
 

--- a/example-templates/dist/shop/checkout/payment.twig
+++ b/example-templates/dist/shop/checkout/payment.twig
@@ -147,6 +147,10 @@
         $paymentForm.dataset.processing = true;
       });
     }
+
+    if ( window.history.replaceState ) {
+      window.history.replaceState( null, null, window.location.href );
+    }
   {% endjs %}
 
 {% endblock %}

--- a/example-templates/src/shop/checkout/payment.twig
+++ b/example-templates/src/shop/checkout/payment.twig
@@ -147,6 +147,10 @@
         $paymentForm.dataset.processing = true;
       });
     }
+
+    if ( window.history.replaceState ) {
+      window.history.replaceState( null, null, window.location.href );
+    }
   {% endjs %}
 
 {% endblock %}


### PR DESCRIPTION
Fixed a bug where reloading after the payment form is submitted re-submits the form in payment.twig example templates.
![97713bf2-9915-4f99-af78-dfd51a7a658f](https://user-images.githubusercontent.com/4172750/174084677-6a236cf6-1b6e-489f-a728-94111fd9b881.jpeg)


### Description



### Related issues

