### PR TITLE
Update Dummy.php expiry date in 4.x

### DIFF
--- a/src/gateways/Dummy.php
+++ b/src/gateways/Dummy.php
@@ -50,7 +50,7 @@ class Dummy extends SubscriptionGateway
             $paymentFormModel->firstName = 'Jenny';
             $paymentFormModel->lastName = 'Andrews';
             $paymentFormModel->number = '4242424242424242';
-            $paymentFormModel->expiry = '01/2023';
+            $paymentFormModel->expiry = '01/' . date('Y', strtotime('+1 year'));
             $paymentFormModel->cvv = '123';
         }
 


### PR DESCRIPTION
### Description

Update the expiration date of the Dummy payment gateway's dummy credit card to always be in the next year, matching how the latest version of Commerce does it. Currently it requires manually changing the year on every use due to being in the past.
