### PR TITLE
Fix duplicate column error in migration

### DIFF
--- a/src/migrations/m221122_055724_move_general_settings_to_per_store_settings.php
+++ b/src/migrations/m221122_055724_move_general_settings_to_per_store_settings.php
@@ -32,7 +32,7 @@ class m221122_055724_move_general_settings_to_per_store_settings extends Migrati
         }
 
         if (!$this->db->columnExists(Table::STORES, 'allowEmptyCartOnCheckout')) {
-            $this->addColumn(Table::STORES, 'autoSetPaymentSource', $this->boolean()->notNull()->defaultValue(false));
+            $this->addColumn(Table::STORES, 'allowEmptyCartOnCheckout', $this->boolean()->notNull()->defaultValue(false));
         }
 
         if (!$this->db->columnExists(Table::STORES, 'allowEmptyCartOnCheckout')) {


### PR DESCRIPTION
### Related issues

Error when running migration on 5.0.5

```Column already exists: 1060 Duplicate column name 'autoSetPaymentSource'```

