### PR TITLE
Deprecate `email` as an attribute on the `Order` element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.3.0 - Unreleased
 
-- PLACEHOLDER
+- Deprecated `craft\commerce\elements\Order::setEmail()`. `Order::setCustomer()` should be used instead.
 
 ## Unreleased
 

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -221,7 +221,8 @@ class CartController extends BaseFrontEndController
             $email = $this->request->getParam('email');
             if ($email && ($this->_cart->getEmail() === null || $this->_cart->getEmail() != $email)) {
                 try {
-                    $this->_cart->setEmail($email);
+                    $user = Craft::$app->getUsers()->ensureUserByEmail($email);
+                    $this->_cart->setCustomer($user);
                 } catch (\Exception $e) {
                     $this->_cart->addError('email', $e->getMessage());
                 }

--- a/src/elements/db/OrderQuery.php
+++ b/src/elements/db/OrderQuery.php
@@ -1412,6 +1412,14 @@ class OrderQuery extends ElementQuery
      */
     public function populate($rows): array
     {
+        // @TODO remove at next breaking change
+        // Remove `email` key from each row.
+        array_walk($rows, function(&$row) {
+            if (array_key_exists('email', $row)) {
+                unset($row['email']);
+            }
+        });
+
         /** @var Order[] $orders */
         $orders = parent::populate($rows);
 
@@ -1463,7 +1471,10 @@ class OrderQuery extends ElementQuery
             'commerce_orders.couponCode',
             'commerce_orders.orderStatusId',
             'commerce_orders.dateOrdered',
+
+            // @TODO remove at next breaking change
             'commerce_orders.email',
+
             'commerce_orders.isCompleted',
             'commerce_orders.datePaid',
             'commerce_orders.currency',
@@ -1536,7 +1547,9 @@ class OrderQuery extends ElementQuery
         }
 
         if (isset($this->email) && $this->email) {
-            $this->subQuery->andWhere(Db::parseParam('commerce_orders.email', $this->email, '=', true));
+            // Join and search the users table for email address
+            $this->subQuery->leftJoin(CraftTable::USERS . ' users', '[[users.id]] = [[commerce_orders.customerId]]');
+            $this->subQuery->andWhere(Db::parseParam('users.email', $this->email, '=', true));
         }
 
         // Allow true ot false but not null

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -153,10 +153,9 @@ class Carts extends Component
         $this->_cart->paymentCurrency = $this->_getCartPaymentCurrencyIso();
         $this->_cart->origin = Order::ORIGIN_WEB;
 
-        if ($currentUser) {
-            if ($this->_cart->getCustomer() === null || ($currentUser->email && $currentUser->email !== $this->_cart->email)) {
-                $this->_cart->setEmail($currentUser->email); // Will ensure the customer is also set
-            }
+        // Switch the cart customer if needed
+        if ($currentUser && ($this->_cart->getCustomer() === null || ($currentUser->email && $currentUser->email !== $this->_cart->getEmail()))) {
+            $this->_cart->setCustomer($currentUser);
         }
 
         $hasIpChanged = $originalIp != $this->_cart->lastIp;

--- a/tests/unit/elements/order/OrderCustomerTest.php
+++ b/tests/unit/elements/order/OrderCustomerTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace unit\elements\order;
+
+use Codeception\Test\Unit;
+use craft\commerce\elements\Order;
+use craft\services\Deprecator;
+use craftcommercetests\fixtures\OrdersFixture;
+use UnitTester;
+use yii\base\Exception;
+use yii\base\InvalidConfigException;
+
+/**
+ * OrderCustomerTest
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 4.3.0
+ */
+class OrderCustomerTest extends Unit
+{
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
+
+    /**
+     * @return array
+     */
+    public function _fixtures(): array
+    {
+        return [
+            'orders' => [
+                'class' => OrdersFixture::class,
+            ],
+        ];
+    }
+
+    /**
+     * @param string $email
+     * @return void
+     * @throws Exception
+     * @throws InvalidConfigException
+     * @dataProvider emailDataProvider
+     */
+    public function testSetEmail(string $email): void
+    {
+        \Craft::$app->set('deprecator', $this->make(Deprecator::class, [
+            'log' => function(string $key, string $message, ?string $file = null, ?int $line = null) {
+                self::once();
+                self::assertEquals(Order::class . '::setEmail', $key);
+            },
+        ]));
+
+        $order = new Order();
+        $order->setEmail($email);
+
+        self::assertEquals($email, $order->getEmail());
+        self::assertNotNull($order->getCustomer());
+        self::assertEquals($email, $order->getCustomer()->email);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function emailDataProvider(): array
+    {
+        return [
+            'existing-credentialed-user' => ['email' => 'customer1@crafttest.com'],
+            'existing-inactive-user' => ['email' => 'inactive.user@crafttest.com'],
+        ];
+    }
+
+    /**
+     * @param string $email
+     * @return void
+     * @dataProvider customerDataProvider
+     */
+    public function testSetCustomer(string $email): void
+    {
+        $user = \Craft::$app->getUsers()->getUserByUsernameOrEmail($email);
+        $order = new Order();
+        $order->setCustomer($user);
+
+        self::assertEquals($email, $order->getEmail());
+        self::assertNotNull($order->getCustomer());
+        self::assertEquals($email, $order->getCustomer()->email);
+        self::assertEquals($user->id, $order->getCustomer()->id);
+        self::assertEquals($user->id, $order->getCustomerId());
+
+        // Test remove customer
+        $order->setCustomer();
+        self::assertNull($order->getCustomer());
+        self::assertNull($order->getCustomerId());
+        self::assertNull($order->getEmail());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function customerDataProvider(): array
+    {
+        return [
+            'existing-credentialed-user' => ['email' => 'customer1@crafttest.com'],
+            'existing-inactive-user' => ['email' => 'inactive.user@crafttest.com'],
+        ];
+    }
+}

--- a/tests/unit/elements/order/OrderMarkAsCompleteTest.php
+++ b/tests/unit/elements/order/OrderMarkAsCompleteTest.php
@@ -60,7 +60,8 @@ class OrderMarkAsCompleteTest extends Unit
     {
         $order = new Order();
         $email = 'test@newemailaddress.xyz';
-        $order->setEmail($email);
+        $user = \Craft::$app->getUsers()->ensureUserByEmail($email);
+        $order->setCustomer($user);
         /** @var Order $order */
         $completedOrder = $this->tester->grabFixture('orders')->getElement('completed-new');
         $lineItem = $completedOrder->getLineItems()[0];
@@ -80,7 +81,7 @@ class OrderMarkAsCompleteTest extends Unit
         self::assertEquals($email, $order->orderCompletedEmail);
 
         $this->_deleteElementIds[] = $order->id;
-        $this->_deleteElementIds[] = $order->getCustomerId();
+        $this->_deleteElementIds[] = $user->id;
     }
 
     /**

--- a/tests/unit/services/OrdersTest.php
+++ b/tests/unit/services/OrdersTest.php
@@ -98,12 +98,15 @@ class OrdersTest extends Unit
 
     public function testGetOrdersByEmail(): void
     {
-        $orders = $this->service->getOrdersByEmail($this->fixtureData->getElement('completed-new')->email);
+        /** @var Order $orderFixture */
+        $orderFixture = $this->fixtureData->getElement('completed-new');
+        $email = $orderFixture->getEmail();
+        $orders = $this->service->getOrdersByEmail($email);
 
         self::assertIsArray($orders);
         self::assertCount(3, $orders);
         foreach ($orders as $order) {
-            self::assertEquals($this->fixtureData->getElement('completed-new')->email, $order->email);
+            self::assertEquals($email, $order->getEmail());
         }
     }
 }


### PR DESCRIPTION
### Description
Currently Commerce is needlessly duplicating data into the `email` column for the order element. As all customers are now user elements (either credentialed or inactive) the email for the order can be taken directly from this.

This is the first part of a two step process to remove `email` as an actual attribute on the `Order` element. In this step it is simply to tidy up the code around emails and deprecate the `setEmail()` on the element. The second part, likely to be in Commerce 5, will be to remove the `email` column entirely from the orders database table.

With `setEmail()` now being deprecated it is advised to switch any code using the method to use `setCustomer` along with the `ensureUserByEmail()` method from Craft's user service.
