### PR TITLE
fix: qualify `Emails::_createEmailQuery` `orderBy`

### DIFF
--- a/src/services/Emails.php
+++ b/src/services/Emails.php
@@ -891,7 +891,7 @@ class Emails extends Component
                 'emails.to',
                 'emails.uid',
             ])
-            ->orderBy('name')
+            ->orderBy('emails.name')
             ->from([Table::EMAILS . ' emails']);
     }
 


### PR DESCRIPTION
Add the table alias to the `orderBy` to avoid driver specific ambiguity in the generated SQL when joining against another table that _also_ has a `name` column.

This is in line with `States::_createStatesQuery`, and should fix #3263.