### PR TITLE
Fixed a bug where `availableForUseWithOrder` on payment gateways not respecting on payment transaction modal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Fixed a bug that occurred when using a custom shipping method. ([#2986](https://github.com/craftcms/commerce/issues/2986))
 - Fixed a bug that could occur when querying products by `type`. ([#2966](https://github.com/craftcms/commerce/issues/2966))
+- Fixed a bug where `availableForUseWithOrder` on payment gateways not respecting on payment transaction modal. ([#2988](https://github.com/craftcms/commerce/issues/2988))
 
 ## 4.1.3 - 2022-10-07
 

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -851,7 +851,7 @@ class OrdersController extends Controller
         /** @var Gateway $gateway */
         foreach ($gateways as $key => $gateway) {
             // If gateway adapter does no support backend cp payments.
-            if (!$gateway->cpPaymentsEnabled() || $gateway instanceof MissingGateway) {
+            if ($gateway->availableForUseWithOrder($order) === false || !$gateway->cpPaymentsEnabled() || $gateway instanceof MissingGateway) {
                 unset($gateways[$key]);
                 continue;
             }


### PR DESCRIPTION

### Description

(Fixed #2988 )