### PR TITLE
Update variant SKU and title before save instead of before validation

### DIFF
--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -1127,11 +1127,6 @@ class Variant extends Purchasable
      */
     public function beforeValidate(): bool
     {
-        $product = $this->getProduct();
-
-        $this->updateTitle($product);
-        $this->updateSku($product);
-
         if ($this->getScenario() === self::SCENARIO_DEFAULT) {
             if (!$this->sku) {
                 $this->setSku(PurchasableHelper::tempSku());
@@ -1159,8 +1154,14 @@ class Variant extends Purchasable
      */
     public function beforeSave(bool $isNew): bool
     {
+        /** @var Product $product */
+        $product = $this->getProduct();
+
+        $this->updateTitle($product);
+        $this->updateSku($product);
+
         // Set the field layout
-        $productType = $this->getProduct()->getType();
+        $productType = $product->getType();
         $this->fieldLayoutId = $productType->variantFieldLayoutId;
 
         return parent::beforeSave($isNew);


### PR DESCRIPTION
### Description

A variants title and SKU are generated automatically based on their respective templates. For this to work correctly when writing code against Commerce APIs and not using validation, we need to ensure that those two side-effects are moved out of validation otherwise they will never be updated correctly without a CLI or CP invoked resave of a product.

This PR removes the `updateTitle`and `updateSku` functions to the `beforeSave` function so that validation of a variant isn't required to generate those two fields data.

### Related issues

