### PR TITLE
Fix German translation

### DIFF
--- a/src/translations/de/commerce.php
+++ b/src/translations/de/commerce.php
@@ -835,7 +835,7 @@ return [
     'Sales updated.' => 'Aktionen aktualisiert.',
     'Sales' => 'Verkäufe',
     'Save and continue editing' => 'Speichern und mit Bearbeitung fortfahren',
-    'Save and return to all orders' => 'Speichern und alle Bestellungen wiedergeben',
+    'Save and return to all orders' => 'Speichern und zur Bestellungsübersicht zurückkehren',
     'Save and set rules' => 'Speichern und Regeln angeben',
     'Save as a new rule' => 'Als eine neue Regel speichern',
     'Save' => 'Speichern',


### PR DESCRIPTION
Fixes one German translation.

`wiedergeben` means to play back, which doesn't make sense in this context.