### PR TITLE
fix orderData to be nullable

### DIFF
--- a/src/events/MailEvent.php
+++ b/src/events/MailEvent.php
@@ -44,5 +44,5 @@ class MailEvent extends CancelableEvent
     /**
      * @var array Order data at the time the email sends.
      */
-    public array $orderData;
+    public ?array $orderData;
 }


### PR DESCRIPTION
### Description
Fixes: TypeError: Cannot assign null to property craft\commerce\events\MailEvent::$orderData of type array

when using the EVENT_BEFORE_SEND_MAIL event