### PR TITLE
Fixed a bug on `perItemDiscount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed a bug where the Edit Product page wasn’t handling site selection changes properly. ([#2920](https://github.com/craftcms/commerce/issues/2920))
 - Fixed a bug where partial elements were not being deleted during garbage collection.
 - Fixed a bug where `itemSubtotal` wasn’t saving to the database.
+- Fixed a bug on `perItemDiscount` where decimals were being stripped in locales that use commas as separators. ([#2937](https://github.com/craftcms/commerce/issues/2937))
 
 ## 4.1.1 - 2022-09-01
 

--- a/src/templates/promotions/discounts/_edit.twig
+++ b/src/templates/promotions/discounts/_edit.twig
@@ -504,7 +504,7 @@
             instructions: "The flat value which should discount each item. i.e “3” for $3 off each item."|t('commerce'),
             id: 'perItemDiscount',
             name: 'perItemDiscount',
-            value: discount.perItemDiscount ? discount.perItemDiscount : 0,
+            value: discount.perItemDiscount ? discount.perItemDiscount|number : 0,
             type: 'number',
             step: 'any',
             errors: discount.getErrors('perItemDiscount'),


### PR DESCRIPTION

### Description

Fixed a bug on `perItemDiscount` where decimals were being stripped in locales that use commas as separators.
