### PR TITLE
Fixed getting product type id's

### DIFF
--- a/src/test/fixtures/elements/ProductFixture.php
+++ b/src/test/fixtures/elements/ProductFixture.php
@@ -72,8 +72,8 @@ class ProductFixture extends BaseElementFixture
     {
         return (new Query())
             ->select([
-                'productTypes.handle',
                 'productTypes.id',
+                'productTypes.handle',
             ])
             ->from([Table::PRODUCTTYPES . ' productTypes'])
             ->indexBy('handle')


### PR DESCRIPTION
### Description

It got the handles instead of the id's

Using this in fixtures results in the following error:

`Exception 'TypeError' with message 'Cannot assign string to property craft\commerce\elements\Product::$typeId of type ?int'`

