### PR TITLE
Fix Commerce 5 for Postgres

### DIFF
--- a/src/migrations/m221122_055725_multi_store.php
+++ b/src/migrations/m221122_055725_multi_store.php
@@ -32,7 +32,7 @@ class m221122_055725_multi_store extends Migration
                 'dateCreated' => $this->dateTime()->notNull(),
                 'dateUpdated' => $this->dateTime()->notNull(),
                 'uid' => $this->uid(),
-                'PRIMARY KEY(id)',
+                'PRIMARY KEY[[(id]])',
             ]);
 
             $this->addForeignKey(null, Table::STORESETTINGS, ['id'], Table::STORES, ['id'], 'CASCADE', 'CASCADE');

--- a/src/migrations/m221122_055725_multi_store.php
+++ b/src/migrations/m221122_055725_multi_store.php
@@ -32,7 +32,7 @@ class m221122_055725_multi_store extends Migration
                 'dateCreated' => $this->dateTime()->notNull(),
                 'dateUpdated' => $this->dateTime()->notNull(),
                 'uid' => $this->uid(),
-                'PRIMARY KEY[[(id]])',
+                'PRIMARY KEY([[id]])',
             ]);
 
             $this->addForeignKey(null, Table::STORESETTINGS, ['id'], Table::STORES, ['id'], 'CASCADE', 'CASCADE');

--- a/src/migrations/m230110_052712_site_stores.php
+++ b/src/migrations/m230110_052712_site_stores.php
@@ -24,7 +24,7 @@ class m230110_052712_site_stores extends Migration
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
             'uid' => $this->uid(),
-            'PRIMARY KEY(siteId)',
+            'PRIMARY KEY([[siteId]])',
         ]);
 
         // Get the primary store


### PR DESCRIPTION
### Description

Properly escapes column names so it works on PostgreSQL as well (which is case-sensitive)

### Related issues

Closes #3486