### PR TITLE
Order Status condition rule styling bug for status with handle of `new`

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -58,6 +58,7 @@
 - It is now possible to automatically set a customer’s primary payment source on new carts using the `autoSetPaymentSource` config setting.
 - It is now possible to query orders by `itemTotal`, `itemSubtotal`, `totalDiscount`, `total`, `totalPaid`, `totalPrice`, `totalQty`, and `totalTax`.
 - Querying an order by `reference` now allows a wider range of inputs.
+- Querying an order by `orderStatus` now allows `uid` as an input.
 - Shipping and Tax Categories are now archived instead of deleted.
 - It is now possible to define how addresses are matched in `Order::hasMatchingAddresses()`.
 - Update order status action now returns relevant flash messages on completion.

--- a/src/elements/conditions/orders/OrderStatusConditionRule.php
+++ b/src/elements/conditions/orders/OrderStatusConditionRule.php
@@ -63,12 +63,12 @@ class OrderStatusConditionRule extends BaseMultiSelectConditionRule implements E
     public function matchElement(ElementInterface $element): bool
     {
         /** @var Order $element */
-        $orderStatusHandle = $element->getOrderStatus()?->handle;
+        $orderStatusHandle = $element->getOrderStatus()?->uid;
         return $this->matchValue($orderStatusHandle);
     }
 
     protected function options(): array
     {
-        return ArrayHelper::map(Plugin::getInstance()->getOrderStatuses()->getAllOrderStatuses(), 'handle', 'name');
+        return ArrayHelper::map(Plugin::getInstance()->getOrderStatuses()->getAllOrderStatuses(), 'uid', 'name');
     }
 }

--- a/src/elements/db/OrderQuery.php
+++ b/src/elements/db/OrderQuery.php
@@ -626,6 +626,7 @@ class OrderQuery extends ElementQuery
                 ->select(['id'])
                 ->from([Table::ORDERSTATUSES])
                 ->where(Db::parseParam('handle', $value))
+                ->orWhere(Db::parseParam('uid', $value))
                 ->column();
         } else {
             $this->orderStatusId = null;


### PR DESCRIPTION
### Description
PR fixes the styling, as outlined in the following issue: https://github.com/craftcms/cms/issues/11946, by using `uid` selection and querying instead of `handle`.

In turn, this means it is now possible to pass an order status `uid` to `$orderStatus` and `orderStatus()` on the `OrderQuery`.
