### PR TITLE
Fixed MySQL error on address migration from v3

### DIFF
--- a/src/console/controllers/UpgradeController.php
+++ b/src/console/controllers/UpgradeController.php
@@ -888,32 +888,32 @@ FROM $addressesTable AS a
 WHERE NOT EXISTS (
   SELECT 1
   FROM $ordersTable AS o1
-  WHERE o1."v3billingAddressId" = a.id
+  WHERE [[o1.v3billingAddressId]] = a.id
 )
 AND NOT EXISTS (
   SELECT 1
   FROM $ordersTable AS o2
-  WHERE o2."v3shippingAddressId" = a.id
+  WHERE [[o2.v3shippingAddressId]] = a.id
 )
 AND NOT EXISTS (
   SELECT 1
   FROM $ordersTable AS o2
-  WHERE o2."v3estimatedBillingAddressId" = a.id
+  WHERE [[o2.v3estimatedBillingAddressId]] = a.id
 )
 AND NOT EXISTS (
   SELECT 1
   FROM $ordersTable AS o2
-  WHERE o2."v3shippingAddressId" = a.id
+  WHERE [[o2.v3shippingAddressId]] = a.id
 )
 AND NOT EXISTS (
   SELECT 1
   FROM $ordersTable AS o2
-  WHERE o2."v3estimatedShippingAddressId" = a.id
+  WHERE [[o2.v3estimatedShippingAddressId]] = a.id
 )
 AND NOT EXISTS (
   SELECT 1
   FROM $customersAddressesTable AS ca
-  WHERE ca."addressId" = a.id
+  WHERE [[ca.addressId]] = a.id
 );
 SQL;
 


### PR DESCRIPTION
### Description
Fix a MySQL syntax error introduced in v4.5.0 from this commit: https://github.com/craftcms/commerce/commit/cee9029aaf40b4582a21a10804d2cd5acc613289
