### PR TITLE
Add inline parameter to DownloadsController

### DIFF
--- a/src/controllers/DownloadsController.php
+++ b/src/controllers/DownloadsController.php
@@ -37,6 +37,7 @@ class DownloadsController extends BaseFrontEndController
         $number = $this->request->getQueryParam('number');
         $pdfHandle = $this->request->getQueryParam('pdfHandle');
         $option = $this->request->getQueryParam('option', '');
+        $inline = (bool) $this->request->getQueryParam('inline', false);
 
         if (!$number) {
             throw new HttpInvalidParamException('Order number required');
@@ -80,6 +81,7 @@ class DownloadsController extends BaseFrontEndController
 
         return $this->response->sendContentAsFile($renderedPdf, $fileName . '.pdf', [
             'mimeType' => 'application/pdf',
+            'inline' => $inline,
         ]);
     }
 }


### PR DESCRIPTION
Add `inline` parameter to `DownloadsController` to display PDFs directly in a browser tab.

### Description

During development of PDF files I find it handy to display them in a browser tab so I just have to reload the tab after changes. For this purpose I added an `inline` parameter to the response object which defaults to `false`. To enable it just add `&inline=true` to the URL of the corresponding request.