### PR TITLE
Fixed shipping zone address condition not showing custom field rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where custom field conditions weren’t showing when editing a shipping zone.
+
 ## 4.2.9 - 2023-05-25
 
 - The `commerce/cart/update-cart` action now accepts `clearAddresses`, `clearBillingAddress`, and `clearShippingAddress` params.
 - Fixed a JavaScript error that occurred when switching control panel tabs on small screens. ([#3162](https://github.com/craftcms/commerce/issues/3162))
 - Fixed a bug where the `commerce/upgrade` command wasn’t migrating discounts’ and coupons’ Max Uses values properly. ([#2947](https://github.com/craftcms/commerce/issues/2947))
-- Fixed a bug where custom field conditions weren’t showing when editing a shipping zone.
 
 ## 4.2.8 - 2023-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The `commerce/cart/update-cart` action now accepts `clearAddresses`, `clearBillingAddress`, and `clearShippingAddress` params.
 - Fixed a JavaScript error that occurred when switching control panel tabs on small screens. ([#3162](https://github.com/craftcms/commerce/issues/3162))
 - Fixed a bug where the `commerce/upgrade` command wasn’t migrating discounts’ and coupons’ Max Uses values properly. ([#2947](https://github.com/craftcms/commerce/issues/2947))
+- Fixed a bug where custom field conditions weren’t showing when editing a shipping zone.
 
 ## 4.2.8 - 2023-05-03
 

--- a/src/base/Zone.php
+++ b/src/base/Zone.php
@@ -11,6 +11,7 @@ use craft\elements\Address;
 use craft\helpers\Json;
 use craft\validators\UniqueValidator;
 use DateTime;
+use yii\base\InvalidConfigException;
 
 /**
  * @property string $cpEditUrl
@@ -63,11 +64,12 @@ abstract class Zone extends BaseModel implements ZoneInterface
     /**
      * @param ZoneAddressCondition|string|array|null $condition
      * @return void
+     * @throws InvalidConfigException
      */
     public function setCondition(ZoneAddressCondition|string|array|null $condition): void
     {
         if ($condition === null) {
-            $condition = new ZoneAddressCondition();
+            $condition = new ZoneAddressCondition(Address::class);
         }
 
         if (is_string($condition)) {
@@ -76,6 +78,10 @@ abstract class Zone extends BaseModel implements ZoneInterface
 
         if (!$condition instanceof ZoneAddressCondition) {
             $condition['class'] = ZoneAddressCondition::class;
+
+            // @TODO remove at next breaking change. Fix for misconfiguration during 3.x -> 4.x migration
+            $condition['elementType'] = Address::class;
+
             /** @var ZoneAddressCondition $condition */
             $condition = Craft::$app->getConditions()->createCondition($condition);
         }

--- a/src/models/Store.php
+++ b/src/models/Store.php
@@ -201,7 +201,7 @@ class Store extends Model
      */
     public function getMarketAddressCondition(): ZoneAddressCondition
     {
-        return $this->_marketAddressCondition ?? new ZoneAddressCondition();
+        return $this->_marketAddressCondition ?? new ZoneAddressCondition(Address::class);
     }
 
     /**
@@ -211,7 +211,7 @@ class Store extends Model
     public function setMarketAddressCondition(ZoneAddressCondition|string|array|null $condition): void
     {
         if ($condition === null) {
-            $condition = new ZoneAddressCondition();
+            $condition = new ZoneAddressCondition(Address::class);
         }
 
         if (is_string($condition)) {
@@ -220,6 +220,10 @@ class Store extends Model
 
         if (!$condition instanceof ZoneAddressCondition) {
             $condition['class'] = ZoneAddressCondition::class;
+
+            // @TODO remove at next breaking change. Fix for misconfiguration during 3.x -> 4.x migration
+            $condition['elementType'] = Address::class;
+
             /** @var ZoneAddressCondition|mixed $condition */
             $condition = Craft::$app->getConditions()->createCondition($condition);
         }


### PR DESCRIPTION
### Description
After migration from `3.x` to `4.x` shipping zones that were migrated were unable to add a custom field condition rule to their address condition builder. If the zone was resaved or a new zone was created custom field conditions rules were available.