### PR TITLE
removed space between the status circle and wording

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -2457,7 +2457,7 @@ class Order extends Element
     public function getOrderStatusHtml(): string
     {
         if ($status = $this->getOrderStatus()) {
-            return '<span class="commerceStatusLabel"><span class="status ' . $status->color . '"></span> ' . $status->name . '</span>';
+            return '<span class="commerceStatusLabel"><span class="status ' . $status->color . '"></span>' . $status->name . '</span>';
         }
 
         return '';
@@ -2469,10 +2469,10 @@ class Order extends Element
     public function getPaidStatusHtml(): string
     {
         return match ($this->getPaidStatus()) {
-            self::PAID_STATUS_OVERPAID => '<span class="commerceStatusLabel"><span class="status blue"></span> ' . Craft::t('commerce', 'Overpaid') . '</span>',
-            self::PAID_STATUS_PAID => '<span class="commerceStatusLabel"><span class="status green"></span> ' . Craft::t('commerce', 'Paid') . '</span>',
-            self::PAID_STATUS_PARTIAL => '<span class="commerceStatusLabel"><span class="status orange"></span> ' . Craft::t('commerce', 'Partial') . '</span>',
-            self::PAID_STATUS_UNPAID => '<span class="commerceStatusLabel"><span class="status red"></span> ' . Craft::t('commerce', 'Unpaid') . '</span>',
+            self::PAID_STATUS_OVERPAID => '<span class="commerceStatusLabel"><span class="status blue"></span>' . Craft::t('commerce', 'Overpaid') . '</span>',
+            self::PAID_STATUS_PAID => '<span class="commerceStatusLabel"><span class="status green"></span>' . Craft::t('commerce', 'Paid') . '</span>',
+            self::PAID_STATUS_PARTIAL => '<span class="commerceStatusLabel"><span class="status orange"></span>' . Craft::t('commerce', 'Partial') . '</span>',
+            self::PAID_STATUS_UNPAID => '<span class="commerceStatusLabel"><span class="status red"></span>' . Craft::t('commerce', 'Unpaid') . '</span>',
             default => '',
         };
     }


### PR DESCRIPTION
### Description
Removed a space between the status circle and status wording so that the spacing is visually consistent.

A cms PR for this issue to follow (https://github.com/craftcms/cms/pull/13915).


### Related issues
https://github.com/craftcms/cms/issues/13910
