### PR TITLE
Fix version number in composer.json for 3.4.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
   },
   "extra": {
     "handle": "commerce",
-    "version": "3.4.21",
+    "version": "3.4.22",
     "name": "Craft Commerce",
     "description": "Create beautifully bespoke ecommerce experiences",
     "developer": "Pixel & Tonic",


### PR DESCRIPTION
composer.json for v3.4.22 is incorrectly set as v3.4.21 resulting in Craft's plugin update page prompting to update even when the latest version is installed.