### PR TITLE
Fix broken cookie removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug that could occur when forgetting a cart. ([#3091](https://github.com/craftcms/commerce/pull/3091))
+
 ## 4.2.5.1 - 2023-02-02
 
 - Fixed a PHP error that occurred when retrieving orders with missing line item descriptions or SKUs. ([#2936](https://github.com/craftcms/commerce/issues/2936))

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -207,7 +207,11 @@ class Carts extends Component
         $this->_cart = null;
         $this->_cartNumber = null;
         if (!Craft::$app->getRequest()->getIsConsoleRequest()) {
-            Craft::$app->getResponse()->getCookies()->remove($this->cartCookie['name'], true);
+            $cookie = Craft::createObject(array_merge($this->cartCookie, [
+                'class' => Cookie::class,
+            ]));
+
+            Craft::$app->getResponse()->getCookies()->remove($cookie, true);
         }
     }
 


### PR DESCRIPTION
Removing the cart cookie on logout was broken, because we were only passing the name, not the full config.
This means if you had set `\craft\config\GeneralConfig::$defaultCookieDomain` to something, removing the cookie would fail silently.