### PR TITLE
Corrected translation for Number (Order Number)

### DIFF
--- a/src/translations/nl/commerce.php
+++ b/src/translations/nl/commerce.php
@@ -744,7 +744,7 @@ return [
     'Note' => 'Opmerking',
     'Notes' => 'Notities',
     'Number of Coupons' => 'Aantal coupons',
-    'Number' => 'Aantal',
+    'Number' => 'Nummer',
     'On Hand' => 'Aanwezig',
     'Only allow this gateway to be used for zero value orders?' => 'Toestaan dat deze gateway alleen wordt gebruikt voor orders met waarde nul?',
     'Only match certain purchasables…' => 'Alleen bepaalde koopbare artikelen vergelijken…',


### PR DESCRIPTION
### Description
It is currently translated to "Aantal", which translates to "Amount" in english. In this context, the correct translation should be "Nummer"


### Related issues

