### PR TITLE
Fixed `autoSetCartShippingMethodOption` creating loop

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -22,3 +22,4 @@
 - Fixed a bug where it was possible to save an order with the same address IDs. ([#2841](https://github.com/craftcms/commerce/issues/2841))
 - Fixed a bug where order addresses were not being saved with the “live” scenario.
 - Fixed a PHP error that occurred when editing a subscription with custom fields.
+- Fixed a bug that occurred when setting `autoSetCartShippingMethodOption` to `true`. ([#2875](https://github.com/craftcms/commerce/issues/2875))

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -129,9 +129,9 @@ class OrdersController extends Controller
         if ($user) {
             $order->setCustomer($user);
 
-            if (Plugin::getInstance()->getSettings()->autoSetNewCartAddresses) {
-                $order->autoSetAddresses();
-            }
+            // Try to set defaults
+            $order->autoSetAddresses();
+            $order->autoSetShippingMethod();
         }
         $order->number = Plugin::getInstance()->getCarts()->generateCartNumber();
         $order->origin = Order::ORIGIN_CP;

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -124,7 +124,7 @@ class Carts extends Component
             }
         }
 
-        if ($this->_cart->autoSetAddresses()) {
+        if ($this->_cart->autoSetAddresses() || $this->_cart->autoSetShippingMethod()) {
             // If we are auto setting address on the cart, save the cart so addresses have an ID to belong to.
             $forceSave = true;
         }


### PR DESCRIPTION
### Description
Fixed an issue where there was an infinite loop when setting `autoSetCartShippingMethodOption` to `true`


### Related issues
#2875 
