### PR TITLE
fix: qualify `Emails::_createEmailQuery` `orderBy`

### DIFF
--- a/src/services/Emails.php
+++ b/src/services/Emails.php
@@ -910,7 +910,7 @@ class Emails extends Component
                 'emails.plainTextTemplatePath',
                 'emails.uid',
             ])
-            ->orderBy('name')
+            ->orderBy('emails.name')
             ->from([Table::EMAILS . ' emails']);
 
         // todo: remove schema version condition after next beakpoint


### PR DESCRIPTION
Add the table alias to the `orderBy` to avoid driver specific ambiguity in the generated SQL when joining against another table that _also_ has a `name` column.

This is in line with `States::_createStatesQuery`, and should fix #3263.
