### PR TITLE
“Load Cart” Example Template Input Value

### DIFF
--- a/example-templates/dist/shop/cart/load.twig
+++ b/example-templates/dist/shop/cart/load.twig
@@ -21,9 +21,9 @@ Outputs form for collecting a cart number to be loaded.
           {{- 'Cart Number'|t -}}
         </label>
         <div>
-          {{ input('text', 'number', 'border border-gray-300 hover:border-gray-500 px-4 py-2 leading-tight rounded', {
+          {{ input('text', 'number', {
             id: 'number',
-            class: ['w-full', ''],
+            class: ['w-full', 'border border-gray-300 hover:border-gray-500 px-4 py-2 leading-tight rounded'],
             placeholder: '7e89fh0ew8034…'
           }) }}
         </div>

--- a/example-templates/src/shop/cart/load.twig
+++ b/example-templates/src/shop/cart/load.twig
@@ -21,9 +21,9 @@ Outputs form for collecting a cart number to be loaded.
           {{- 'Cart Number'|t -}}
         </label>
         <div>
-          {{ input('text', 'number', '[[classes.input]]', {
+          {{ input('text', 'number', null, {
             id: 'number',
-            class: ['w-full', ''],
+            class: ['w-full', '[[classes.input]]'],
             placeholder: '7e89fh0ew8034…'
           }) }}
         </div>


### PR DESCRIPTION
Ok, this one is much better. No longer tangled up with the changes in #3235!

Modifies the input on the `shop/cart/load.twig` template such that the Tailwind classes don't leak into the `value` attribute!