### PR TITLE
[4.x] Additional Generators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     "codeception/module-yii2": "^1.0.0",
     "craftcms/ckeditor": "^3.0",
     "craftcms/ecs": "dev-main",
+    "craftcms/generator": "^1.5",
     "craftcms/phpstan": "dev-main",
     "craftcms/rector": "dev-main",
     "craftcms/redactor": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ca19d91c0d39483a103ed4da20fa2cf",
+    "content-hash": "38bc045fe255183c3f3575b6c6488569",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -7792,6 +7792,65 @@
             "time": "2022-06-30T16:27:12+00:00"
         },
         {
+            "name": "craftcms/generator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/craftcms/generator.git",
+                "reference": "e8f5970fc294da2431933f5d13095911ae99117a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/craftcms/generator/zipball/e8f5970fc294da2431933f5d13095911ae99117a",
+                "reference": "e8f5970fc294da2431933f5d13095911ae99117a",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^4.4.11",
+                "nette/php-generator": "^4.0",
+                "nikic/php-parser": "^4.15",
+                "php": "^8.0.2"
+            },
+            "require-dev": {
+                "craftcms/ecs": "dev-main",
+                "craftcms/phpstan": "dev-main",
+                "pestphp/pest": "^1.22"
+            },
+            "type": "yii2-extension",
+            "extra": {
+                "bootstrap": "craft\\generator\\Extension"
+            },
+            "autoload": {
+                "psr-4": {
+                    "craft\\generator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "mit"
+            ],
+            "authors": [
+                {
+                    "name": "Pixel & Tonic",
+                    "homepage": "https://pixelandtonic.com/"
+                }
+            ],
+            "description": "Craft CMS component generator",
+            "homepage": "https://craftcms.com",
+            "keywords": [
+                "cms",
+                "craftcms",
+                "yii2"
+            ],
+            "support": {
+                "email": "support@craftcms.com",
+                "issues": "https://github.com/craftcms/generator/issues?state=open",
+                "rss": "https://github.com/craftcms/generator/releases.atom",
+                "source": "https://github.com/craftcms/generator"
+            },
+            "time": "2023-05-15T17:18:45+00:00"
+        },
+        {
             "name": "craftcms/html-field",
             "version": "2.0.7",
             "source": {
@@ -8308,6 +8367,162 @@
                 }
             ],
             "time": "2023-03-08T13:26:56+00:00"
+        },
+        {
+            "name": "nette/php-generator",
+            "version": "v4.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/php-generator.git",
+                "reference": "de1843fbb692125e307937c85d43937d0dc0c1d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/de1843fbb692125e307937c85d43937d0dc0c1d4",
+                "reference": "de1843fbb692125e307937c85d43937d0dc0c1d4",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^3.2.9 || ^4.0",
+                "php": ">=8.0 <8.3"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "dev-master",
+                "nette/tester": "^2.4",
+                "nikic/php-parser": "^4.15",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.8"
+            },
+            "suggest": {
+                "nikic/php-parser": "to use ClassType::from(withBodies: true) & ClassType::fromCode()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 8.2 features.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "code",
+                "nette",
+                "php",
+                "scaffolding"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/php-generator/issues",
+                "source": "https://github.com/nette/php-generator/tree/v4.0.7"
+            },
+            "time": "2023-04-26T15:09:53+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "cacdbf5a91a657ede665c541eda28941d4b09c1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/cacdbf5a91a657ede665c541eda28941d4b09c1e",
+                "reference": "cacdbf5a91a657ede665c541eda28941d4b09c1e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0 <8.3"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "dev-master",
+                "nette/tester": "^2.4",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
+                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.0.0"
+            },
+            "time": "2023-02-02T10:41:53+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,6 +34,7 @@ use craft\commerce\fields\Products as ProductsField;
 use craft\commerce\fields\Variants as VariantsField;
 use craft\commerce\generators\Adjuster;
 use craft\commerce\generators\Gateway as GatewayGenerator;
+use craft\commerce\generators\ShippingMethod;
 use craft\commerce\gql\interfaces\elements\Product as GqlProductInterface;
 use craft\commerce\gql\interfaces\elements\Variant as GqlVariantInterface;
 use craft\commerce\gql\queries\Product as GqlProductQueries;
@@ -1045,6 +1046,7 @@ class Plugin extends BasePlugin
             Event::on(Command::class, Command::EVENT_REGISTER_GENERATOR_TYPES, function (RegisterComponentTypesEvent $event) {
                 $event->types[] = Adjuster::class;
                 $event->types[] = GatewayGenerator::class;
+                $event->types[] = ShippingMethod::class;
             });
         }
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -32,6 +32,7 @@ use craft\commerce\fieldlayoutelements\VariantsField as VariantsLayoutElement;
 use craft\commerce\fieldlayoutelements\VariantTitleField;
 use craft\commerce\fields\Products as ProductsField;
 use craft\commerce\fields\Variants as VariantsField;
+use craft\commerce\generators\Gateway as GatewayGenerator;
 use craft\commerce\gql\interfaces\elements\Product as GqlProductInterface;
 use craft\commerce\gql\interfaces\elements\Variant as GqlVariantInterface;
 use craft\commerce\gql\queries\Product as GqlProductQueries;
@@ -114,6 +115,7 @@ use craft\events\RegisterGqlSchemaComponentsEvent;
 use craft\events\RegisterGqlTypesEvent;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\fixfks\controllers\RestoreController;
+use craft\generator\Command;
 use craft\gql\ElementQueryConditionBuilder;
 use craft\helpers\Console;
 use craft\helpers\Db;
@@ -254,6 +256,7 @@ class Plugin extends BasePlugin
         $this->_registerCacheTypes();
         $this->_registerGarbageCollection();
         $this->_registerDebugPanels();
+        $this->_registerGenerators();
 
         if ($request->getIsConsoleRequest()) {
             $this->_defineResaveCommand();
@@ -1027,6 +1030,20 @@ class Plugin extends BasePlugin
         if ($this->getSettings()->showEditUserCommerceTab) {
             Craft::$app->getView()->hook('cp.users.edit', [$this->getCustomers(), 'addEditUserCommerceTab']);
             Craft::$app->getView()->hook('cp.users.edit.content', [$this->getCustomers(), 'addEditUserCommerceTabContent']);
+        }
+    }
+
+    /**
+     * Registers custom generators for Commerce components.
+     *
+     * @since 4.3
+     */
+    private function _registerGenerators(): void
+    {
+        if (class_exists(Command::class)) {
+            Event::on(Command::class, Command::EVENT_REGISTER_GENERATOR_TYPES, function (RegisterComponentTypesEvent $event) {
+                $event->types[] = GatewayGenerator::class;
+            });
         }
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1043,7 +1043,7 @@ class Plugin extends BasePlugin
     private function _registerGenerators(): void
     {
         if (class_exists(Command::class)) {
-            Event::on(Command::class, Command::EVENT_REGISTER_GENERATOR_TYPES, function (RegisterComponentTypesEvent $event) {
+            Event::on(Command::class, Command::EVENT_REGISTER_GENERATOR_TYPES, function(RegisterComponentTypesEvent $event) {
                 $event->types[] = Adjuster::class;
                 $event->types[] = GatewayGenerator::class;
                 $event->types[] = ShippingMethod::class;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -32,6 +32,7 @@ use craft\commerce\fieldlayoutelements\VariantsField as VariantsLayoutElement;
 use craft\commerce\fieldlayoutelements\VariantTitleField;
 use craft\commerce\fields\Products as ProductsField;
 use craft\commerce\fields\Variants as VariantsField;
+use craft\commerce\generators\Adjuster;
 use craft\commerce\generators\Gateway as GatewayGenerator;
 use craft\commerce\gql\interfaces\elements\Product as GqlProductInterface;
 use craft\commerce\gql\interfaces\elements\Variant as GqlVariantInterface;
@@ -1042,6 +1043,7 @@ class Plugin extends BasePlugin
     {
         if (class_exists(Command::class)) {
             Event::on(Command::class, Command::EVENT_REGISTER_GENERATOR_TYPES, function (RegisterComponentTypesEvent $event) {
+                $event->types[] = Adjuster::class;
                 $event->types[] = GatewayGenerator::class;
             });
         }

--- a/src/generators/Adjuster.php
+++ b/src/generators/Adjuster.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace craft\commerce\generators;
+
+use Craft;
+use Nette\PhpGenerator\PhpNamespace;
+use craft\base\Component;
+use craft\commerce\base\AdjusterInterface;
+use craft\commerce\helpers\Currency;
+use craft\commerce\models\OrderAdjustment;
+use craft\commerce\services\OrderAdjustments;
+use craft\generator\BaseGenerator;
+use Illuminate\Support\Collection;
+use yii\helpers\Inflector;
+
+/**
+ * Creates a new order adjuster class.
+ */
+class Adjuster extends BaseGenerator
+{
+    private string $className;
+    private string $namespace;
+    private string $displayName;
+
+    public function run(): bool
+    {
+        $this->className = $this->classNamePrompt('Adjuster name:', [
+            'required' => true,
+        ]);
+
+        $this->namespace = $this->namespacePrompt('Adjuster namespace:', [
+            'default' => "$this->baseNamespace\\adjusters",
+        ]);
+
+        $this->displayName = Inflector::camel2words($this->className);
+
+        $namespace = (new PhpNamespace($this->namespace))
+            ->addUse(Craft::class)
+            ->addUse(Component::class)
+            ->addUse(AdjusterInterface::class)
+            ->addUse(OrderAdjustment::class)
+            ->addUse(Currency::class);
+
+        $class = $this->createClass($this->className, Component::class, [
+            self::CLASS_IMPLEMENTS => [
+                AdjusterInterface::class,
+            ],
+            self::CLASS_METHODS => [
+                'adjust' => <<<PHP
+\$adjustments = [];
+
+// This adjuster only cares about individual items. Yours may need to perform deeper analysis of the cart’s contents to determine whether an item (or items) need an adjustment, or which item (if any) the adjustment should be applied to.
+foreach (\$order->getLineItems() as \$lineItem) {
+    if (\$lineItem->qty >= 10) {
+        \$adjustment = new OrderAdjustment();
+        \$adjustment->setLineItem(\$lineItem); // Optional!
+        \$adjustment->setOrder(\$order);
+        \$adjustment->type = 'discount';
+        \$adjustment->amount = Currency::round(\$lineItem->qty * \$lineItem->salePrice * -0.1);
+        \$adjustment->name = 'Bulk Discount';
+        \$adjustment->description = '10% off when you buy 10 or more!';
+
+        \$adjustments[] = \$adjustment;
+    }
+}
+
+return \$adjustments;
+PHP,
+            ],
+        ]);
+        $namespace->add($class);
+
+        $class->setComment(<<<MD
+$this->displayName adjuster
+
+Grants 10% off when ordering in bulk.
+MD);
+
+        $this->writePhpClass($namespace);
+
+        if (
+            $this->isForModule() &&
+            !$this->addRegistrationEventHandlerCode(
+                OrderAdjustments::class,
+                'EVENT_REGISTER_ORDER_ADJUSTERS',
+                "$this->namespace\\$this->className",
+                $fallbackExample,
+            )
+        ) {
+            $moduleFile = $this->moduleFile();
+            $this->command->note(<<<MD
+Add the following code to `$moduleFile` to register the adjuster:
+
+```
+$fallbackExample
+```
+MD);
+        }
+
+        $this->command->success("**Adjuster created!**");
+        return true;
+    }
+}

--- a/src/generators/Adjuster.php
+++ b/src/generators/Adjuster.php
@@ -10,7 +10,7 @@ use craft\commerce\helpers\Currency;
 use craft\commerce\models\OrderAdjustment;
 use craft\commerce\services\OrderAdjustments;
 use craft\generator\BaseGenerator;
-use Illuminate\Support\Collection;
+use Nette\PhpGenerator\Constant;
 use yii\helpers\Inflector;
 
 /**
@@ -68,6 +68,12 @@ return \$adjustments;
 PHP,
             ],
         ]);
+
+        $typeConstant = new Constant('ADJUSTMENT_TYPE');
+        $typeConstant->setValue('discount');
+        $typeConstant->setComment('Must be one of `discount`, `shipping`, or `tax`.');
+
+        $class->addMember($typeConstant);
         $namespace->add($class);
 
         $class->setComment(<<<MD

--- a/src/generators/Adjuster.php
+++ b/src/generators/Adjuster.php
@@ -3,7 +3,6 @@
 namespace craft\commerce\generators;
 
 use Craft;
-use Nette\PhpGenerator\PhpNamespace;
 use craft\base\Component;
 use craft\commerce\base\AdjusterInterface;
 use craft\commerce\helpers\Currency;
@@ -11,6 +10,7 @@ use craft\commerce\models\OrderAdjustment;
 use craft\commerce\services\OrderAdjustments;
 use craft\generator\BaseGenerator;
 use Nette\PhpGenerator\Constant;
+use Nette\PhpGenerator\PhpNamespace;
 use yii\helpers\Inflector;
 
 /**

--- a/src/generators/Gateway.php
+++ b/src/generators/Gateway.php
@@ -3,7 +3,6 @@
 namespace craft\commerce\generators;
 
 use Craft;
-use Nette\PhpGenerator\PhpNamespace;
 use craft\commerce\base\Gateway as BaseGateway;
 use craft\commerce\base\Plan;
 use craft\commerce\base\RequestResponseInterface;
@@ -24,6 +23,7 @@ use craft\generator\BaseGenerator;
 use craft\helpers\DateTimeHelper;
 use craft\web\Response as WebResponse;
 use craft\web\View;
+use Nette\PhpGenerator\PhpNamespace;
 use yii\helpers\Inflector;
 
 /**

--- a/src/generators/Gateway.php
+++ b/src/generators/Gateway.php
@@ -1,0 +1,471 @@
+<?php
+
+namespace craft\commerce\generators;
+
+use Craft;
+use Nette\PhpGenerator\PhpNamespace;
+use craft\commerce\base\Gateway as BaseGateway;
+use craft\commerce\base\Plan;
+use craft\commerce\base\RequestResponseInterface;
+use craft\commerce\base\SubscriptionGateway;
+use craft\commerce\base\SubscriptionResponseInterface;
+use craft\commerce\elements\Order;
+use craft\commerce\elements\Subscription;
+use craft\commerce\errors\NotImplementedException;
+use craft\commerce\models\payments\BasePaymentForm;
+use craft\commerce\models\PaymentSource;
+use craft\commerce\models\subscriptions\CancelSubscriptionForm;
+use craft\commerce\models\subscriptions\SubscriptionForm;
+use craft\commerce\models\subscriptions\SwitchPlansForm;
+use craft\commerce\models\Transaction;
+use craft\commerce\services\Gateways;
+use craft\elements\User;
+use craft\generator\BaseGenerator;
+use craft\helpers\DateTimeHelper;
+use craft\web\Response as WebResponse;
+use yii\helpers\Inflector;
+
+/**
+ * Creates a new payment gateway.
+ */
+class Gateway extends BaseGenerator
+{
+    private string $className;
+    private string $displayName;
+    private bool $supportsSubscriptions;
+    private string $gatewayNamespace;
+    private string $paymentFormNamespace;
+    private string $responseNamespace;
+
+    public function run(): bool
+    {
+        $this->className = $this->classNamePrompt('Gateway name:', [
+            'required' => true,
+        ]);
+
+        $this->displayName = Inflector::camel2words($this->className);
+
+        $this->supportsSubscriptions = $this->command->confirm('Will your gateway support subscriptions?', true);
+
+        $this->gatewayNamespace = $this->namespacePrompt('Gateway namespace:', [
+            'default' => "$this->baseNamespace\\gateways",
+        ]);
+
+        $this->paymentFormNamespace = $this->namespacePrompt('Payment form namespace:', [
+            'default' => "$this->baseNamespace\\models\\payments",
+        ]);
+
+        $this->responseNamespace = $this->namespacePrompt('Request/response namespace:', [
+            'default' => "$this->baseNamespace\\models\\responses",
+        ]);
+
+        $this->writeGatewayClass();
+        $this->writePaymentFormClass();
+        $this->writeResponseClass();
+
+        if (
+            $this->isForModule() &&
+            !$this->addRegistrationEventHandlerCode(
+                Gateways::class,
+                'EVENT_REGISTER_GATEWAY_TYPES',
+                "$this->gatewayNamespace\\$this->className",
+                $fallbackExample,
+            )
+        ) {
+            $moduleFile = $this->moduleFile();
+            $this->command->note(<<<MD
+Add the following code to `$moduleFile` to register the gateway:
+
+```
+$fallbackExample
+```
+MD);
+        }
+
+        return true;
+    }
+
+    /**
+     * Generates the primary Gateway class.
+     */
+    private function writeGatewayClass(): void
+    {
+        $namespace = (new PhpNamespace($this->gatewayNamespace))
+            ->addUse(Craft::class)
+            ->addUse(User::class)
+            ->addUse(BaseGateway::class)
+            ->addUse(NotImplementedException::class)
+            ->addUse(Order::class)
+            ->addUse(BasePaymentForm::class)
+            ->addUse(RequestResponseInterface::class)
+            ->addUse(PaymentSource::class)
+            ->addUse(Transaction::class)
+            ->addUse(WebResponse::class, 'WebResponse')
+            ->addUse("$this->paymentFormNamespace\\{$this->className}PaymentForm")
+            ->addUse("$this->responseNamespace\\{$this->className}Response");
+
+        $methods = [
+            'displayName' => sprintf('return %s;', $this->messagePhp($this->displayName)),
+            'getPaymentFormHtml' => <<<PHP
+// Return a string or render a template (and don’t forget to register any relevant asset bundles):
+\$view = Craft::\$app->getView();
+
+// If you are implementing this in a module, you will need to register a template root:
+return \$view->renderTemplate('{$this->module->id}/forms/payment', [
+    'gateway' => \$this,
+]);
+PHP,
+            'authorize' => <<<PHP
+    // Use the form data to determine whether the payment can be made:
+    return new {$this->className}Response();
+PHP,
+            'capture' => <<<PHP
+// Finalize an authorized payment with the processor, then return an appropriate response object:
+return new {$this->className}Response();
+PHP,
+            'completeAuthorize' => <<<PHP
+// The customer has returned after authorizing a payment off-site. It may need to be manually captured, later!
+return new {$this->className}Response();
+PHP,
+            'completePurchase' => <<<PHP
+// The customer has returned after completing a payment.
+return new {$this->className}Response();
+PHP,
+            'createPaymentSource' => <<<PHP
+throw new NotImplementedException({$this->messagePhp('This gateway does not support saved payment sources.')});
+PHP,
+            'deletePaymentSource' => <<<PHP
+throw new NotImplementedException({$this->messagePhp('This gateway does not support saved payment sources.')});
+PHP,
+            'getPaymentFormModel' => <<<PHP
+return new {$this->className}PaymentForm();
+PHP,
+            'purchase' => <<<PHP
+// Tell the processor to complete a payment, then populate a response object:
+return new {$this->className}Response();
+PHP,
+            'refund' => <<<PHP
+// Tell the processor to refund the payment, then populate a response object:
+return new {$this->className}Response();
+PHP,
+            'supportsAuthorize' => <<<PHP
+return true;
+PHP,
+            'supportsCapture' => <<<PHP
+return true;
+PHP,
+            'supportsCompleteAuthorize' => <<<PHP
+return true;
+PHP,
+            'supportsCompletePurchase' => <<<PHP
+return true;
+PHP,
+            'supportsPaymentSources' => <<<PHP
+return true;
+PHP,
+            'supportsPurchase' => <<<PHP
+return true;
+PHP,
+            'supportsRefund' => <<<PHP
+return true;
+PHP,
+            'supportsPartialRefund' => <<<PHP
+return true;
+PHP,
+            'supportsPartialPayment' => <<<PHP
+return true;
+PHP,
+            'availableForUseWithOrder' => <<<PHP
+// Make available to all Orders:
+return true;
+PHP,
+            'supportsWebhooks' => <<<PHP
+// Commerce will handle receiving webhooks, but if you return `true` here, you must also implement `processWebhook()`!
+return true;
+PHP,
+            'processWebhook' => <<<PHP
+// Gather + act on data from the request, then return a response (like a controller would):
+\$rawData = Craft::\$app->getRequest()->getRawBody();
+\$data = craft\helpers\Json::decodeIfJson(\$rawData);
+
+\$response = Craft::\$app->getResponse();
+\$response->format = WebResponse::FORMAT_RAW;
+
+// Responses are only seen by the machine that sent the webhook:
+\$response->data = 'Thanks, robot!';
+
+// If an exception is thrown while processing a webhook, Craft will
+// automatically send an HTTP response code >= 400!
+
+return \$response;
+PHP,
+            'getTransactionHashFromWebhook' => <<<PHP
+\$rawData = Craft::\$app->getRequest()->getRawBody();
+\$data = Json::decodeIfJson(\$rawData);
+PHP,
+        ];
+
+        // Additional methods must be implemented to satisfy SubscriptionGatewayInterface:
+        if ($this->supportsSubscriptions) {
+            $methods = array_merge($methods, [
+                'cancelSubscription' => <<<PHP
+// Tell the processor to cancel the subscription, then populate a response object:
+return new {$this->className}SubscriptionResponse();
+PHP,
+                'getNextPaymentAmount' => <<<PHP
+// Return a human-readable description of the next invoice:
+return 'Some formatted price or description!';
+PHP,
+                'getSubscriptionPayments' => <<<PHP
+// Get payments for the provided subscription:
+return [];
+PHP,
+                'refreshPaymentHistory' => <<<PHP
+// Re-load payments for the provided subscription from the provider.
+PHP,
+                'getSubscriptionPlanByReference' => <<<PHP
+// Load a definition for the subscription’s plan from the provider.
+return 'some-plan-identifier';
+PHP,
+                'getSubscriptionPlans' => <<<PHP
+return [];
+PHP,
+                'subscribe' => <<<PHP
+// Create or configure the subscription record with the provider, then return a response:
+\$response = new {$this->className}SubscriptionResponse();
+
+// ...set some properties on the response object...
+
+return \$response;
+PHP,
+                'reactivateSubscription' => <<<PHP
+// Update the subscription with the provider, then populate a response object:
+return new {$this->className}SubscriptionResponse();
+PHP,
+                'switchSubscriptionPlan' => <<<PHP
+// Tell the provider to change plans, then populate a response object:
+return new {$this->className}SubscriptionResponse();
+PHP,
+                'supportsReactivation' => <<<PHP
+return true;
+PHP,
+                'supportsPlanSwitch' => <<<PHP
+// If you return `true`, you must also implement `getSwitchPlansFormHtml()`!
+return false;
+PHP,
+                'getHasBillingIssues' => <<<PHP
+return false;
+PHP,
+                'getBillingIssueDescription' => <<<PHP
+return 'Human-readable description of the issue explains why `getHasBillingIssues()` returns true. This should not be static text!';
+PHP,
+                'getBillingIssueResolveFormHtml' => <<<PHP
+\$view = Craft::\$app->getView();
+
+return \$view->renderTemplate('{$this->module->id}/forms/resolve-billing-issue', [
+    'gateway' => \$this,
+    'subscription' => \$subscription,
+]);
+PHP,
+            ]);
+
+            // Additional `use` statements are required:
+            $namespace
+                ->addUse(SubscriptionGateway::class)
+                ->addUse(Subscription::class)
+                ->addUse(SubscriptionForm::class)
+                ->addUse(SwitchPlansForm::class)
+                ->addUse(CancelSubscriptionForm::class)
+                ->addUse(SubscriptionResponseInterface::class)
+                ->addUse(Plan::class)
+                ->addUse("{$this->responseNamespace}\\{$this->className}SubscriptionResponse");
+        }
+
+        $class = $this->createClass($this->className, $this->supportsSubscriptions ? SubscriptionGateway::class : BaseGateway::class, [
+            self::CLASS_METHODS => $methods,
+        ]);
+        $namespace->add($class);
+
+        $class->setComment(<<<MD
+$this->displayName gateway
+
+You may instead extend {@see craft\commerce\base\SubscriptionGateway} if your gateway should support subscriptions! Additional methods must be implemented for 
+MD);
+        $this->writePhpClass($namespace);
+        $this->command->success("**Gateway created!**");
+
+        // Payment form templates:
+        $paymentFormTemplate = <<<TWIG
+{# Replace this with the HTML your form requires. Keep in mind that any `input` elements’ `name` attributes will be namespaced *after* it is returned from your gateway’s `getPaymentFormHtml()` method! #}
+<input type="hidden" name="customGatewayProperty">
+TWIG;
+
+        $this->command->writeToFile("{$this->basePath}/templates/forms/payment.twig", $paymentFormTemplate);
+
+        $this->command->success("**Created payment templates!**");
+
+        if ($this->supportsSubscriptions) {
+            $cancelSubscriptionForm = <<<TWIG
+{# Any settings you want to give the customer control of (when sending a cancellation request) should be added here. #}
+TWIG;
+            $this->command->writeToFile("{$this->basePath}/templates/forms/subscription-cancel.twig", $cancelSubscriptionForm);
+
+            $cancelSubscriptionForm = <<<TWIG
+{# Any settings you want to give the customer control of (when sending a cancellation request) should be added here. #}
+TWIG;
+            $this->command->writeToFile("{$this->basePath}/templates/forms/subscription-cancel.twig", $cancelSubscriptionForm);
+
+            $this->command->success("**Created subscription templates!**");
+        }
+    }
+
+    /**
+     * Generates a PaymentForm class.
+     */
+    private function writePaymentFormClass(): void
+    {
+        $namespace = (new PhpNamespace($this->paymentFormNamespace))
+        ->addUse(Craft::class)
+        ->addUse(BasePaymentForm::class);
+
+        $class = $this->createClass("{$this->className}PaymentForm", BasePaymentForm::class, [
+            self::CLASS_METHODS => [
+                'populateFromPaymentSource' => <<<PHP
+// Copy properties from the Commerce \$paymentSource model to populate it with a saved payment method.
+// \$this->myGatewayPaymentMethodId = \$paymentSource->token;
+// \$customer = Commerce::getInstance()->getCustomers()->getCustomer(\$paymentSource->gatewayId, \$paymentSource->getCustomer());
+// \$this->myGatewayCustomerId = \$customer->reference;
+PHP,
+                'defineRules' => <<<PHP
+// Validate critical attributes before sending to the gateway to prevent common errors and omissions:
+return [];
+PHP,
+            ],
+        ]);
+
+        $namespace->add($class);
+
+        $class->setComment(<<<COMMENT
+$this->displayName payment form
+
+You may instead extend {@see craft\commerce\models\payments\CreditCardPaymentForm}, if your gateway uses a standard tokenized payment flow!
+COMMENT);
+
+        $this->writePhpClass($namespace);
+        $this->command->success("**Payment form created!**");
+    }
+
+    private function writeResponseClass(): void
+    {
+        $responseNamespace = (new PhpNamespace($this->responseNamespace))
+            ->addUse(Craft::class)
+            ->addUse(RequestResponseInterface::class);
+
+        $paymentResponseClass = $this->createClass("{$this->className}Response", null, [
+            self::CLASS_IMPLEMENTS => [
+                RequestResponseInterface::class,
+            ],
+            self::CLASS_METHODS => [
+                'getData' => <<<PHP
+// Return any data that should be stored along with the transaction (or subscription):
+return [];
+PHP,
+                'isSuccessful' => <<<PHP
+// Does the response indicate the payment was successful?
+return true;
+PHP,
+                'isProcessing' => <<<PHP
+// Does the response indicate the payment is still processing?
+return true;
+PHP,
+                'isRedirect' => <<<PHP
+// Does the response indicate that the customer needs to be directed offsite to complete a payment?
+return false;
+PHP,
+                'getRedirectMethod' => <<<PHP
+// Should the redirection happen naturally via a 300-level GET request, or through an HTML form?
+return 'GET';
+PHP,
+                'getRedirectData' => <<<PHP
+// Key-value pairs that are sent along with offsite redirects:
+return [];
+PHP,
+                'getRedirectUrl' => <<<PHP
+// If `isRedirect()` is `true`, where should the customer be sent?
+return \$this->getData()['complete_payment_url'];
+PHP,
+                'getTransactionReference' => <<<PHP
+// A unique identifier for the transaction, from the gateway:
+return \$this->getData()['...'];
+PHP,
+                'getCode' => <<<PHP
+// Gateway-specific success or error code for the response:
+return 'OK';
+PHP,
+                'getMessage' => <<<PHP
+// An explanation of the state of the request or payment. Your gateway may require more than two “modes,” and those situations might depend on more than just the response’s success state.
+return \$this->isSuccessful() ? {$this->messagePhp('Payment complete.')} : {$this->messagePhp('Payment failed.')};
+PHP,
+                'redirect' => <<<PHP
+// When using `GET` for the redirect method, you have an opportunity to take control of the redirection. Otherwise, Commerce will naturally redirect to the URL returned by `getRedirectUrl()`.
+PHP,
+            ],
+        ]);
+
+        $paymentResponseClass->setComment("$this->displayName payment request response container");
+        $responseNamespace->add($paymentResponseClass);
+
+        $this->writePhpClass($responseNamespace);
+        $this->command->success("**Request/response class for payments created!**");
+
+        if ($this->supportsSubscriptions) {
+            $subscriptionResponseNamespace = (new PhpNamespace($this->responseNamespace))
+                ->addUse(Craft::class)
+                ->addUse(SubscriptionResponseInterface::class)
+                ->addUse(DateTimeHelper::class);
+
+            $subscriptionResponseClass = $this->createClass("{$this->className}SubscriptionResponse", null, [
+                self::CLASS_IMPLEMENTS => [
+                    SubscriptionResponseInterface::class,
+                ],
+                self::CLASS_METHODS => [
+                    'getReference' => <<<PHP
+// Return an identifier for the subscription in the gateway—typically an ID or UUID generated by the processor.
+return \$this->getData()['...'] ?? '';
+PHP,
+                    'getTrialDays' => <<<PHP
+// The time in days that the subscription will be in a "trial" state for.
+return 0;
+PHP,
+                    'getNextPaymentDate' => <<<PHP
+\$data = \$this->getData();
+return DateTimeHelper::toDateTime(\$this->getData()['next_payment_date']);
+PHP,
+                    'isCanceled' => <<<PHP
+// Based on latest information from the gateway, is the subscription in a canceled state?
+return false;
+PHP,
+                    'isScheduledForCancellation' => <<<PHP
+// Based on latest information from the gateway, is the subscription scheduled to be canceled?
+return false;
+PHP,
+                    'isInactive' => <<<PHP
+// Based on latest information from the gateway, is the subscription in an inactive state?
+return false;
+PHP,
+                ],
+            ]);
+
+            $subscriptionResponseClass->setComment(<<<COMMENT
+$this->className subscription response container
+
+You will instantiate and populate this class with data retrieved from your gateway (whatever its source of truth may be). Add a public property and/or a constructor to memoize that data!
+COMMENT);
+
+            $subscriptionResponseNamespace->add($subscriptionResponseClass);
+            $this->writePhpClass($subscriptionResponseNamespace);
+            $this->command->success("**Request/response class for subscriptions created!**");
+        }
+
+    }
+}

--- a/src/generators/ShippingMethod.php
+++ b/src/generators/ShippingMethod.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace craft\commerce\generators;
+
+use Craft;
+use craft\commerce\base\Model;
+use Nette\PhpGenerator\PhpNamespace;
+use craft\commerce\base\ShippingMethodInterface;
+use craft\commerce\base\ShippingRuleInterface;
+use craft\commerce\elements\Order;
+use craft\commerce\models\ShippingRule;
+use craft\generator\BaseGenerator;
+use yii\helpers\Inflector;
+
+/**
+ * Creates a new shipping method.
+ */
+class ShippingMethod extends BaseGenerator
+{
+    private string $className;
+    private string $namespace;
+    private string $displayName;
+
+    public function run(): bool
+    {
+        $this->className = $this->classNamePrompt('Shipping method name:', [
+            'required' => true,
+        ]);
+
+        $this->namespace = $this->namespacePrompt('Shipping method namespace:', [
+            'default' => "$this->baseNamespace\\models",
+        ]);
+
+        $this->displayName = Inflector::camel2words($this->className);
+
+        $id = Inflector::camel2id($this->className);
+
+        $methodNamespace = (new PhpNamespace($this->namespace))
+            ->addUse(Craft::class)
+            ->addUse(Order::class)
+            ->addUse(Model::class)
+            ->addUse(ShippingMethodInterface::class)
+            ->addUse(ShippingRuleInterface::class)
+            ->addUse(ShippingRule::class);
+
+        $methodClass = $this->createClass($this->className, Model::class, [
+            self::CLASS_IMPLEMENTS => [
+                ShippingMethodInterface::class,
+            ],
+            self::CLASS_METHODS => [
+                'getType' => sprintf('return \'%s\';', $id),
+                'getId' => 'return null;',
+                'getName' => sprintf('return \'%s\';', $this->displayName),
+                'getHandle' => <<<PHP
+// If you are registering multiple shipping methods, this should be unique for each instance—perhaps incorporating an ID from a third-party system:
+return 'someStableIdentifier';
+PHP,
+                'getCpEditUrl' => "return '';",
+                'getShippingRules' => <<<PHP
+// Populate an array of `ShippingRule` classes from whatever data source you like. Information could come from a fulfillment or shipping API, be hard-coded, or configured via the control panel—just as the native Commerce methods and rules are!
+// You may also extend the base `ShippingRule` class to store additional data and encapsulate logic.
+return [
+    new ShippingRule([
+        'name' => 'Example {$this->displayName} Rule',
+        'description' => 'This will always match.',
+        'baseRate' => 10.0,
+    ]),
+];
+PHP,
+                'getIsEnabled' => 'return true;',
+                'matchOrder' => <<<PHP
+// Look at `\$order` and decide whether this method should match:
+return true;
+PHP,
+                'getMatchingShippingRule' => <<<PHP
+foreach (\$this->getShippingRules() as \$rule) {
+    /** @var ShippingRuleInterface \$rule */
+    if (\$rule->matchOrder(\$order)) {
+        return \$rule;
+    }
+}
+
+return null;
+PHP,
+                'getPriceForOrder' => <<<PHP
+\$rule = \$this->getMatchingShippingRule(\$order);
+// Calculate the total shipping value for the order based on the matched rule’s rates.
+// See (or extend) `craft\commerce\base\ShippingMethod` for an example implementation that examines each shippable LineItem!
+return \$rule->getBaseRate();
+PHP,
+            ],
+        ]);
+        $methodNamespace->add($methodClass);
+
+        $methodClass->setComment(<<<MD
+$this->displayName shipping method
+
+This class may be instantiated any number of times when registering shipping methods. Each instance should represent a discrete method—but the source of truth about those methods can be anything.
+MD);
+
+        $this->writePhpClass($methodNamespace);
+        $this->command->success("**Shipping method created!**");
+
+        // Finish up, output instructions:
+        $moduleFile = $this->moduleFile();
+        $this->command->note(<<<MD
+To register your shipping method, add the following code to the `init()` or `attachEventHandlers()` methods in `$moduleFile`:
+
+```
+use yii\\base\\Event;
+use craft\\commerce\\services\\ShippingMethods;
+use craft\\commerce\\events\\RegisterAvailableShippingMethodsEvent;
+use {$this->namespace}\\{$this->className};
+
+Event::on(
+    ShippingMethods::class,
+    ShippingMethods::EVENT_REGISTER_AVAILABLE_SHIPPING_METHODS,
+    function(RegisterAvailableShippingMethodsEvent \$event) {
+        \$event->shippingMethods[] = new {$this->className}();
+    }
+);
+```
+
+You may register multiple shipping methods at once, by replacing the body of the event handler with this:
+
+```
+foreach (YourPlugin::getInstance()->getShipping()->getShippingMethods() as \$method) {
+    \$event->shippingMethods[] = \$method;
+}
+```
+
+The service and method we’re invoking here are your responsibility to implement.
+
+Commerce will narrow the returned list to only those whose `matchOrder()` method returns `true`.
+MD);
+
+        $this->command->note(<<<MD
+The manner in which shipping methods can be managed is up to you. Shipping “categories” and “zones” are concepts implemented by (and specific to) the flexible built-in shipping engine. Your shipping method(s) should use other criteria and management tools to customize matching.
+MD);
+
+        $this->command->warning(<<<MD
+Querying an external API? Shipping methods are evaluated frequently. Don’t hold up your customers while you wait for fresh data, unless it’s *absolutely* essential.
+MD);
+
+        return true;
+    }
+}

--- a/src/generators/ShippingMethod.php
+++ b/src/generators/ShippingMethod.php
@@ -4,12 +4,12 @@ namespace craft\commerce\generators;
 
 use Craft;
 use craft\commerce\base\Model;
-use Nette\PhpGenerator\PhpNamespace;
 use craft\commerce\base\ShippingMethodInterface;
 use craft\commerce\base\ShippingRuleInterface;
 use craft\commerce\elements\Order;
 use craft\commerce\models\ShippingRule;
 use craft\generator\BaseGenerator;
+use Nette\PhpGenerator\PhpNamespace;
 use yii\helpers\Inflector;
 
 /**


### PR DESCRIPTION
I was exploring some stuff in the Commerce extension docs and figured it was worth implementing [Generators](https://craftcms.com/docs/4.x/extend/generator.html) for some of the common components. My primary motivation is to have some external examples to point at, and to move some of the fussy out-of-context method signature stuff into code that can be maintained with the package, rather than as external documentation.

This introduces three new options, when the Generator is installed:

- Adjusters (`craft make adjuster`): Stubs and registers a new Order Adjuster class in the specified module or plugin;
- Gateways (`craft make gateway`): Stubs and registers a new Gateway class in the specified module or plugin (as well as creating the appropriate payment form and request/response models, and the corresponding back- and front-end templates);
- Shipping Method (`craft make shipping-method`): Stubs a new shipping method in the specified module or plugin (developer is responsible for registering it, as the logic for this is significantly different based on whether you just need a single hard-coded method or many methods—say, defined by and loaded from a third-party service);

Submitting as a **Draft**, because this definitely needs a second set of eyes… but I'm also not confident this covers even a fraction of the extension surface area. Purchasables are probably the biggest omission—and I don't even know where to begin with Tax Engines! 😂

### Todo:
- [x] Adjusters
- [x] Gateways
- [x] Shipping Methods
- [ ] Purchasables (unsure of workload here—seems like it would be pretty similar to `make element-type`…)