### PR TITLE
Retry send email job

### DIFF
--- a/src/queue/jobs/SendEmail.php
+++ b/src/queue/jobs/SendEmail.php
@@ -57,7 +57,12 @@ class SendEmail extends BaseJob implements RetryableJobInterface
         $this->setProgress($queue, 1);
     }
 
-    public function canRetry($attempt, $error)
+    public function getTtr(): int
+    {
+        return 60;
+    }
+
+    public function canRetry($attempt, $error): bool
     {
         return $attempt < 5;
     }

--- a/src/queue/jobs/SendEmail.php
+++ b/src/queue/jobs/SendEmail.php
@@ -12,8 +12,9 @@ use craft\commerce\errors\EmailException;
 use craft\commerce\helpers\Locale;
 use craft\commerce\Plugin;
 use craft\queue\BaseJob;
+use yii\queue\RetryableJobInterface;
 
-class SendEmail extends BaseJob
+class SendEmail extends BaseJob implements RetryableJobInterface
 {
     /**
      * @var int Order ID
@@ -34,7 +35,6 @@ class SendEmail extends BaseJob
      * @var int the order history ID
      */
     public int $orderHistoryId;
-
 
     public function execute($queue): void
     {
@@ -57,6 +57,10 @@ class SendEmail extends BaseJob
         $this->setProgress($queue, 1);
     }
 
+    public function canRetry($attempt, $error)
+    {
+        return $attempt < 5;
+    }
 
     protected function defaultDescription(): ?string
     {


### PR DESCRIPTION
### Description

Sending e-mail can fail when your e-mail provider is down, for example. But an order confirmation mail is important to get, and important to send without checking your CP for failed jobs all the time. I think it should retry a few times?
