### PR TITLE
Optionally allow a shippingMethod to be associated with a ShippingMethodOption

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1984,6 +1984,7 @@ class Order extends Element
             $option->handle = $method->getHandle();
             $option->matchesOrder = ArrayHelper::isIn($method->getHandle(), $matchingMethodHandles);
             $option->price = $method->getPriceForOrder($this);
+            $option->shippingMethod = $method;
 
             // Add all methods if completed, and only the matching methods when it is not completed.
             if ($this->isCompleted || $option->matchesOrder) {

--- a/src/models/ShippingMethodOption.php
+++ b/src/models/ShippingMethodOption.php
@@ -7,6 +7,7 @@
 
 namespace craft\commerce\models;
 
+use craft\commerce\base\ShippingMethod as BaseShippingMethod;
 use craft\commerce\behaviors\CurrencyAttributeBehavior;
 use craft\commerce\elements\Order;
 use craft\commerce\Plugin;
@@ -38,6 +39,20 @@ class ShippingMethodOption extends ShippingMethod
      * @var boolean
      */
     public bool $matchesOrder;
+
+    /**
+     * @var BaseShippingMethod|null The shipping method this option was derived from.
+     */
+    public ?BaseShippingMethod $shippingMethod = null;
+
+    public function getShippingRules(): array
+    {
+        if ($this->shippingMethod !== null) {
+            return $this->shippingMethod->getShippingRules();
+        }
+
+        return parent::getShippingRules();
+    }
 
     /**
      * @throws InvalidConfigException


### PR DESCRIPTION
### Description

Craft Commerce's `ShippingMethodOption` erases the information of any custom `ShippingMethod`s that were used to create them. While not ideal, this change sets a new field, `shippingMethod` on the `ShippingMethodOption` class and also proxies the call to `getShippingRules` to use the attached `ShippingMethod` if it is present.

Of course, other functions such as `getName`, `getType`, etc will not be overridden and would need to be accessed like `$option->shippingMethod->getType()`.

With this change the following snippet works with Commerce built-ins and custom shipping methods:

```twig
{% set cart = craft.orders().one() %}

{% for handle, method in cart.availableShippingMethodOptions %}
  <div class="shipping-select">
    <label>
      <input type="radio" name="shippingMethodHandle" value="{{ handle }}" {% if handle == cart.shippingMethodHandle %}checked{% endif %} />
      <strong>{{ method.name }}</strong>

      <span class="price">
          {{ method.getPrice() | commerceCurrency(cart.currency) }}
      </span>

      {% set shippingRules = method.getShippingRules() %}
      <code>{{ dump(shippingRules) }}</code>
    </label>
  </div>
{% endfor %}

```

### Related issues

- Resolves #3271
