### PR TITLE
Cart custom field validation no longer works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed a bug that occurred when creating a tax category inline on the Edit Tax Rate page.
 - Ajax requests to`commerce/payments/pay` actions now includes `redirectData` data in their response.
 - Added `craft\commerce\base\Gateway::showPaymentFormSubmitButton()`
+- Fixed a bug where custom field validation doesn't work when updating a cart. ([#3109](https://github.com/craftcms/commerce/issues/3109))
 
 ## 4.2.5.1 - 2023-02-02
 

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -433,7 +433,7 @@ class CartController extends BaseFrontEndController
             // $fields will be null so
             if ($submittedFields = $this->request->getBodyParam('fields')) {
                 $this->_cart->setScenario(Element::SCENARIO_LIVE);
-                $customFieldAttributes = array_keys($submittedFields);
+                $customFieldAttributes = array_map(fn($handle) => "field:$handle", array_keys($submittedFields));
             }
         }
 

--- a/src/services/Payments.php
+++ b/src/services/Payments.php
@@ -460,7 +460,7 @@ class Payments extends Component
 
         if ($response->isRedirect() && $transaction->status === TransactionRecord::STATUS_REDIRECT) {
             $mutex->release($transactionLockName);
-            $this->_handleRedirect($response, $redirect);
+            $this->_handleRedirect($response, $redirect, $redirectData);
             Craft::$app->getResponse()->redirect($redirect);
             Craft::$app->end();
         }


### PR DESCRIPTION


### Description

Fixed a bug where custom field validation doesn’t work when updating a cart. (#3109 3109)

