### PR TITLE
Textlint Fixes

### DIFF
--- a/src/elements/db/OrderQuery.php
+++ b/src/elements/db/OrderQuery.php
@@ -1103,7 +1103,7 @@ class OrderQuery extends ElementQuery
     }
 
     /**
-     * Narrows the query results based on the order's item total.
+     * Narrows the query results based on the order’s item total.
      *
      * Possible values include:
      *
@@ -1125,7 +1125,7 @@ class OrderQuery extends ElementQuery
     }
 
     /**
-     * Narrows the query results based on the order's item subtotal.
+     * Narrows the query results based on the order’s item subtotal.
      *
      * Possible values include:
      *

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -70,7 +70,7 @@ class Settings extends Model
     public bool $autoSetCartShippingMethodOption = false;
 
     /**
-     * @var bool Whether the user's primary payment source should be set automatically on new carts.
+     * @var bool Whether the user’s primary payment source should be set automatically on new carts.
      *
      * @group Cart
      * @since 4.2


### PR DESCRIPTION
This was blowing up in textlint when compiling docs… :expressionless:

Changes a few `'` to `’` for new `craft\commerce\elements\db\OrderQuery` and `craft\commerce\models\Settings` docblocks.