### PR TITLE
Order element docblock

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -88,7 +88,6 @@ use yii\log\Logger;
  * @property string $recalculationMode the mode of recalculation.
  * @property string $origin
  * @property int|null $customerId The order customer ID
- * @property-read ShippingMethod[] $availableShippingMethods
  * @property-read bool $activeCart Is the current order the same as the active cart
  * @property-read User|null $customer
  * @property-read Gateway $gateway

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -148,7 +148,7 @@ use yii\log\Logger;
  * @property float $totalTaxIncluded
  * @property float $totalTax
  * @property float $totalShippingCost
- * @property ShippingMethodOption[] $availableShippingMethodOptions
+ * @property-read ShippingMethodOption[] $availableShippingMethodOptions
  * @property-read float|int $totalAuthorized
  * @property float $paymentAmount
  * @property-read null|string $loadCartUrl


### PR DESCRIPTION
Via support—a developer noticed that `Order::availableShippingMethods` was [still in the class reference](https://docs.craftcms.com/commerce/api/v4/craft-commerce-elements-order.html#availableshippingmethods), despite the method being removed in 4.0.

This removes the offending property hint, and adjusts the new `availableShippingMethodOptions` getter to be `property-read`.