### PR TITLE
Variable name typos

### DIFF
--- a/src/base/PlanInterface.php
+++ b/src/base/PlanInterface.php
@@ -21,5 +21,5 @@ interface PlanInterface
     /**
      * Returns whether it's possible to switch to this plan from a different plan.
      */
-    public function canSwitchFrom(PlanInterface $currentPlant): bool;
+    public function canSwitchFrom(PlanInterface $currentPlan): bool;
 }

--- a/src/models/subscriptions/DummyPlan.php
+++ b/src/models/subscriptions/DummyPlan.php
@@ -21,7 +21,7 @@ class DummyPlan extends Plan
     /**
      * @inheritdoc
      */
-    public function canSwitchFrom(PlanInterface $currentPlant): bool
+    public function canSwitchFrom(PlanInterface $currentPlan): bool
     {
         return true;
     }


### PR DESCRIPTION
`$currentPlan` had an extra `t` at the end in a couple of instances!

~~This is an inconsequential patch—in both cases, the variable wasn't actually used in-scope… and to my knowledge, interfaces aren't required to have the same argument names (just the types).~~

See below! 😬

🌱