### PR TITLE
Docs: Link Corrections

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -188,7 +188,7 @@ class Settings extends Model
      * @var string URL for a user to resolve billing issues with their subscription.
      *
      * ::: tip
-     * The example templates include [a template for this page](https://github.com/craftcms/commerce/tree/main/example-templates/dist/shop/plans/update-billing-details.twig).
+     * The example templates include [a template for this page](https://github.com/craftcms/commerce/tree/5.x/example-templates/dist/shop/plans/update-billing-details.twig).
      * :::
      *
      * @group Orders

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -141,7 +141,7 @@ class Settings extends Model
     /**
      * @var string|null Default URL to be loaded after using the [load cart controller action](orders-carts.md#loading-a-cart).
      *
-     * If `null` (default), Craft’s default [`siteUrl`](config4:siteUrl) will be used.
+     * If `null` (default), Craft’s default [`siteUrl`](config5:siteUrl) will be used.
      *
      * @group Cart
      * @since 3.1

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -139,7 +139,7 @@ class Settings extends Model
     public string $gatewayPostRedirectTemplate = '';
 
     /**
-     * @var string|null Default URL to be loaded after using the [load cart controller action](orders-carts.md#loading-a-cart).
+     * @var string|null Default URL to be loaded after using the [load cart controller action](https://craftcms.com/docs/commerce/5.x/system/orders-carts.html#loading-a-cart).
      *
      * If `null` (default), Craft’s default [`siteUrl`](config5:siteUrl) will be used.
      *
@@ -151,7 +151,7 @@ class Settings extends Model
     /**
      * @var array|null ISO codes for supported payment currencies.
      *
-     * See [Payment Currencies](payment-currencies.md).
+     * See [Payment Currencies](https://craftcms.com/docs/commerce/5.x/system/payment-currencies.html).
      *
      * @group Payments
      */

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -66,7 +66,7 @@ class Settings extends Model
     /**
      * @var mixed How long a cart should go without being updated before it’s considered inactive.
      *
-     * See [craft\helpers\ConfigHelper::durationInSeconds()](craft4:craft\helpers\ConfigHelper::durationInSeconds()) for a list of supported value types.
+     * See [craft\helpers\ConfigHelper::durationInSeconds()](craft5:craft\helpers\ConfigHelper::durationInSeconds()) for a list of supported value types.
      *
      * @group Cart
      * @since 2.2
@@ -177,7 +177,7 @@ class Settings extends Model
     /**
      * @var mixed Default length of time before inactive carts are purged. (Defaults to 90 days.)
      *
-     * See [craft\helpers\ConfigHelper::durationInSeconds()](craft4:craft\helpers\ConfigHelper::durationInSeconds()) for a list of supported value types.
+     * See [craft\helpers\ConfigHelper::durationInSeconds()](craft5:craft\helpers\ConfigHelper::durationInSeconds()) for a list of supported value types.
      *
      * @group Cart
      * @defaultAlt 90 days

--- a/src/models/Store.php
+++ b/src/models/Store.php
@@ -492,7 +492,7 @@ class Store extends Model
     }
 
     /**
-     * Whether [partial payment](making-payments.md#checkout-with-partial-payment) can be made from the front end when the gateway allows them.
+     * Whether [partial payment](https://craftcms.com/docs/commerce/5.x/system/development/making-payments.html#checkout-with-partial-payment) can be made from the front end when the gateway allows them.
      *
      * The `false` default does not allow partial payments on the front end.
      *
@@ -624,7 +624,7 @@ class Store extends Model
     /**
      * Human-friendly reference number format for orders. Result must be unique.
      *
-     * See [Order Numbers](orders-carts.md#order-numbers).
+     * See [Order Numbers](https://craftcms.com/docs/commerce/5.x/system/orders-carts.html#order-numbers).
      *
      * @param bool $parse
      * @return string


### PR DESCRIPTION
Catching up on a few Craft/Commerce 5.x housekeeping items—this corrects a few absolute links and a few “anchor prefixes” that are used within the Docs pipeline. ✌️