### PR TITLE
Use hiddenInput() helper function

### DIFF
--- a/example-templates/src/shop/_private/address/fields.twig
+++ b/example-templates/src/shop/_private/address/fields.twig
@@ -198,11 +198,11 @@ Outputs address form fields for editing an address.
   {% if showPrimaryCheckboxes %}
     <hr class="my-2">
     <div class="my-2">
-      {{ input('text', 'isPrimaryBilling', address.isPrimarybilling ? 1 : 0) }}
+      {{ hiddenInput('isPrimaryBilling', address.isPrimarybilling ? 1 : 0) }}
       <label>{{ input('checkbox', 'isPrimaryBillingBox', 1, { checked: address.isPrimaryBilling, 'data-primary-input': 'isPrimaryBilling' }) }} {{ 'Use as the primary billing address'|t('commerce') }}</label>
     </div>
     <div class="my-2">
-      {{ input('text', 'isPrimaryShipping', address.isPrimaryShipping ? 1 : 0) }}
+      {{ hiddenInput('isPrimaryShipping', address.isPrimaryShipping ? 1 : 0) }}
       <label>{{ input('checkbox', 'isPrimaryShippingBox', 1, { checked: address.isPrimaryShipping, 'data-primary-input': 'isPrimaryShipping' }) }} {{ 'Use as the primary shipping address'|t('commerce') }}</label>
     </div>
   {% endif %}


### PR DESCRIPTION
Noticed this while helping someone [in Discord](https://discord.com/channels/456442477667418113/666747438794670140/1135940871964065917).

Issuing as a Draft, because I think it's worth revisiting the involvement of Javascript… I don't think it's necessary in most situations, because of [native HTML form behavior](https://stackoverflow.com/questions/476426/submit-an-html-form-with-empty-checkboxes)?

For instance, this pair of patches preserves the functionality (as best I can tell):

- Remove this script block:
    ```twig
    {% if showPrimaryCheckboxes %}
        document.querySelectorAll('input[type=checkbox][data-primary-input]').forEach(el => {
            el.addEventListener('change', ev => {
                let primaryInput = document.querySelector(`input[name="${ev.target.dataset.primaryInput}"]`);
                if (ev.target.checked) {
                    primaryInput.value = 1;
                } else {
                    primaryInput.value = 0;
                }
            });
        });
    {% endif %}
    ```
- Modify inputs:
    ```twig
    <div class="my-2">
      {{ hiddenInput('isPrimaryBilling', 0) }}
      <label>{{ input('checkbox', 'isPrimaryBilling', 1, { checked: address.isPrimaryBilling }) }} {{ 'Use as the primary billing address'|t('commerce') }}</label>
    </div>
    <div class="my-2">
      {{ hiddenInput('isPrimaryShipping', 0) }}
      <label>{{ input('checkbox', 'isPrimaryShipping', 1, { checked: address.isPrimaryShipping }) }} {{ 'Use as the primary shipping address'|t('commerce') }}</label>
    </div>
    ```

The `0` is sent unless the second box is checked. Only the second box’s state is important, and it doesn't need to be synchronized with a “virtual” input.