### PR TITLE
Fixed #2886 product slideout editors showing draft capability

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -22,3 +22,4 @@
 - Fixed a bug where it was possible to save an order with the same address IDs. ([#2841](https://github.com/craftcms/commerce/issues/2841))
 - Fixed a bug where order addresses were not being saved with the “live” scenario.
 - Fixed a PHP error that occurred when editing a subscription with custom fields.
+- Fixed a bug where product slideout editors appeared to allow the saving of drafts. ([#2886](https://github.com/craftcms/commerce/issues/2886))

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -390,7 +390,7 @@ class Product extends Element
      */
     public function canCreateDrafts(User $user): bool
     {
-        return $this->canSave($user);
+        return false;
     }
 
     /**

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -388,14 +388,6 @@ class Product extends Element
     /**
      * @inheritdoc
      */
-    public function canCreateDrafts(User $user): bool
-    {
-        return false;
-    }
-
-    /**
-     * @inheritdoc
-     */
     public function createAnother(): ?ElementInterface
     {
         return null;


### PR DESCRIPTION
### Description
When using the Commerce Products field, if you double-click to edit a product, the slideout shows drafts capabilities that products do not support.

This causes a confusing experience for content authors.

### Related issues
#2886 