### PR TITLE
GC orphaned variants and partial element data

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - Addresses submitted to the cart are now validated. ([#2874](https://github.com/craftcms/commerce/pull/2874))
+- Garbage collection now removes any orphaned variants, as well as partial donation, order, product, subscription, and variant data.
 - `craft\commerce\elements\Product` now supports the `EVENT_DEFINE_CACHE_TAGS` event.
 - `craft\commorce\elements\Variant` now supports the `EVENT_DEFINE_CACHE_TAGS` event.
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,7 @@ use craft\base\Plugin as BasePlugin;
 use craft\commerce\base\Purchasable;
 use craft\commerce\behaviors\CustomerAddressBehavior;
 use craft\commerce\behaviors\CustomerBehavior;
+use craft\commerce\db\Table;
 use craft\commerce\debug\CommercePanel;
 use craft\commerce\elements\Donation;
 use craft\commerce\elements\Order;
@@ -108,6 +109,7 @@ use craft\events\RegisterGqlTypesEvent;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\fixfks\controllers\RestoreController;
 use craft\gql\ElementQueryConditionBuilder;
+use craft\helpers\Db;
 use craft\helpers\FileHelper;
 use craft\helpers\UrlHelper;
 use craft\models\FieldLayout;
@@ -801,9 +803,21 @@ class Plugin extends BasePlugin
      */
     private function _registerGarbageCollection(): void
     {
-        Event::on(Gc::class, Gc::EVENT_RUN, static function() {
+        Event::on(Gc::class, Gc::EVENT_RUN, function(Event $event) {
             // Deletes carts that meet the purge settings
             Plugin::getInstance()->getCarts()->purgeIncompleteCarts();
+
+            // Delete orphaned variants
+            Db::delete(Table::VARIANTS, ['productId' => null]);
+
+            // Delete partial elements
+            /** @var Gc $gc */
+            $gc = $event->sender;
+            $gc->deletePartialElements(Donation::class, Table::DONATIONS, 'id');
+            $gc->deletePartialElements(Order::class, Table::ORDERS, 'id');
+            $gc->deletePartialElements(Product::class, Table::PRODUCTS, 'id');
+            $gc->deletePartialElements(Subscription::class, Table::SUBSCRIPTIONS, 'id');
+            $gc->deletePartialElements(Variant::class, Table::VARIANTS, 'id');
         });
     }
 


### PR DESCRIPTION
### Description

This updates garbage collection to include orphaned variants and partial element data.

(Orphaned variants could exist because `variants.productId` is nullable, and the FK is set to `ON DELETE SET NULL`.)

### Related issues

- craftcms/cms#11411