### PR TITLE
Fix Attempt to read property "id" on array error

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -3137,6 +3137,7 @@ class Order extends Element
         if (!$address instanceof AddressElement) {
             $addressElement = new AddressElement();
             $addressElement->setAttributes($address);
+            $address = $addressElement;
         }
 
         $this->estimatedBillingAddressId = $address->id;


### PR DESCRIPTION
### Description

Fixes an error when trying to set estimatedBillingAddress with an array (added the same line that's included in setEstimatedShippingAddress)


### Related issues

