### PR TITLE
Use subquery in hasVariant & hasProduct criteria to improve performance

### DIFF
--- a/src/elements/db/ProductQuery.php
+++ b/src/elements/db/ProductQuery.php
@@ -1126,12 +1126,11 @@ class ProductQuery extends ElementQuery
 
         $variantQuery->limit = null;
         $variantQuery->select('commerce_variants.productId');
-        $productIds = $variantQuery->asArray()->column();
 
         // Remove any blank product IDs (if any)
-        $productIds = array_filter($productIds);
+        $variantQuery->andWhere(['not', ['commerce_variants.productId' => null]]);
 
-        $this->subQuery->andWhere(['commerce_products.id' => array_values($productIds)]);
+        $this->subQuery->andWhere(['commerce_products.id' => $variantQuery]);
     }
 
     /**

--- a/src/elements/db/VariantQuery.php
+++ b/src/elements/db/VariantQuery.php
@@ -927,11 +927,11 @@ class VariantQuery extends ElementQuery
 
         $productQuery->limit = null;
         $productQuery->select('commerce_products.id');
-        $productIds = $productQuery->column();
 
         // Remove any blank product IDs (if any)
-        $productIds = array_filter($productIds);
-        $this->subQuery->andWhere(['commerce_variants.productId' => $productIds]);
+        $productQuery->andWhere(['not', ['commerce_products.id' => null]]);
+        
+        $this->subQuery->andWhere(['commerce_variants.productId' => $productQuery]);
     }
 
     /**


### PR DESCRIPTION
### Description

This change makes the `hasVariant` criteria apply a subquery instead of fetching and applying via PHP

