### PR TITLE
Fix #3278. Migrate address fullName in `commerce/upgrade`

### DIFF
--- a/src/console/controllers/UpgradeController.php
+++ b/src/console/controllers/UpgradeController.php
@@ -965,9 +965,13 @@ SQL;
         $address->locality = $data['city'];
         $address->dependentLocality = '';
 
-        if ($data['firstName'] || $data['lastName']) {
+        if ($data['fullName'] || $data['firstName'] || $data['lastName']) {
             $this->_ensureAddressField(new FullNameField());
-            $address->fullName = implode(' ', array_filter([$data['firstName'], $data['lastName']]));
+            if ($data['fullName']) {
+                $address->fullName = $data['fullName'];
+            } else {
+                $address->fullName = implode(' ', array_filter([$data['firstName'], $data['lastName']]));
+            }
         }
 
         if ($data['businessName']) {


### PR DESCRIPTION
### Description

Fix for #3278 

UpgradeController wasn't migrating the `fullName` field when calling `_createAddress()`.