### PR TITLE
Fixed `renderPdfForOrder()` method error on `null` `$pdf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added the `commerce/gateways/webhook-url` command.
 - Fixed a bug where the delete button would be shown for users that do not have permission to delete on the Product edit page. ([#3285](https://github.com/craftcms/commerce/issues/3285))
 - Fixed a bug where deleted shipping categories were still available for selection. ([#3272](https://github.com/craftcms/commerce/issues/3272))
+- Fixed an error that could occur when rendering a PDF. ([#2633](https://github.com/craftcms/commerce/issues/2633))
 
 ## 4.3.0 - 2023-09-13
 

--- a/src/services/Pdfs.php
+++ b/src/services/Pdfs.php
@@ -466,7 +466,7 @@ class Pdfs extends Component
         $view = Craft::$app->getView();
         $originalLanguage = Craft::$app->language;
         $originalFormattingLanguage = Craft::$app->formattingLocale;
-        $pdfLanguage = $pdf->getRenderLanguage($order);
+        $pdfLanguage = $pdf?->getRenderLanguage($order) ?? $originalLanguage;
 
         // TODO add event
         Locale::switchAppLanguage($pdfLanguage);


### PR DESCRIPTION
### Description
The method states `$pdf` argument is nullable but the code expects it to exist.


### Related issues
#2633 
