### PR TITLE
Make primaryPaymentSourceId an attribute

### DIFF
--- a/src/records/Customer.php
+++ b/src/records/Customer.php
@@ -22,6 +22,7 @@ use yii\db\ActiveQueryInterface;
  * @property ?int $primaryPaymentSourceId
  * @property-read ActiveQueryInterface $primaryShippingAddress
  * @property-read ActiveQueryInterface $primaryBillingAddress
+ * @property-read ActiveQueryInterface $primaryPaymentSource
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.0
  */
@@ -38,6 +39,7 @@ class Customer extends ActiveRecord
                     'customerId',
                     'primaryBillingAddressId',
                     'primaryShippingAddressId',
+                    'primaryPaymentSourceId',
                 ], 'safe',
             ],
         ];
@@ -59,5 +61,10 @@ class Customer extends ActiveRecord
     public function getPrimaryShippingAddress(): ActiveQueryInterface
     {
         return $this->hasOne(Element::class, ['id' => 'primaryShippingAddressId']);
+    }
+
+    public function getPrimaryPaymentSource(): ActiveQueryInterface
+    {
+        return $this->hasOne(PaymentSource::class, ['id' => 'primaryPaymentSourceId']);
     }
 }


### PR DESCRIPTION
### Description
I was attempting to listen for a changed `primaryPaymentSourceId` from `\yii\db\AfterSaveEvent::changedAttributes`, but it never appears, as it isn't an attribute because it was never added to `rules()` like the others (`primaryBillingAddressId`, `primaryShippingAddressId`).


```php
Event::on(Customer::class, BaseActiveRecord::EVENT_AFTER_UPDATE, function (AfterSaveEvent $e) {
    $changedAttributes = $e->changedAttributes;
});
```