### PR TITLE
[5.7] Allow payment currency rate override

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -41,8 +41,8 @@
 - Added `craft\commerce\services\Carts::peekCart()`.
 - Added `craft\commerce\controllers\CartController::actionPeekCart()`.
 - Added `craft\commerce\events\PaymentCurrencyRateEvent`, allowing plugins to override a payment currency's exchange rate at the point of use without affecting the rate stored on the `PaymentCurrency` record.
-- Added `craft\commerce\models\PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE`.
-- Added `craft\commerce\models\PaymentCurrency::getRate()`.
+- Added `craft\commerce\services\PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE`.
+- Added `craft\commerce\services\PaymentCurrencies::getRateFor()`.
 - Deprecated `craft\commerce\services\ProductTypes::hasPermission()`. Use `$user->can()` directly instead.
 - Deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()`. Use `getViewableProductTypes()` instead.
 - Deprecated `craft\commerce\services\ProductTypes::getEditableProductTypeIds()`. Use `getViewableProductTypeIds()` instead.

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -40,6 +40,9 @@
 - Added `craft\commerce\services\ProductTypes::getCreatableProductTypeIds()`.
 - Added `craft\commerce\services\Carts::peekCart()`.
 - Added `craft\commerce\controllers\CartController::actionPeekCart()`.
+- Added `craft\commerce\events\PaymentCurrencyRateEvent`, allowing plugins to override a payment currency's exchange rate at the point of use without affecting the rate stored on the `PaymentCurrency` record.
+- Added `craft\commerce\models\PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE`.
+- Added `craft\commerce\models\PaymentCurrency::getRate()`.
 - Deprecated `craft\commerce\services\ProductTypes::hasPermission()`. Use `$user->can()` directly instead.
 - Deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()`. Use `getViewableProductTypes()` instead.
 - Deprecated `craft\commerce\services\ProductTypes::getEditableProductTypeIds()`. Use `getViewableProductTypeIds()` instead.

--- a/src/events/PaymentCurrencyRateEvent.php
+++ b/src/events/PaymentCurrencyRateEvent.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\events;
+
+use craft\commerce\models\Transaction;
+use yii\base\Event;
+
+/**
+ * Payment Currency Rate Event
+ *
+ * @property ?Transaction $transaction
+ * @since 2.0
+ */
+class PaymentCurrencyRateEvent extends Event
+{
+	/**
+	* @var float The rate the event
+	*/
+	public float $rate;
+
+	public ?Transaction $transaction = null;
+}

--- a/src/events/PaymentCurrencyRateEvent.php
+++ b/src/events/PaymentCurrencyRateEvent.php
@@ -13,15 +13,17 @@ use yii\base\Event;
 /**
  * Payment Currency Rate Event
  *
- * @property ?Transaction $transaction
- * @since 2.0
+ * @since 5.7.0
  */
 class PaymentCurrencyRateEvent extends Event
 {
-	/**
-	* @var float The rate the event
-	*/
-	public float $rate;
+    /**
+     * @var float The rate that will be used. Set this to override the rate.
+     */
+    public float $rate;
 
-	public ?Transaction $transaction = null;
+    /**
+     * @var Transaction|null The transaction the rate is being resolved for, if any.
+     */
+    public ?Transaction $transaction = null;
 }

--- a/src/events/PaymentCurrencyRateEvent.php
+++ b/src/events/PaymentCurrencyRateEvent.php
@@ -7,6 +7,7 @@
 
 namespace craft\commerce\events;
 
+use craft\commerce\models\PaymentCurrency;
 use craft\commerce\models\Transaction;
 use yii\base\Event;
 
@@ -21,6 +22,11 @@ class PaymentCurrencyRateEvent extends Event
      * @var float The rate that will be used. Set this to override the rate.
      */
     public float $rate;
+
+    /**
+     * @var PaymentCurrency The payment currency the rate is being resolved for.
+     */
+    public PaymentCurrency $paymentCurrency;
 
     /**
      * @var Transaction|null The transaction the rate is being resolved for, if any.

--- a/src/models/PaymentCurrency.php
+++ b/src/models/PaymentCurrency.php
@@ -8,6 +8,7 @@
 namespace craft\commerce\models;
 
 use craft\commerce\base\Model;
+use craft\commerce\events\PaymentCurrencyRateEvent;
 use craft\commerce\records\PaymentCurrency as PaymentCurrencyRecord;
 use craft\helpers\UrlHelper;
 use craft\validators\UniqueValidator;
@@ -28,7 +29,13 @@ use DateTime;
  */
 class PaymentCurrency extends Model
 {
-    /**
+
+	/**
+	 * @event PaymentCurrencyRateEvent The event that is triggered when the payment currency rate is defined
+	 */
+	const EVENT_DEFINE_PAYMENT_CURRENCY_RATE = 'definePaymentCurrencyRate';
+
+	/**
      * @var int|null ID
      */
     public ?int $id = null;
@@ -149,6 +156,22 @@ class PaymentCurrency extends Model
     {
         $this->_currency = $currency;
     }
+
+	/**
+	 * @param Transaction|null $transaction
+	 * @return float
+	 */
+	public function getRate(Transaction $transaction = null) : float
+	{
+		$event = new PaymentCurrencyRateEvent([
+			'rate' => $this->rate,
+			'transaction' => $transaction,
+		]);
+
+		$this->trigger(self::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $event);
+
+		return $this->rate;
+	}
 
     /**
      * @inheritdoc

--- a/src/models/PaymentCurrency.php
+++ b/src/models/PaymentCurrency.php
@@ -8,7 +8,6 @@
 namespace craft\commerce\models;
 
 use craft\commerce\base\Model;
-use craft\commerce\events\PaymentCurrencyRateEvent;
 use craft\commerce\Plugin;
 use craft\commerce\records\PaymentCurrency as PaymentCurrencyRecord;
 use craft\helpers\UrlHelper;
@@ -32,12 +31,6 @@ use yii\base\InvalidConfigException;
  */
 class PaymentCurrency extends Model
 {
-    /**
-     * @event PaymentCurrencyRateEvent The event that is triggered when the payment currency rate is being resolved.
-     * @since 5.7.0
-     */
-    public const EVENT_DEFINE_PAYMENT_CURRENCY_RATE = 'definePaymentCurrencyRate';
-
     /**
      * @var int|null ID
      */
@@ -195,23 +188,6 @@ class PaymentCurrency extends Model
     public function getCode()
     {
         return $this->iso;
-    }
-
-    /**
-     * @param Transaction|null $transaction
-     * @return float
-     * @since 5.7.0
-     */
-    public function getRate(?Transaction $transaction = null): float
-    {
-        $event = new PaymentCurrencyRateEvent([
-            'rate' => $this->rate,
-            'transaction' => $transaction,
-        ]);
-
-        $this->trigger(self::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $event);
-
-        return $event->rate;
     }
 
     /**

--- a/src/models/PaymentCurrency.php
+++ b/src/models/PaymentCurrency.php
@@ -209,7 +209,7 @@ class PaymentCurrency extends Model
 
         $this->trigger(self::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $event);
 
-        return $this->rate;
+        return $event->rate;
     }
 
     /**

--- a/src/models/PaymentCurrency.php
+++ b/src/models/PaymentCurrency.php
@@ -33,7 +33,8 @@ use yii\base\InvalidConfigException;
 class PaymentCurrency extends Model
 {
     /**
-     * @event PaymentCurrencyRateEvent The event that is triggered when the payment currency rate is defined
+     * @event PaymentCurrencyRateEvent The event that is triggered when the payment currency rate is being resolved.
+     * @since 5.7.0
      */
     public const EVENT_DEFINE_PAYMENT_CURRENCY_RATE = 'definePaymentCurrencyRate';
 
@@ -199,6 +200,7 @@ class PaymentCurrency extends Model
     /**
      * @param Transaction|null $transaction
      * @return float
+     * @since 5.7.0
      */
     public function getRate(?Transaction $transaction = null): float
     {

--- a/src/models/PaymentCurrency.php
+++ b/src/models/PaymentCurrency.php
@@ -8,6 +8,7 @@
 namespace craft\commerce\models;
 
 use craft\commerce\base\Model;
+use craft\commerce\events\PaymentCurrencyRateEvent;
 use craft\commerce\Plugin;
 use craft\commerce\records\PaymentCurrency as PaymentCurrencyRecord;
 use craft\helpers\UrlHelper;
@@ -31,6 +32,11 @@ use yii\base\InvalidConfigException;
  */
 class PaymentCurrency extends Model
 {
+    /**
+     * @event PaymentCurrencyRateEvent The event that is triggered when the payment currency rate is defined
+     */
+    public const EVENT_DEFINE_PAYMENT_CURRENCY_RATE = 'definePaymentCurrencyRate';
+
     /**
      * @var int|null ID
      */
@@ -188,6 +194,22 @@ class PaymentCurrency extends Model
     public function getCode()
     {
         return $this->iso;
+    }
+
+    /**
+     * @param Transaction|null $transaction
+     * @return float
+     */
+    public function getRate(?Transaction $transaction = null): float
+    {
+        $event = new PaymentCurrencyRateEvent([
+            'rate' => $this->rate,
+            'transaction' => $transaction,
+        ]);
+
+        $this->trigger(self::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $event);
+
+        return $this->rate;
     }
 
     /**

--- a/src/services/PaymentCurrencies.php
+++ b/src/services/PaymentCurrencies.php
@@ -197,10 +197,10 @@ class PaymentCurrencies extends Component
 
         if ($this->getPrimaryPaymentCurrency()->iso != $fromCurrency) {
             // now the amount is in the primary currency
-            $amount /= $fromCurrency->rate;
+            $amount /= $fromCurrency->getRate();
         }
 
-        $result = $amount * $toCurrency->rate;
+        $result = $amount * $toCurrency->getRate();
 
         if ($round) {
             return CurrencyHelper::round($result, $toCurrency);
@@ -239,7 +239,7 @@ class PaymentCurrencies extends Component
         $record->iso = strtoupper($model->iso);
         $record->primary = $model->primary;
         // If this rate is primary, the rate must be 1 since it is now the rate all prices are enter in as.
-        $record->rate = $model->primary ? 1 : $model->rate;
+        $record->rate = $model->primary ? 1 : $model->getRate();
 
         $record->save(false);
 

--- a/src/services/PaymentCurrencies.php
+++ b/src/services/PaymentCurrencies.php
@@ -239,7 +239,7 @@ class PaymentCurrencies extends Component
         $record->iso = strtoupper($model->iso);
         $record->storeId = $model->storeId;
         // If this rate is primary, the rate must be 1 since it is now the rate all prices are enter in as.
-        $record->rate = $model->getPrimary() ? 1 : $model->getRate();
+        $record->rate = $model->getPrimary() ? 1 : $model->rate;
 
         $record->save(false);
 
@@ -276,7 +276,7 @@ class PaymentCurrencies extends Component
         $storeId ??= Plugin::getInstance()->getStores()->getCurrentStore()->id;
 
         $storeCurrency = Plugin::getInstance()->getStores()->getStoreById($storeId)->getCurrency();
-        $nonPrimaryCurrencies = $this->getNonPrimaryPaymentCurrencies($storeId)->mapWithKeys(fn(PaymentCurrency $currency) => [$currency->iso => (string)$currency->rate]);
+        $nonPrimaryCurrencies = $this->getNonPrimaryPaymentCurrencies($storeId)->mapWithKeys(fn(PaymentCurrency $currency) => [$currency->iso => (string)$currency->getRate()]);
 
         $exchange = [$storeCurrency->getCode() => $nonPrimaryCurrencies->all()];
 

--- a/src/services/PaymentCurrencies.php
+++ b/src/services/PaymentCurrencies.php
@@ -197,10 +197,10 @@ class PaymentCurrencies extends Component
 
         if ($this->getPrimaryPaymentCurrency()->iso != $fromCurrency) {
             // now the amount is in the primary currency
-            $amount /= $fromCurrency->rate;
+            $amount /= $fromCurrency->getRate();
         }
 
-        $result = $amount * $toCurrency->rate;
+        $result = $amount * $toCurrency->getRate();
 
         if ($round) {
             return CurrencyHelper::round($result, $toCurrency);
@@ -239,7 +239,7 @@ class PaymentCurrencies extends Component
         $record->iso = strtoupper($model->iso);
         $record->storeId = $model->storeId;
         // If this rate is primary, the rate must be 1 since it is now the rate all prices are enter in as.
-        $record->rate = $model->getPrimary() ? 1 : $model->rate;
+        $record->rate = $model->getPrimary() ? 1 : $model->getRate();
 
         $record->save(false);
 

--- a/src/services/PaymentCurrencies.php
+++ b/src/services/PaymentCurrencies.php
@@ -10,8 +10,10 @@ namespace craft\commerce\services;
 use Craft;
 use craft\commerce\db\Table;
 use craft\commerce\errors\CurrencyException;
+use craft\commerce\events\PaymentCurrencyRateEvent;
 use craft\commerce\helpers\Currency as CurrencyHelper;
 use craft\commerce\models\PaymentCurrency;
+use craft\commerce\models\Transaction;
 use craft\commerce\Plugin;
 use craft\commerce\records\PaymentCurrency as PaymentCurrencyRecord;
 use craft\db\Query;
@@ -41,9 +43,34 @@ use yii\db\StaleObjectException;
 class PaymentCurrencies extends Component
 {
     /**
+     * @event PaymentCurrencyRateEvent The event that is triggered when a payment currency rate is being resolved.
+     * Set `$event->rate` to override the rate used for conversions and historical transaction snapshots.
+     * @since 5.7.0
+     */
+    public const EVENT_DEFINE_PAYMENT_CURRENCY_RATE = 'definePaymentCurrencyRate';
+
+    /**
      * @var null|Collection<PaymentCurrency>[]
      */
     private ?array $_allPaymentCurrencies = null;
+
+    /**
+     * Returns the rate for a payment currency, after giving event handlers a chance to override it.
+     *
+     * @since 5.7.0
+     */
+    public function getRateFor(PaymentCurrency $currency, ?Transaction $transaction = null): float
+    {
+        $event = new PaymentCurrencyRateEvent([
+            'rate' => $currency->rate,
+            'paymentCurrency' => $currency,
+            'transaction' => $transaction,
+        ]);
+
+        $this->trigger(self::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $event);
+
+        return $event->rate;
+    }
 
     /**
      * Get payment currency by its ID.
@@ -197,10 +224,10 @@ class PaymentCurrencies extends Component
 
         if ($this->getPrimaryPaymentCurrency()->iso != $fromCurrency) {
             // now the amount is in the primary currency
-            $amount /= $fromCurrency->getRate();
+            $amount /= $this->getRateFor($fromCurrency);
         }
 
-        $result = $amount * $toCurrency->getRate();
+        $result = $amount * $this->getRateFor($toCurrency);
 
         if ($round) {
             return CurrencyHelper::round($result, $toCurrency);
@@ -276,7 +303,7 @@ class PaymentCurrencies extends Component
         $storeId ??= Plugin::getInstance()->getStores()->getCurrentStore()->id;
 
         $storeCurrency = Plugin::getInstance()->getStores()->getStoreById($storeId)->getCurrency();
-        $nonPrimaryCurrencies = $this->getNonPrimaryPaymentCurrencies($storeId)->mapWithKeys(fn(PaymentCurrency $currency) => [$currency->iso => (string)$currency->getRate()]);
+        $nonPrimaryCurrencies = $this->getNonPrimaryPaymentCurrencies($storeId)->mapWithKeys(fn(PaymentCurrency $currency) => [$currency->iso => (string)$this->getRateFor($currency)]);
 
         $exchange = [$storeCurrency->getCode() => $nonPrimaryCurrencies->all()];
 

--- a/src/services/Transactions.php
+++ b/src/services/Transactions.php
@@ -216,7 +216,7 @@ class Transactions extends Component
             $transaction->amount = Currency::round($amount, $currency);
 
             // Capture historical rate
-            $transaction->paymentRate = $paymentCurrency->rate;
+            $transaction->paymentRate = $paymentCurrency->getRate($transaction);
 
             $transaction->setOrder($order);
         }

--- a/src/services/Transactions.php
+++ b/src/services/Transactions.php
@@ -233,7 +233,7 @@ class Transactions extends Component
             $transaction->setOrder($order);
 
             // Capture historical rate
-            $transaction->paymentRate = $paymentCurrency->getRate($transaction);
+            $transaction->paymentRate = Plugin::getInstance()->getPaymentCurrencies()->getRateFor($paymentCurrency, $transaction);
         }
 
         $user = Craft::$app->getUser()->getIdentity();

--- a/src/services/Transactions.php
+++ b/src/services/Transactions.php
@@ -231,7 +231,7 @@ class Transactions extends Component
             $transaction->amount = $amount;
 
             // Capture historical rate
-            $transaction->paymentRate = $paymentCurrency->rate;
+            $transaction->paymentRate = $paymentCurrency->getRate($transaction);
 
             $transaction->setOrder($order);
         }

--- a/src/services/Transactions.php
+++ b/src/services/Transactions.php
@@ -230,10 +230,10 @@ class Transactions extends Component
             // Amount is always in the base currency
             $transaction->amount = $amount;
 
+            $transaction->setOrder($order);
+
             // Capture historical rate
             $transaction->paymentRate = $paymentCurrency->getRate($transaction);
-
-            $transaction->setOrder($order);
         }
 
         $user = Craft::$app->getUser()->getIdentity();

--- a/tests/unit/services/PaymentCurrenciesTest.php
+++ b/tests/unit/services/PaymentCurrenciesTest.php
@@ -10,7 +10,6 @@ namespace craftcommercetests\unit\services;
 use Codeception\Test\Unit;
 use craft\commerce\errors\CurrencyException;
 use craft\commerce\events\PaymentCurrencyRateEvent;
-use craft\commerce\models\PaymentCurrency;
 use craft\commerce\Plugin;
 use craft\commerce\records\PaymentCurrency as PaymentCurrencyRecord;
 use craft\commerce\services\PaymentCurrencies;
@@ -164,32 +163,32 @@ class PaymentCurrenciesTest extends Unit
     /**
      * @group PaymentCurrencies
      */
-    public function testGetRateReturnsRawRateWithoutHandler(): void
+    public function testGetRateForReturnsRawRateWithoutHandler(): void
     {
         $eur = $this->pc->getPaymentCurrencyByIso('EUR');
-        self::assertSame(0.5, $eur->getRate());
+        self::assertSame(0.5, $this->pc->getRateFor($eur));
     }
 
     /**
      * @group PaymentCurrencies
      */
-    public function testGetRateReturnsEventRate(): void
+    public function testGetRateForReturnsEventRate(): void
     {
         $handler = static function(PaymentCurrencyRateEvent $event) {
-            if ($event->sender instanceof PaymentCurrency && $event->sender->iso === 'EUR') {
+            if ($event->paymentCurrency->iso === 'EUR') {
                 $event->rate = 0.25;
             }
         };
-        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        Event::on(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
 
         try {
             $eur = $this->pc->getPaymentCurrencyByIso('EUR');
-            self::assertSame(0.25, $eur->getRate());
+            self::assertSame(0.25, $this->pc->getRateFor($eur));
 
             $aud = $this->pc->getPaymentCurrencyByIso('AUD');
-            self::assertSame(1.3, $aud->getRate(), 'Untouched currencies fall through to the raw rate.');
+            self::assertSame(1.3, $this->pc->getRateFor($aud), 'Untouched currencies fall through to the raw rate.');
         } finally {
-            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+            Event::off(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
         }
     }
 
@@ -199,17 +198,17 @@ class PaymentCurrenciesTest extends Unit
     public function testConvertCurrencyUsesEventRate(): void
     {
         $handler = static function(PaymentCurrencyRateEvent $event) {
-            if ($event->sender instanceof PaymentCurrency && $event->sender->iso === 'EUR') {
+            if ($event->paymentCurrency->iso === 'EUR') {
                 $event->rate = 0.25;
             }
         };
-        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        Event::on(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
 
         try {
             $converted = $this->pc->convertCurrency(40, $this->pc->getPrimaryPaymentCurrencyIso(), 'EUR');
             self::assertSame(10.0, $converted);
         } finally {
-            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+            Event::off(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
         }
     }
 
@@ -219,11 +218,11 @@ class PaymentCurrenciesTest extends Unit
     public function testConvertAmountUsesEventRate(): void
     {
         $handler = static function(PaymentCurrencyRateEvent $event) {
-            if ($event->sender instanceof PaymentCurrency && $event->sender->iso === 'EUR') {
+            if ($event->paymentCurrency->iso === 'EUR') {
                 $event->rate = 0.25;
             }
         };
-        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        Event::on(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
 
         try {
             $usd = new Money(4000, new Currency('USD'));
@@ -231,7 +230,7 @@ class PaymentCurrenciesTest extends Unit
             self::assertSame('EUR', $converted->getCurrency()->getCode());
             self::assertSame('1000', $converted->getAmount());
         } finally {
-            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+            Event::off(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
         }
     }
 
@@ -246,7 +245,7 @@ class PaymentCurrenciesTest extends Unit
         $handler = static function(PaymentCurrencyRateEvent $event) {
             $event->rate = 999.0;
         };
-        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        Event::on(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
 
         try {
             $eur = $this->pc->getPaymentCurrencyByIso('EUR');
@@ -263,7 +262,7 @@ class PaymentCurrenciesTest extends Unit
             $eur->rate = $originalRate;
             $this->pc->savePaymentCurrency($eur);
         } finally {
-            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+            Event::off(PaymentCurrencies::class, PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
         }
     }
 }

--- a/tests/unit/services/PaymentCurrenciesTest.php
+++ b/tests/unit/services/PaymentCurrenciesTest.php
@@ -9,10 +9,16 @@ namespace craftcommercetests\unit\services;
 
 use Codeception\Test\Unit;
 use craft\commerce\errors\CurrencyException;
+use craft\commerce\events\PaymentCurrencyRateEvent;
+use craft\commerce\models\PaymentCurrency;
 use craft\commerce\Plugin;
+use craft\commerce\records\PaymentCurrency as PaymentCurrencyRecord;
 use craft\commerce\services\PaymentCurrencies;
 use craftcommercetests\fixtures\PaymentCurrenciesFixture;
+use Money\Currency;
+use Money\Money;
 use UnitTester;
+use yii\base\Event;
 use yii\base\InvalidConfigException;
 
 /**
@@ -153,5 +159,111 @@ class PaymentCurrenciesTest extends Unit
     {
         $this->expectException(CurrencyException::class);
         $this->pc->convert(20, 'aaa');
+    }
+
+    /**
+     * @group PaymentCurrencies
+     */
+    public function testGetRateReturnsRawRateWithoutHandler(): void
+    {
+        $eur = $this->pc->getPaymentCurrencyByIso('EUR');
+        self::assertSame(0.5, $eur->getRate());
+    }
+
+    /**
+     * @group PaymentCurrencies
+     */
+    public function testGetRateReturnsEventRate(): void
+    {
+        $handler = static function(PaymentCurrencyRateEvent $event) {
+            if ($event->sender instanceof PaymentCurrency && $event->sender->iso === 'EUR') {
+                $event->rate = 0.25;
+            }
+        };
+        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+
+        try {
+            $eur = $this->pc->getPaymentCurrencyByIso('EUR');
+            self::assertSame(0.25, $eur->getRate());
+
+            $aud = $this->pc->getPaymentCurrencyByIso('AUD');
+            self::assertSame(1.3, $aud->getRate(), 'Untouched currencies fall through to the raw rate.');
+        } finally {
+            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        }
+    }
+
+    /**
+     * @group PaymentCurrencies
+     */
+    public function testConvertCurrencyUsesEventRate(): void
+    {
+        $handler = static function(PaymentCurrencyRateEvent $event) {
+            if ($event->sender instanceof PaymentCurrency && $event->sender->iso === 'EUR') {
+                $event->rate = 0.25;
+            }
+        };
+        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+
+        try {
+            $converted = $this->pc->convertCurrency(40, $this->pc->getPrimaryPaymentCurrencyIso(), 'EUR');
+            self::assertSame(10.0, $converted);
+        } finally {
+            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        }
+    }
+
+    /**
+     * @group PaymentCurrencies
+     */
+    public function testConvertAmountUsesEventRate(): void
+    {
+        $handler = static function(PaymentCurrencyRateEvent $event) {
+            if ($event->sender instanceof PaymentCurrency && $event->sender->iso === 'EUR') {
+                $event->rate = 0.25;
+            }
+        };
+        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+
+        try {
+            $usd = new Money(4000, new Currency('USD'));
+            $converted = $this->pc->convertAmount($usd, 'EUR');
+            self::assertSame('EUR', $converted->getCurrency()->getCode());
+            self::assertSame('1000', $converted->getAmount());
+        } finally {
+            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        }
+    }
+
+    /**
+     * The event must not affect the rate that gets persisted when saving a
+     * payment currency — saving isn't a conversion.
+     *
+     * @group PaymentCurrencies
+     */
+    public function testSavePaymentCurrencyIgnoresEventRate(): void
+    {
+        $handler = static function(PaymentCurrencyRateEvent $event) {
+            $event->rate = 999.0;
+        };
+        Event::on(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+
+        try {
+            $eur = $this->pc->getPaymentCurrencyByIso('EUR');
+            $originalRate = $eur->rate;
+            $eur->rate = 0.75;
+
+            self::assertTrue($this->pc->savePaymentCurrency($eur));
+
+            $record = PaymentCurrencyRecord::findOne(['id' => $eur->id]);
+            self::assertNotNull($record);
+            self::assertEquals(0.75, $record->rate, 'Raw admin-entered rate is persisted, not the event rate.');
+
+            // Restore for any tests that run after this one without isolation.
+            $eur->rate = $originalRate;
+            $this->pc->savePaymentCurrency($eur);
+        } finally {
+            Event::off(PaymentCurrency::class, PaymentCurrency::EVENT_DEFINE_PAYMENT_CURRENCY_RATE, $handler);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `PaymentCurrencyRateEvent` so plugins can override a payment currency's exchange rate at the point of use, while leaving the rate stored on the `PaymentCurrency` record untouched.

The event fires from `PaymentCurrencies::getRateFor()`, which is now called by:

- `PaymentCurrencies::_getExchange()` — feeds `convertAmount()` and any Money-based conversion.
- `PaymentCurrencies::convertCurrency()` — the deprecated float-based path.
- `Transactions::createTransaction()` — to capture the historical rate on the transaction (`$transaction->paymentRate`). The transaction has its order attached before this call, so handlers can read `$event->transaction->getOrder()`.

`savePaymentCurrency()` writes `$model->rate` directly, so the admin-entered rate is the value persisted to the database — the event never affects what's stored.

## Public API

- `craft\commerce\events\PaymentCurrencyRateEvent` (new)
- `craft\commerce\services\PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE` (new)
- `craft\commerce\services\PaymentCurrencies::getRateFor(PaymentCurrency $currency, ?Transaction $transaction = null): float` (new)

## Use case: snapshot rates at order completion, reuse them on later payments

A common scenario: when an order is placed, freeze the payment-currency exchange rates onto the order. When the customer pays (possibly days later, after rates have shifted), charge them at the original rates rather than the current ones.

### 1. Snapshot rates onto the order when it completes

Listen for `Order::EVENT_AFTER_COMPLETE_ORDER` and write the rates into a custom field on the order (a JSON field, or a plain text field that you'll JSON-encode):

```php
use Craft;
use craft\commerce\elements\Order;
use craft\commerce\Plugin as Commerce;
use yii\base\Event;

Event::on(
    Order::class,
    Order::EVENT_AFTER_COMPLETE_ORDER,
    static function(Event $event) {
        /** @var Order $order */
        $order = $event->sender;

        $rates = [];
        foreach (Commerce::getInstance()->getPaymentCurrencies()->getAllPaymentCurrencies($order->getStore()->id) as $currency) {
            $rates[$currency->iso] = $currency->rate;
        }

        $order->setFieldValue('paymentRateSnapshot', $rates);
        Craft::$app->getElements()->saveElement($order);
    }
);
```

### 2. Apply the snapshot when a payment transaction is created

Listen for `PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE`. When the event fires with a transaction attached, look up the snapshot on that transaction's order and use it as the rate:

```php
use craft\commerce\events\PaymentCurrencyRateEvent;
use craft\commerce\services\PaymentCurrencies;
use yii\base\Event;

Event::on(
    PaymentCurrencies::class,
    PaymentCurrencies::EVENT_DEFINE_PAYMENT_CURRENCY_RATE,
    static function(PaymentCurrencyRateEvent $event) {
        $transaction = $event->transaction;
        if ($transaction === null) {
            return;
        }

        $order = $transaction->getOrder();
        if ($order === null) {
            return;
        }

        $snapshot = $order->getFieldValue('paymentRateSnapshot');
        if (!is_array($snapshot)) {
            return;
        }

        $iso = $event->paymentCurrency->iso;
        if (isset($snapshot[$iso])) {
            $event->rate = (float)$snapshot[$iso];
        }
    }
);
```

That's it. New transactions on a completed order will record the snapshotted rate on `$transaction->paymentRate`, and any Money/`convertAmount` conversion made with a transaction in scope will use it too.

### Notes

- The handler is keyed on `$event->transaction`. When the event fires without transaction context (e.g. an isolated `convertAmount()` call elsewhere in the application), the handler returns early and the raw rate is used.
- `$event->paymentCurrency` is the `PaymentCurrency` model being resolved. Use `$event->paymentCurrency->iso` to look up the right rate from your snapshot.
- The rate stored on the `PaymentCurrency` record is unchanged — admins can still maintain current rates in the control panel and they'll be used everywhere outside of completed-order payment flows.
- Direct reads of `$currency->rate` skip the event by design. Anywhere you want the resolved rate, call `Commerce::getInstance()->getPaymentCurrencies()->getRateFor($currency, $transaction)`.

## Test plan

- [x] `composer run testunit` — 5 new tests in `services/PaymentCurrenciesTest`:
  - raw rate returned when no handler is attached
  - event-overridden rate returned from `getRateFor()`
  - `convertCurrency()` honors the override
  - `convertAmount()` honors the override (via `_getExchange`)
  - `savePaymentCurrency()` persists the raw rate, not the event rate
- [x] `composer run fix-cs`, `composer run phpstan` clean
