### PR TITLE
commerce-specific site condition rule for zones

### DIFF
--- a/src/elements/conditions/CommerceSiteConditionRule.php
+++ b/src/elements/conditions/CommerceSiteConditionRule.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace craft\commerce\elements\conditions;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\elements\conditions\SiteConditionRule;
+
+/**
+ * Site condition rule.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.0.0
+ */
+class CommerceSiteConditionRule extends SiteConditionRule
+{
+    /**
+     * @inheritdoc
+     */
+    public function matchElement(ElementInterface $element): bool
+    {
+        return $this->matchValue(Craft::$app->getSites()->getCurrentSite()->uid);
+    }
+}

--- a/src/elements/conditions/addresses/CommerceSiteConditionRule.php
+++ b/src/elements/conditions/addresses/CommerceSiteConditionRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace craft\commerce\elements\conditions;
+namespace craft\commerce\elements\conditions\addresses;
 
 use Craft;
 use craft\base\ElementInterface;

--- a/src/elements/conditions/addresses/ZoneAddressCondition.php
+++ b/src/elements/conditions/addresses/ZoneAddressCondition.php
@@ -2,7 +2,7 @@
 
 namespace craft\commerce\elements\conditions\addresses;
 
-use craft\commerce\elements\conditions\CommerceSiteConditionRule;
+use craft\commerce\elements\conditions\addresses\CommerceSiteConditionRule;
 use craft\elements\conditions\addresses\AddressCondition as ElementAddressCondition;
 use craft\elements\db\ElementQueryInterface;
 use yii\base\NotSupportedException;

--- a/src/elements/conditions/addresses/ZoneAddressCondition.php
+++ b/src/elements/conditions/addresses/ZoneAddressCondition.php
@@ -2,6 +2,7 @@
 
 namespace craft\commerce\elements\conditions\addresses;
 
+use craft\commerce\elements\conditions\CommerceSiteConditionRule;
 use craft\elements\conditions\addresses\AddressCondition as ElementAddressCondition;
 use craft\elements\db\ElementQueryInterface;
 use yii\base\NotSupportedException;
@@ -19,9 +20,16 @@ class ZoneAddressCondition extends ElementAddressCondition
      */
     protected function conditionRuleTypes(): array
     {
-        return array_merge(parent::conditionRuleTypes(),
+        $parentConditionRuleTypes = parent::conditionRuleTypes();
+
+        if (($key = array_search('craft\elements\conditions\SiteConditionRule', $parentConditionRuleTypes)) !== false) {
+            unset($parentConditionRuleTypes[$key]);
+        }
+
+        return array_merge($parentConditionRuleTypes,
             [
                 PostalCodeFormulaConditionRule::class,
+                CommerceSiteConditionRule::class,
             ]);
     }
 

--- a/src/elements/conditions/addresses/ZoneAddressCondition.php
+++ b/src/elements/conditions/addresses/ZoneAddressCondition.php
@@ -2,7 +2,6 @@
 
 namespace craft\commerce\elements\conditions\addresses;
 
-use craft\commerce\elements\conditions\addresses\CommerceSiteConditionRule;
 use craft\elements\conditions\addresses\AddressCondition as ElementAddressCondition;
 use craft\elements\db\ElementQueryInterface;
 use yii\base\NotSupportedException;

--- a/src/migrations/m230103_153208_tax_zone_site_condition_update.php
+++ b/src/migrations/m230103_153208_tax_zone_site_condition_update.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace craft\commerce\migrations;
+
+use Craft;
+use craft\commerce\records\TaxZone;
+use craft\db\Migration;
+
+/**
+ * m230103_153208_tax_zone_site_condition_update migration.
+ */
+class m230103_153208_tax_zone_site_condition_update extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        // get all tax zone records
+        $taxZoneRecords = TaxZone::find()->all();
+
+        // iterate through all, json decode the 'condition'
+        foreach ($taxZoneRecords as $i => $taxZoneRecord) {
+            $condition = json_decode($taxZoneRecord->attributes['condition'], true);
+
+            // if it contains "conditionRules":[{"class":"craft\\elements\\conditions\\SiteConditionRule"
+            // change it to "conditionRules":[{"class":"craft\\commerce\\elements\\conditions\\CommerceSiteConditionRule"
+            if ($condition['class'] === 'craft\commerce\elements\conditions\addresses\ZoneAddressCondition' &&
+                !empty($condition['conditionRules'])
+            ) {
+                foreach ($condition['conditionRules'] as $j => $rule) {
+                    if ($rule['class'] === 'craft\elements\conditions\SiteConditionRule') {
+                        $condition['conditionRules'][$j]['class'] = 'craft\commerce\elements\conditions\CommerceSiteConditionRule';
+                        $taxZoneRecord->setAttribute('condition', json_encode($condition));
+                        $taxZoneRecord->save();
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        // get all tax zone records
+        $taxZoneRecords = TaxZone::find()->all();
+
+        // iterate through all, json decode the 'condition'
+        foreach ($taxZoneRecords as $i => $taxZoneRecord) {
+            $condition = json_decode($taxZoneRecord->attributes['condition'], true);
+
+            // if it contains "conditionRules":[{"class":"craft\\commerce\\elements\\conditions\\CommerceSiteConditionRule"
+            // change it back to "conditionRules":[{"class":"craft\\elements\\conditions\\SiteConditionRule"
+            if ($condition['class'] === 'craft\commerce\elements\conditions\addresses\ZoneAddressCondition' &&
+                !empty($condition['conditionRules'])
+            ) {
+                foreach ($condition['conditionRules'] as $j => $rule) {
+                    if ($rule['class'] === 'craft\commerce\elements\conditions\CommerceSiteConditionRule') {
+                        $condition['conditionRules'][$j]['class'] = 'craft\elements\conditions\SiteConditionRule';
+                        $taxZoneRecord->setAttribute('condition', json_encode($condition));
+                        $taxZoneRecord->save();
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
### Description
Adds a `CommerceSiteConditionRule` which extends the `SiteConditionRule` and handles the site conditioning not based on the element's site, but the currently loaded site. 

That new condition rule is used when triggered via `ZoneAddressCondition`. 
I also added a migration so that “old” site rules in tax & shipping zones still work with this approach. 

Since I’ve already written it all before Brandon closed the related CMS issue as not planned, I am raising this PR. Feel free to use, adjust or discard it.


### Related issues
[#12491](https://github.com/craftcms/cms/issues/12491)

