### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Addresses submitted to the cart are now validated. ([#2874](https://github.com/craftcms/commerce/pull/2874))
 - Garbage collection now removes any orphaned variants, as well as partial donation, order, product, subscription, and variant data.
 - `craft\commerce\elements\Product` now supports the `EVENT_DEFINE_CACHE_TAGS` event.
-- `craft\commorce\elements\Variant` now supports the `EVENT_DEFINE_CACHE_TAGS` event.
+- `craft\commerce\elements\Variant` now supports the `EVENT_DEFINE_CACHE_TAGS` event.
 
 ### Fixed
 - Fixed an error that occurred when disabling all variants on Edit Product pages.


### PR DESCRIPTION
### Description

Fixes a typo in the changelog notes for 4.1.0, replaces one case of `craft\commorce\elements\Variant` with `craft\commerce\elements\Variant`.

### Related issues

n/a