### PR TITLE
Delete redundant addition of column

### DIFF
--- a/src/migrations/m221122_055724_move_general_settings_to_per_store_settings.php
+++ b/src/migrations/m221122_055724_move_general_settings_to_per_store_settings.php
@@ -32,10 +32,6 @@ class m221122_055724_move_general_settings_to_per_store_settings extends Migrati
         }
 
         if (!$this->db->columnExists(Table::STORES, 'allowEmptyCartOnCheckout')) {
-            $this->addColumn(Table::STORES, 'autoSetPaymentSource', $this->boolean()->notNull()->defaultValue(false));
-        }
-
-        if (!$this->db->columnExists(Table::STORES, 'allowEmptyCartOnCheckout')) {
             $this->addColumn(Table::STORES, 'allowEmptyCartOnCheckout', $this->boolean()->notNull()->defaultValue(false));
         }
 


### PR DESCRIPTION
This PR deletes the redundant addition of a column that is previously added, resulting in a `Column already exists` exception when running migrations in Commerce 5.0.5.

```
    > add column autoSetPaymentSource boolean NOT NULL DEFAULT FALSE to table {{%commerce_stores}} ... done (time: 0.006s)
    > add column autoSetPaymentSource boolean NOT NULL DEFAULT FALSE to table {{%commerce_stores}} ...Exception: SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'autoSetPaymentSource'
The SQL being executed was: ALTER TABLE `commerce_stores` ADD `autoSetPaymentSource` tinyint(1) NOT NULL DEFAULT FALSE (/var/www/html/vendor/yiisoft/yii2/db/Schema.php:676)
#0 /var/www/html/vendor/yiisoft/yii2/db/Command.php(1307): yii\db\Schema->convertException(Object(PDOException), 'ALTER TABLE `co...')
#1 /var/www/html/vendor/yiisoft/yii2/db/Command.php(1102): yii\db\Command->internalExecute('ALTER TABLE `co...')
#2 /var/www/html/vendor/yiisoft/yii2/db/Migration.php(376): yii\db\Command->execute()
#3 /var/www/html/vendor/craftcms/commerce/src/migrations/m221122_055724_move_general_settings_to_per_store_settings.php(35): yii\db\Migration->addColumn('{{%commerce_sto...', 'autoSetPaymentS...', Object(craft\db\mysql\ColumnSchemaBuilder))
```