### PR TITLE
Fix deprecated typo in Order.php

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -3142,7 +3142,7 @@ class Order extends Element
     /**
      * @return ShippingMethod|null
      * @throws InvalidConfigException
-     * @deprected in 3.4.18. Use `$shippingMethodHandle` or `$shippingMethodName` instead.
+     * @deprecated in 3.4.18. Use `$shippingMethodHandle` or `$shippingMethodName` instead.
      */
     public function getShippingMethod(): ?ShippingMethod
     {


### PR DESCRIPTION
### Description

Minor fix, but lets PHPStorm and code linters find this deprecated method. 
