### PR TITLE
Add `ModifyPurchasablesQueryEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.3.0 - Unreleased
 
-- It’s now possible to modify the purchasables shown in the add line item table on the Edit Order page.
+- It’s now possible to modify the purchasables shown in the add line item table on the Edit Order page. ([#3194](https://github.com/craftcms/commerce/issues/3194))
 - Added `craft\commerce\events\ModifyPurchasablesQueryEvent`.
 - Added `craft\commerce\controllers\OrdersController::EVENT_MODIFY_PURCHASABLES_QUERY`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Craft Commerce
 
+## 4.3.0 - Unreleased
+
+- It’s now possible to modify the purchasables shown in the add line item table on the Edit Order page.
+- Added `craft\commerce\events\ModifyPurchasablesQueryEvent`.
+- Added `craft\commerce\controllers\OrdersController::EVENT_MODIFY_PURCHASABLES_QUERY`.
+
 ## Unreleased
 
 - Fixed a bug where changing a user’s email would cause extra user elements to be created. ([#3138](https://github.com/craftcms/commerce/issues/3138))

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -18,6 +18,7 @@ use craft\commerce\errors\CurrencyException;
 use craft\commerce\errors\OrderStatusException;
 use craft\commerce\errors\RefundException;
 use craft\commerce\errors\TransactionException;
+use craft\commerce\events\ModifyPurchasablesQueryEvent;
 use craft\commerce\gateways\MissingGateway;
 use craft\commerce\helpers\Currency;
 use craft\commerce\helpers\DebugPanel;
@@ -72,6 +73,26 @@ use yii\web\Response;
  */
 class OrdersController extends Controller
 {
+    /**
+     * @event Event The event that’s triggered when retrieving the purchasables for the add line item table on the order edit page.
+     *
+     * ---
+     * ```php
+     * use craft\commerce\controllers\OrdersController;
+     * use craft\commerce\events\ModifyPurchasablesQueryEvent;
+     * use yii\base\Event;
+     *
+     * Event::on(
+     *     OrdersController::class,
+     *     OrdersController::EVENT_MODIFY_PURCHASABLES_QUERY,
+     *     function(ModifyCartInfoEvent $e) {
+     *         $e->query->andWhere(['sku' => 'foo']);
+     *     }
+     * );
+     * ```
+     */
+    public const EVENT_MODIFY_PURCHASABLES_QUERY = 'modifyPurchasablesQuery';
+
     /**
      * @throws HttpException
      * @throws InvalidConfigException
@@ -542,10 +563,21 @@ class OrdersController extends Controller
             $sqlQuery->orderBy(['id' => 'asc']);
         }
 
+        // Trigger event before working out the total and limiting the results for pagination
+        if ($this->hasEventHandlers(self::EVENT_MODIFY_PURCHASABLES_QUERY)) {
+            $event = new ModifyPurchasablesQueryEvent([
+                'query' => $sqlQuery,
+                'search' => $search,
+            ]);
+            $this->trigger(self::EVENT_MODIFY_PURCHASABLES_QUERY, $event);
+            $sqlQuery = $event->query;
+        }
+
         $total = $sqlQuery->count();
 
         $sqlQuery->limit($limit);
         $sqlQuery->offset($offset);
+
         $result = $sqlQuery->all();
 
         $purchasables = $this->_addLivePurchasableInfo($result);

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -75,6 +75,7 @@ class OrdersController extends Controller
 {
     /**
      * @event Event The event that’s triggered when retrieving the purchasables for the add line item table on the order edit page.
+     * @since 4.3.0
      *
      * ---
      * ```php

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -18,7 +18,7 @@ use craft\commerce\errors\CurrencyException;
 use craft\commerce\errors\OrderStatusException;
 use craft\commerce\errors\RefundException;
 use craft\commerce\errors\TransactionException;
-use craft\commerce\events\ModifyPurchasablesQueryEvent;
+use craft\commerce\events\ModifyPurchasablesTableQueryEvent;
 use craft\commerce\gateways\MissingGateway;
 use craft\commerce\helpers\Currency;
 use craft\commerce\helpers\DebugPanel;
@@ -85,14 +85,14 @@ class OrdersController extends Controller
      *
      * Event::on(
      *     OrdersController::class,
-     *     OrdersController::EVENT_MODIFY_PURCHASABLES_QUERY,
+     *     OrdersController::EVENT_MODIFY_PURCHASABLES_TABLE_QUERY,
      *     function(ModifyCartInfoEvent $e) {
      *         $e->query->andWhere(['sku' => 'foo']);
      *     }
      * );
      * ```
      */
-    public const EVENT_MODIFY_PURCHASABLES_QUERY = 'modifyPurchasablesQuery';
+    public const EVENT_MODIFY_PURCHASABLES_TABLE_QUERY = 'modifyPurchasablesTableQuery';
 
     /**
      * @throws HttpException
@@ -565,12 +565,12 @@ class OrdersController extends Controller
         }
 
         // Trigger event before working out the total and limiting the results for pagination
-        if ($this->hasEventHandlers(self::EVENT_MODIFY_PURCHASABLES_QUERY)) {
-            $event = new ModifyPurchasablesQueryEvent([
+        if ($this->hasEventHandlers(self::EVENT_MODIFY_PURCHASABLES_TABLE_QUERY)) {
+            $event = new ModifyPurchasablesTableQueryEvent([
                 'query' => $sqlQuery,
                 'search' => $search,
             ]);
-            $this->trigger(self::EVENT_MODIFY_PURCHASABLES_QUERY, $event);
+            $this->trigger(self::EVENT_MODIFY_PURCHASABLES_TABLE_QUERY, $event);
             $sqlQuery = $event->query;
         }
 

--- a/src/events/ModifyPurchasablesQueryEvent.php
+++ b/src/events/ModifyPurchasablesQueryEvent.php
@@ -7,7 +7,6 @@
 
 namespace craft\commerce\events;
 
-use craft\commerce\elements\Order;
 use craft\db\Query;
 use yii\base\Event;
 

--- a/src/events/ModifyPurchasablesQueryEvent.php
+++ b/src/events/ModifyPurchasablesQueryEvent.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use craft\commerce\elements\Order;
+use craft\db\Query;
+use yii\base\Event;
+
+/**
+ * ModifyPurchasablesQueryEvent class.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.3.0
+ */
+class ModifyPurchasablesQueryEvent extends Event
+{
+    /**
+     * @var Query
+     */
+    public Query $query;
+
+    /**
+     * @var string|null The search term that is being used in the query, if any
+     */
+    public ?string $search = null;
+}

--- a/src/events/ModifyPurchasablesTableQueryEvent.php
+++ b/src/events/ModifyPurchasablesTableQueryEvent.php
@@ -11,12 +11,12 @@ use craft\db\Query;
 use yii\base\Event;
 
 /**
- * ModifyPurchasablesQueryEvent class.
+ * ModifyPurchasablesTableQueryEvent class.
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.3.0
  */
-class ModifyPurchasablesQueryEvent extends Event
+class ModifyPurchasablesTableQueryEvent extends Event
 {
     /**
      * @var Query


### PR DESCRIPTION
### Description
This event gives developers the opportunity to modify the query that is used when retrieving purchasables for the "add a line item" table on the order edit page.

Example usage:
```php
use craft\commerce\controllers\OrdersController;
use craft\commerce\events\ModifyPurchasablesTableQueryEvent;
// ...
Event::on(
    OrdersController::class,
    OrdersController::EVENT_MODIFY_PURCHASABLES_TABLE_QUERY,
    function(ModifyPurchasablesTableQueryEvent $event) {
        $likeOperator = Craft::$app->getDb()->getIsPgsql() ? 'ILIKE' : 'LIKE';
        $event->query->andWhere([$likeOperator, 'sku', 'foo']);
    }
);
```

#### To Review
- [x] Event naming
- [x] Example in PHPdoc

### Related issues
#3194 
