### PR TITLE
Fix `loadCartRedirectUrl` to allow paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where it wasn't possible to use a path value for the `loadCartRedirectUrl` setting. ([#2992](https://github.com/craftcms/commerce/pull/2992))
+
 ## 4.1.3 - 2022-10-07
 
 ### Changed

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -299,6 +299,9 @@ class CartController extends BaseFrontEndController
             return $this->request->getIsGet() ? $this->redirect($redirect) : null;
         }
 
+        // If we have a cart, use the site for that cart for the URL redirect.
+        $redirect = UrlHelper::siteUrl(path: $loadCartRedirectUrl, siteId: $cart->orderSiteId ?? null);
+
         $carts->forgetCart();
         $carts->setSessionCartNumber($number);
 

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -300,7 +300,7 @@ class CartController extends BaseFrontEndController
         }
 
         // If we have a cart, use the site for that cart for the URL redirect.
-        $redirect = UrlHelper::siteUrl(path: $loadCartRedirectUrl, siteId: $cart->orderSiteId ?? null);
+        $redirect = UrlHelper::siteUrl(path: $loadCartRedirectUrl, siteId: $cart->orderSiteId);
 
         $carts->forgetCart();
         $carts->setSessionCartNumber($number);

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -270,10 +270,10 @@ class CartController extends BaseFrontEndController
      */
     public function actionLoadCart(): ?Response
     {
-        $session = Craft::$app->getSession();
         $carts = Plugin::getInstance()->getCarts();
         $number = $this->request->getParam('number');
-        $redirect = Plugin::getInstance()->getSettings()->loadCartRedirectUrl ?: UrlHelper::siteUrl();
+        $loadCartRedirectUrl = Plugin::getInstance()->getSettings()->loadCartRedirectUrl ?? '';
+        $redirect = UrlHelper::siteUrl($loadCartRedirectUrl);
 
         if (!$number) {
             $error = Craft::t('commerce', 'A cart number must be specified.');


### PR DESCRIPTION
### Description

Currently the `loadCartRedirectUrl` setting only works with full URLs. This allows a simple path value to be used that will generate a site specific URL.

Also when generating the redirect URL, we should use the site of the cart if known.

Fixes https://github.com/craftcms/commerce/issues/2990