### PR TITLE
Show fail flash message when trying to delete a user with an existing…

### DIFF
--- a/src/services/Orders.php
+++ b/src/services/Orders.php
@@ -170,7 +170,7 @@ class Orders extends Component
 
         // If there are any orders, make sure that this is not allowed.
         if (Order::find()->customerId($user->id)->status(null)->exists()) {
-            $event->isValid = false;
+            throw new Exception("Unable to delete a user with an existing order, user ID “{$user->id}”");
         }
     }
 }

--- a/src/services/Subscriptions.php
+++ b/src/services/Subscriptions.php
@@ -405,7 +405,7 @@ class Subscriptions extends Component
 
         // If there are any subscriptions, make sure that this is not allowed.
         if ($this->doesUserHaveSubscriptions($user->id)) {
-            $event->isValid = false;
+            throw new Exception("Unable to delete a user with an existing subscription, user ID “{$user->id}”");
         }
     }
 


### PR DESCRIPTION
… order/subscription

### Description
Shows a fail flash message that we can't delete such user because it have an existing order or subscription.


### Related issues
https://github.com/craftcms/commerce/issues/3070
