### PR TITLE
Don't attempt to claim another customer's cart

### DIFF
--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -190,8 +190,19 @@ class Carts extends Component
             ->status(null)
             ->one();
 
-        // If the cart is already completed or trashed, forget the cart and start again.
-        if ($cart && ($cart->isCompleted || $cart->trashed)) {
+        if (!$cart) {
+            return null;
+        }
+
+        $currentUser = Craft::$app->getUser()->getIdentity();
+        $customerMismatch =
+            $currentUser &&
+            $cart->customer &&
+            $cart->customer->getIsCredentialed() &&
+            $currentUser->id !== $cart->customerId;
+
+        // If the cart is already completed, trashed, or belongs to another active user, forget the cart and start again.
+        if ($cart->isCompleted || $cart->trashed || $customerMismatch) {
             $this->forgetCart();
             return null;
         }

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -195,11 +195,11 @@ class Carts extends Component
         }
 
         $currentUser = Craft::$app->getUser()->getIdentity();
+        $cartCustomer = $cart->getCustomer();
+
         $customerMismatch =
-            $currentUser &&
-            $cart->customer &&
-            $cart->customer->getIsCredentialed() &&
-            $currentUser->id !== $cart->customerId;
+            ($currentUser && $cartCustomer && $currentUser->id !== $cartCustomer->id) ||
+            (!$currentUser && $cartCustomer && $cartCustomer->getIsCredentialed());
 
         // If the cart is already completed, trashed, or belongs to another active user, forget the cart and start again.
         if ($cart->isCompleted || $cart->trashed || $customerMismatch) {


### PR DESCRIPTION
Here's how to reproduce the current bug:

- log in as `userA` (a user with a default payment source set)
- an empty cart will be created on login
  -  `paymentSourceId` set
  -  number will be stored in the `xxxxxxx_commerce_cart` cookie
- Delete your php session cookie manually (don't use `logout`).
- log in as `userB`
- At this point, you'll get an `invalid payment source` exception because it is trying to save the cart with the new user and the payment source doesn't belong to that user.

I don't _think_ we'd even want to allow a customer to change in this way, assuming the cart customer was an active/credentialed user.

I'm not 💯 this code is necessarily in the right place, but I think something close to this is what is needed.

https://app.bugsnag.com/pixel-and-tonic-inc/craftnet/errors/63e2930d8db91100088f535d?event_id=63ed50ac00ad321f8a250000&i=sk&m=oc