### PR TITLE
Fixed #3444 deleting shipping methods from footer action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where the footer delete action wasn’t deleting shipping methods. ([#3444](https://github.com/craftcms/commerce/issues/3444))
+
 ## 4.5.4 - 2024-04-24
 
 - Fixed a bug where date ranges weren’t displayed correctly on the Discounts index page. ([#3457](https://github.com/craftcms/commerce/issues/3457))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improved the performance when querying transactions. ([#3464](https://github.com/craftcms/commerce/issues/3464))
 - Fixed a bug where the footer delete action wasn’t deleting shipping methods. ([#3444](https://github.com/craftcms/commerce/issues/3444))
 
 ## 4.5.4 - 2024-04-24

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -207,7 +207,7 @@ class Plugin extends BasePlugin
     /**
      * @inheritDoc
      */
-    public string $schemaVersion = '4.5.1';
+    public string $schemaVersion = '4.5.2';
 
     /**
      * @inheritdoc

--- a/src/controllers/ShippingCategoriesController.php
+++ b/src/controllers/ShippingCategoriesController.php
@@ -129,17 +129,36 @@ class ShippingCategoriesController extends BaseShippingSettingsController
     /**
      * @throws HttpException
      */
-    public function actionDelete(): Response
+    public function actionDelete(): ?Response
     {
         $this->requirePostRequest();
-        $this->requireAcceptsJson();
 
-        $id = $this->request->getRequiredBodyParam('id');
+        $id = $this->request->getBodyParam('id');
+        $ids = $this->request->getBodyParam('ids');
 
-        if (!Plugin::getInstance()->getShippingCategories()->deleteShippingCategoryById($id)) {
+        if ((!$id && empty($ids)) || ($id && !empty($ids))) {
+            throw new BadRequestHttpException('id or ids must be specified.');
+        }
+
+        if ($id) {
+            // If it is just the one id we know it has come from an ajax request on the table
+            $this->requireAcceptsJson();
+            $ids = [$id];
+        }
+
+        $failedIds = [];
+        foreach ($ids as $id) {
+            if (!Plugin::getInstance()->getShippingCategories()->deleteShippingCategoryById($id)) {
+                $failedIds[] = $id;
+            }
+        }
+
+        if (!empty($failedIds)) {
+            // @TODO: re-word this message at next translations update
             return $this->asFailure(Craft::t('commerce', 'Could not delete shipping category'));
         }
 
+        // @TODO: re-word add better message in next translation update
         return $this->asSuccess();
     }
 

--- a/src/controllers/ShippingMethodsController.php
+++ b/src/controllers/ShippingMethodsController.php
@@ -103,14 +103,33 @@ class ShippingMethodsController extends BaseShippingSettingsController
     public function actionDelete(): ?Response
     {
         $this->requirePostRequest();
-        $this->requireAcceptsJson();
 
-        $id = $this->request->getRequiredBodyParam('id');
+        $id = $this->request->getBodyParam('id');
+        $ids = $this->request->getBodyParam('ids');
 
-        if (!Plugin::getInstance()->getShippingMethods()->deleteShippingMethodById($id)) {
+        if ((!$id && empty($ids)) || ($id && !empty($ids))) {
+            throw new BadRequestHttpException('id or ids must be specified.');
+        }
+
+        if ($id) {
+            // If it is just the one id we know it has come from an ajax request on the table
+            $this->requireAcceptsJson();
+            $ids = [$id];
+        }
+
+        $failedIds = [];
+        foreach ($ids as $id) {
+            if (!Plugin::getInstance()->getShippingMethods()->deleteShippingMethodById($id)) {
+                $failedIds[] = $id;
+            }
+        }
+
+        if (!empty($failedIds)) {
+            // @TODO: re-word this message at next translations update
             return $this->asFailure(Craft::t('commerce', 'Could not delete shipping method and its rules.'));
         }
 
+        // @TODO: re-word add better message in next translation update
         return $this->asSuccess();
     }
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -922,6 +922,7 @@ class Install extends Migration
         $this->createIndex(null, Table::TRANSACTIONS, 'gatewayId', false);
         $this->createIndex(null, Table::TRANSACTIONS, 'orderId', false);
         $this->createIndex(null, Table::TRANSACTIONS, 'userId', false);
+        $this->createIndex(null, Table::TRANSACTIONS, 'hash', false);
         $this->createIndex(null, Table::VARIANTS, 'sku', false);
         $this->createIndex(null, Table::VARIANTS, 'productId', false);
     }

--- a/src/migrations/m240430_161804_add_index_to_transaction_hash.php
+++ b/src/migrations/m240430_161804_add_index_to_transaction_hash.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace craft\commerce\migrations;
+
+use craft\commerce\db\Table;
+use craft\db\Migration;
+
+/**
+ * m240430_161804_add_index_to_transaction_hash migration.
+ */
+class m240430_161804_add_index_to_transaction_hash extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $this->createIndexIfMissing(Table::TRANSACTIONS, 'hash', false);
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m240430_161804_add_index_to_transaction_hash cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/services/ShippingCategories.php
+++ b/src/services/ShippingCategories.php
@@ -230,6 +230,16 @@ class ShippingCategories extends Component
             return false;
         }
 
+        // Find the shipping category and check it isn't the default
+        /** @var ShippingCategory $shippingCategory */
+        $shippingCategory = ArrayHelper::firstWhere($all, function(ShippingCategory $s) use ($id) {
+            return $s->id == $id;
+        });
+
+        if ($shippingCategory->default) {
+            return false;
+        }
+
         $affectedRows = Craft::$app->getDb()->createCommand()
             ->softDelete(\craft\commerce\db\Table::SHIPPINGCATEGORIES, ['id' => $id])
             ->execute();


### PR DESCRIPTION
### Description
Fix the issue with deleting a shipping method from the footer action.

This does also rely on a fix from Craft itself: https://github.com/craftcms/cms/pull/14902

### Related Issues
#3444 