### PR TITLE
Updated `CustomerBehavior` and `CustomerAddressBehavior` to add properties to `toArray()` returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 # Unreleased
 
-- Fixed a PHP error that could occur when saving a discount. ([#3538](https://github.com/craftcms/commerce/issues/3538)) 
+- Fixed a PHP error that could occur when saving a discount. ([#3538](https://github.com/craftcms/commerce/issues/3538))
+- Added `craft\commerce\behaviors\CustomerAddressBehavior::defineFields()`.
+- Added `craft\commerce\behaviors\CustomerBehavior::defineFields()`.
 
 ## 5.0.9 - 2024-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Unreleased
 
 - Fixed a PHP error that could occur when saving a discount. ([#3538](https://github.com/craftcms/commerce/issues/3538))
+- `craft\elements\User::toArray()` now includes `primaryBillingAddressId` and `primaryShippingAddressId` keys in its response array.
+- `craft\elements\Address::toArray()` now includes `isPrimaryBilling` and `isPrimaryShipping` keys in its response array for User addresses.
 - Added `craft\commerce\behaviors\CustomerAddressBehavior::defineFields()`.
 - Added `craft\commerce\behaviors\CustomerBehavior::defineFields()`.
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,6 +117,7 @@ use craft\console\controllers\ResaveController;
 use craft\controllers\UsersController;
 use craft\debug\Module;
 use craft\elements\Address;
+use craft\elements\db\AddressQuery;
 use craft\elements\db\UserQuery;
 use craft\elements\User as UserElement;
 use craft\enums\CmsEdition;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -773,8 +773,8 @@ class Plugin extends BasePlugin
             $sender = $event->sender;
             if (Craft::$app->getDb()->getIsPgsql()) {
                 $sender->query->addSelect([
-                    'isPrimaryBilling' => new Expression('CASE WHEN [[commerce_customers.primaryBillingAddressId]] = [[addresses.id]] THEN true ELSE false'),
-                    'isPrimaryShipping' => new Expression('CASE WHEN [[commerce_customers.primaryShippingAddressId]] = [[addresses.id]] THEN true ELSE false'),
+                    'isPrimaryBilling' => new Expression('CASE WHEN [[commerce_customers.primaryBillingAddressId]] = [[addresses.id]] THEN true ELSE false END'),
+                    'isPrimaryShipping' => new Expression('CASE WHEN [[commerce_customers.primaryShippingAddressId]] = [[addresses.id]] THEN true ELSE false END'),
                 ]);
             } else {
                 $sender->query->addSelect([

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -117,7 +117,6 @@ use craft\console\controllers\ResaveController;
 use craft\controllers\UsersController;
 use craft\debug\Module;
 use craft\elements\Address;
-use craft\elements\db\AddressQuery;
 use craft\elements\db\UserQuery;
 use craft\elements\User as UserElement;
 use craft\enums\CmsEdition;
@@ -127,7 +126,6 @@ use craft\events\DefineConsoleActionsEvent;
 use craft\events\DefineEditUserScreensEvent;
 use craft\events\DefineFieldLayoutFieldsEvent;
 use craft\events\DeleteSiteEvent;
-use craft\events\PopulateElementEvent;
 use craft\events\RebuildConfigEvent;
 use craft\events\RegisterCacheOptionsEvent;
 use craft\events\RegisterComponentTypesEvent;
@@ -161,7 +159,6 @@ use craft\web\Application;
 use craft\web\twig\variables\CraftVariable;
 use Exception;
 use yii\base\Event;
-use yii\db\Expression;
 use yii\web\User;
 
 /**

--- a/src/behaviors/CustomerAddressBehavior.php
+++ b/src/behaviors/CustomerAddressBehavior.php
@@ -93,6 +93,10 @@ class CustomerAddressBehavior extends Behavior
             return;
         }
 
+        if ($this->owner->duplicateOf) {
+            return;
+        }
+
         $customersService = Plugin::getInstance()->getCustomers();
 
         $customer = $customersService->ensureCustomer($user);

--- a/src/behaviors/CustomerAddressBehavior.php
+++ b/src/behaviors/CustomerAddressBehavior.php
@@ -10,6 +10,7 @@ namespace craft\commerce\behaviors;
 use craft\commerce\Plugin;
 use craft\elements\Address;
 use craft\elements\User;
+use craft\events\DefineFieldsEvent;
 use craft\events\DefineRulesEvent;
 use yii\base\Behavior;
 use yii\base\InvalidConfigException;
@@ -25,7 +26,18 @@ use yii\base\InvalidConfigException;
  */
 class CustomerAddressBehavior extends Behavior
 {
+    /**
+     * @var bool
+     * @see getIsPrimaryBilling()
+     * @see setIsPrimaryBilling()
+     */
     private bool $_isPrimaryBilling;
+
+    /**
+     * @var bool
+     * @see getIsPrimaryShipping()
+     * @see setIsPrimaryShipping()
+     */
     private bool $_isPrimaryShipping;
 
     /**
@@ -36,7 +48,23 @@ class CustomerAddressBehavior extends Behavior
         return [
             Address::EVENT_DEFINE_RULES => 'defineRules',
             Address::EVENT_AFTER_PROPAGATE => 'afterPropagate',
+            Address::EVENT_DEFINE_FIELDS => 'defineFields',
         ];
+    }
+
+    /**
+     * @param DefineFieldsEvent $event
+     * @return void
+     * @since 5.0.10
+     */
+    public function defineFields(DefineFieldsEvent $event): void
+    {
+        if (!$this->owner->getOwner() instanceof User) {
+            return;
+        }
+
+        $event->fields['isPrimaryBilling'] = 'isPrimaryBilling';
+        $event->fields['isPrimaryShipping'] = 'isPrimaryShipping';
     }
 
     /**

--- a/src/behaviors/CustomerBehavior.php
+++ b/src/behaviors/CustomerBehavior.php
@@ -16,6 +16,7 @@ use craft\commerce\Plugin;
 use craft\commerce\records\Customer;
 use craft\elements\Address;
 use craft\elements\User;
+use craft\events\DefineFieldsEvent;
 use craft\events\DefineRulesEvent;
 use craft\events\ModelEvent;
 use craft\helpers\ArrayHelper;
@@ -83,6 +84,17 @@ class CustomerBehavior extends Behavior
     }
 
     /**
+     * @param DefineFieldsEvent $event
+     * @return void
+     * @since 5.0.10
+     */
+    public function defineFields(DefineFieldsEvent $event): void
+    {
+        $event->fields['primaryBillingAddressId'] = 'primaryBillingAddressId';
+        $event->fields['primaryShippingAddressId'] = 'primaryShippingAddressId';
+    }
+
+    /**
      * @inheritdoc
      */
     public function events(): array
@@ -90,6 +102,7 @@ class CustomerBehavior extends Behavior
         return [
             User::EVENT_AFTER_SAVE => 'afterSaveUserHandler',
             User::EVENT_DEFINE_RULES => 'defineRules',
+            User::EVENT_DEFINE_FIELDS => 'defineFields',
         ];
     }
 

--- a/tests/unit/elements/address/CustomerAddressBehaviorTest.php
+++ b/tests/unit/elements/address/CustomerAddressBehaviorTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craftcommercetests\unit\elements\address;
+
+use Codeception\Test\Unit;
+use craft\commerce\behaviors\CustomerAddressBehavior;
+use craft\elements\Address;
+use craft\elements\User;
+use UnitTester;
+
+/**
+ * CustomerAddressBehaviorTest
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.0.10
+ */
+class CustomerAddressBehaviorTest extends Unit
+{
+    /**
+     * @var UnitTester
+     */
+    protected UnitTester $tester;
+
+    public function testHasPropertiesAndMethods(): void
+    {
+        $address = \Craft::createObject(['class' => Address::class, 'primaryOwnerId' => User::find()->one()->id]);
+
+        self::assertInstanceOf(CustomerAddressBehavior::class, $address->getBehavior('commerce:address'));
+        self::assertArrayHasKey('isPrimaryBilling', $address->toArray());
+        self::assertArrayHasKey('isPrimaryShipping', $address->toArray());
+    }
+}

--- a/tests/unit/elements/user/CustomerBehaviorTest.php
+++ b/tests/unit/elements/user/CustomerBehaviorTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craftcommercetests\unit\elements\user;
+
+use Codeception\Test\Unit;
+use craft\commerce\behaviors\CustomerBehavior;
+use craft\elements\User;
+use UnitTester;
+
+/**
+ * CustomerBehaviorTest
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.0.10
+ */
+class CustomerBehaviorTest extends Unit
+{
+    /**
+     * @var UnitTester
+     */
+    protected UnitTester $tester;
+
+    public function testHasPropertiesAndMethods(): void
+    {
+        $user = User::find()->one();
+
+        self::assertInstanceOf(CustomerBehavior::class, $user->getBehavior('commerce:customer'));
+        self::assertArrayHasKey('primaryBillingAddressId', $user->toArray());
+        self::assertArrayHasKey('primaryShippingAddressId', $user->toArray());
+    }
+}


### PR DESCRIPTION
### Description
Currently, if you are in twig you have access to `primaryBillingAddressId` and `primaryShippingAddressId` on the `User` element, and `isPrimaryBilling` and `isPrimaryShipping` on the `Address` element.

However these properties were missing from the fields definitions for both of these elements. There for if you were interacting with the system via AJAX you would not receive those properties as part of the responses.

This PR adds those in as well as attempts to optimise both the user and address queries to try and negate any performance issues.