### PR TITLE
[4.7] Fix Paid Status

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -2422,7 +2422,7 @@ class Order extends Element
      */
     public function getPaidStatus(): string
     {
-        if ($this->getIsPaid() && $this->getTotalPrice() > 0 && $this->getTotalPaid() > $this->getTotalPrice()) {
+        if ($this->getIsPaid() && Currency::greaterThan($this->getTotalPrice(), 0) && Currency::greaterThan($this->getTotalPaid(), $this->getTotalPrice())) {
             return self::PAID_STATUS_OVERPAID;
         }
 
@@ -2430,7 +2430,7 @@ class Order extends Element
             return self::PAID_STATUS_PAID;
         }
 
-        if ($this->getTotalPaid() > 0) {
+        if (Currency::greaterThan($this->getTotalPaid(), 0)) {
             return self::PAID_STATUS_PARTIAL;
         }
 
@@ -2539,10 +2539,7 @@ class Order extends Element
      */
     public function getOutstandingBalance(): float
     {
-        $totalPaid = Currency::round($this->getTotalPaid());
-        $totalPrice = $this->getTotalPrice(); // Already rounded
-
-        return $totalPrice - $totalPaid;
+        return Currency::subtract($this->getTotalPrice(), $this->getTotalPaid());
     }
 
     public function hasOutstandingBalance(): bool

--- a/src/helpers/Currency.php
+++ b/src/helpers/Currency.php
@@ -50,14 +50,14 @@ class Currency
      * @param float $amountA
      * @param float $amountB
      * @param PaymentCurrency|CurrencyModel|null $currency
-     * @return bool
+     * @return float
      */
     public static function subtract(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
     {
-        $adjustedA = static::baseAmount($amountA, $currency);
-        $adjustedB = static::baseAmount($amountB, $currency);
+        $adjustedA = Currency::baseAmount($amountA, $currency);
+        $adjustedB = Currency::baseAmount($amountB, $currency);
 
-        return static::floatAmount($adjustedA - $adjustedB);
+        return Currency::floatAmount($adjustedA - $adjustedB);
     }
 
     /**
@@ -67,14 +67,14 @@ class Currency
      * @param float $amountA
      * @param float $amountB
      * @param PaymentCurrency|CurrencyModel|null $currency
-     * @return bool
+     * @return float
      */
     public static function add(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
     {
-        $adjustedA = static::baseAmount($amountA, $currency);
-        $adjustedB = static::baseAmount($amountB, $currency);
+        $adjustedA = Currency::baseAmount($amountA, $currency);
+        $adjustedB = Currency::baseAmount($amountB, $currency);
 
-        return static::floatAmount($adjustedA + $adjustedB);
+        return Currency::floatAmount($adjustedA + $adjustedB);
     }
 
     /**
@@ -88,8 +88,8 @@ class Currency
      */
     public static function equals(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): bool
     {
-        $adjustedA = static::baseAmount($amountA, $currency);
-        $adjustedB = static::baseAmount($amountB, $currency);
+        $adjustedA = Currency::baseAmount($amountA, $currency);
+        $adjustedB = Currency::baseAmount($amountB, $currency);
 
         return $adjustedA == $adjustedB;
     }
@@ -103,10 +103,10 @@ class Currency
      * @param PaymentCurrency|CurrencyModel|null $currency
      * @return bool
      */
-    public static function greaterThan(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
+    public static function greaterThan(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): bool
     {
-        $adjustedA = static::baseAmount($amountA, $currency);
-        $adjustedB = static::baseAmount($amountB, $currency);
+        $adjustedA = Currency::baseAmount($amountA, $currency);
+        $adjustedB = Currency::baseAmount($amountB, $currency);
 
         return $adjustedA > $adjustedB;
     }
@@ -120,10 +120,10 @@ class Currency
      * @param PaymentCurrency|CurrencyModel|null $currency
      * @return bool
      */
-    public static function lessThan(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
+    public static function lessThan(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): bool
     {
-        $adjustedA = static::baseAmount($amountA, $currency);
-        $adjustedB = static::baseAmount($amountB, $currency);
+        $adjustedA = Currency::baseAmount($amountA, $currency);
+        $adjustedB = Currency::baseAmount($amountB, $currency);
 
         return $adjustedA < $adjustedB;
     }
@@ -134,7 +134,7 @@ class Currency
      *
      * @param float $amount
      * @param PaymentCurrency|CurrencyModel|null $currency
-     * @return bool
+     * @return int
      */
     private static function baseAmount(float $amount, PaymentCurrency|CurrencyModel|null $currency = null): int
     {
@@ -145,16 +145,16 @@ class Currency
 
 
         $decimals = $currency->minorUnit;
-        return intval(floatval(static::round($amount, $currency) . '') * pow(10, $decimals));
+        return intval(floatval(Currency::round($amount, $currency) . '') * pow(10, $decimals));
     }
 
     /**
      * Converts the amount from an integer while maintaining the required amount of decimal places per the currency minor unit information. Not passing
      * a currency model results in rounding in default currency.
      *
-     * @param float $amount
+     * @param int $amount
      * @param PaymentCurrency|CurrencyModel|null $currency
-     * @return bool
+     * @return float
      */
     private static function floatAmount(int $amount, PaymentCurrency|CurrencyModel|null $currency = null): float
     {
@@ -165,7 +165,7 @@ class Currency
 
 
         $decimals = $currency->minorUnit;
-        return floatval(static::round($amount / pow(10, $decimals), $currency) . '');
+        return floatval(Currency::round($amount / pow(10, $decimals), $currency) . '');
     }
 
     public static function defaultDecimals(): int

--- a/src/helpers/Currency.php
+++ b/src/helpers/Currency.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://craftcms.com/
  * @copyright Copyright (c) Pixel & Tonic, Inc.
@@ -40,6 +41,131 @@ class Currency
 
         $decimals = $currency->minorUnit;
         return round($amount, $decimals);
+    }
+
+    /**
+     * Subtracts amountB from amountA in a reliable way as per the currency minor unit information. Not passing
+     * a currency model results in rounding in default currency.
+     *
+     * @param float $amountA
+     * @param float $amountB
+     * @param PaymentCurrency|CurrencyModel|null $currency
+     * @return bool
+     */
+    public static function subtract(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
+    {
+        $adjustedA = static::baseAmount($amountA, $currency);
+        $adjustedB = static::baseAmount($amountB, $currency);
+
+        return static::floatAmount($adjustedA - $adjustedB);
+    }
+
+    /**
+     * Adds the two amounts in a reliable way as per the currency minor unit information. Not passing
+     * a currency model results in rounding in default currency.
+     *
+     * @param float $amountA
+     * @param float $amountB
+     * @param PaymentCurrency|CurrencyModel|null $currency
+     * @return bool
+     */
+    public static function add(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
+    {
+        $adjustedA = static::baseAmount($amountA, $currency);
+        $adjustedB = static::baseAmount($amountB, $currency);
+
+        return static::floatAmount($adjustedA + $adjustedB);
+    }
+
+    /**
+     * Compares the equality of two amounts in a reliable way as per the currency minor unit information. Not passing
+     * a currency model results in rounding in default currency.
+     *
+     * @param float $amountA
+     * @param float $amountB
+     * @param PaymentCurrency|CurrencyModel|null $currency
+     * @return bool
+     */
+    public static function equals(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): bool
+    {
+        $adjustedA = static::baseAmount($amountA, $currency);
+        $adjustedB = static::baseAmount($amountB, $currency);
+
+        return $adjustedA == $adjustedB;
+    }
+
+    /**
+     * Compares if amountA is greater than amountB in a reliable way as per the currency minor unit information. Not passing
+     * a currency model results in rounding in default currency.
+     *
+     * @param float $amountA
+     * @param float $amountB
+     * @param PaymentCurrency|CurrencyModel|null $currency
+     * @return bool
+     */
+    public static function greaterThan(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
+    {
+        $adjustedA = static::baseAmount($amountA, $currency);
+        $adjustedB = static::baseAmount($amountB, $currency);
+
+        return $adjustedA > $adjustedB;
+    }
+
+    /**
+     * Compares if amountA is less than amountB in a reliable way as per the currency minor unit information. Not passing
+     * a currency model results in rounding in default currency.
+     *
+     * @param float $amountA
+     * @param float $amountB
+     * @param PaymentCurrency|CurrencyModel|null $currency
+     * @return bool
+     */
+    public static function lessThan(float $amountA, float $amountB, PaymentCurrency|CurrencyModel|null $currency = null): float
+    {
+        $adjustedA = static::baseAmount($amountA, $currency);
+        $adjustedB = static::baseAmount($amountB, $currency);
+
+        return $adjustedA < $adjustedB;
+    }
+
+    /**
+     * Converts the amount to an integer while maintaining the required amount of decimal places per the currency minor unit information. Not passing
+     * a currency model results in rounding in default currency.
+     *
+     * @param float $amount
+     * @param PaymentCurrency|CurrencyModel|null $currency
+     * @return bool
+     */
+    private static function baseAmount(float $amount, PaymentCurrency|CurrencyModel|null $currency = null): int
+    {
+        if (!$currency) {
+            $defaultPaymentCurrency = Plugin::getInstance()->getPaymentCurrencies()->getPrimaryPaymentCurrency();
+            $currency = Plugin::getInstance()->getCurrencies()->getCurrencyByIso($defaultPaymentCurrency->iso);
+        }
+
+
+        $decimals = $currency->minorUnit;
+        return intval(floatval(static::round($amount, $currency) . '') * pow(10, $decimals));
+    }
+
+    /**
+     * Converts the amount from an integer while maintaining the required amount of decimal places per the currency minor unit information. Not passing
+     * a currency model results in rounding in default currency.
+     *
+     * @param float $amount
+     * @param PaymentCurrency|CurrencyModel|null $currency
+     * @return bool
+     */
+    private static function floatAmount(int $amount, PaymentCurrency|CurrencyModel|null $currency = null): float
+    {
+        if (!$currency) {
+            $defaultPaymentCurrency = Plugin::getInstance()->getPaymentCurrencies()->getPrimaryPaymentCurrency();
+            $currency = Plugin::getInstance()->getCurrencies()->getCurrencyByIso($defaultPaymentCurrency->iso);
+        }
+
+
+        $decimals = $currency->minorUnit;
+        return floatval(static::round($amount / pow(10, $decimals), $currency) . '');
     }
 
     public static function defaultDecimals(): int


### PR DESCRIPTION
### Description

This fixes the paid status issue by sometimes being overpaid or partially paid by converting the floats to ints, then doing the comparisons or arithmetic, altogether avoiding any float issues. 

We just imported several hundred thousand orders from a legacy system into a new Commerce build, and this issue in #1836  was one of the issues we encountered while auditing the data migration. This solution resolves the issues in our sample size. 

We were running 4.4.1.1.

### Related issues

https://github.com/craftcms/commerce/issues/1836

First Attempt: https://github.com/craftcms/commerce/pull/1837

