### PR TITLE
Added CurrentSiteConditionRule for ZondeAddressCondition

### DIFF
--- a/src/elements/conditions/addresses/CurrentSiteConditionRule.php
+++ b/src/elements/conditions/addresses/CurrentSiteConditionRule.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace craft\commerce\elements\conditions\addresses;
+
+use Craft;
+use craft\base\ElementInterface;
+use craft\elements\conditions\SiteConditionRule;
+
+/**
+ * Current Site condition rule.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.0.0
+ */
+class CurrentSiteConditionRule extends SiteConditionRule
+{
+    /**
+     * @inheritdoc
+     */
+    public function getLabel(): string
+    {
+        return Craft::t('app', 'Current Site');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function matchElement(ElementInterface $element): bool
+    {
+        $currentSite = Craft::$app->getSites()->getCurrentSite();
+        return $this->matchValue($currentSite->uid);
+    }
+}

--- a/src/elements/conditions/addresses/ZoneAddressCondition.php
+++ b/src/elements/conditions/addresses/ZoneAddressCondition.php
@@ -22,6 +22,7 @@ class ZoneAddressCondition extends ElementAddressCondition
         return array_merge(parent::conditionRuleTypes(),
             [
                 PostalCodeFormulaConditionRule::class,
+                CurrentSiteConditionRule::class,
             ]);
     }
 


### PR DESCRIPTION
### Description
The craft\elements\conditions\SiteConditionRule::matchElement gets the site ID from the element resulting to the Commerce adjustments with Site Condition Rule having unexpected behavior. 

I created CurrentSiteConditionRule to get the Site ID from the logged in user's current site URL that's been accessed.

### Steps to reproduce

1. Create 2 tax zones with different site condition rule
2. Create 2 tax rates assigning each created tax zones
3. Go to site 1 on front end and checkout a product then proceed to address. This will apply tax from the tax rate with primary site condition
4. Repeat step 3 but accessing site 2 on front end. It will still apply tax from the tax rate with primary site condition.

### Expected behavior
When checking out a product on site 2 it should apply tax rate with the site 2 condition rule.