### PR TITLE
Fix migration for Postgres

### DIFF
--- a/src/migrations/m231110_081143_inventory_movement_table.php
+++ b/src/migrations/m231110_081143_inventory_movement_table.php
@@ -22,7 +22,7 @@ class m231110_081143_inventory_movement_table extends Migration
         $primaryStoreId = (new Query())
             ->select(['id'])
             ->from(Table::STORES)
-            ->where(['primary' => 1])
+            ->where(['primary' => true])
             ->scalar();
 
         // Gather the current purchasable stock counts


### PR DESCRIPTION
### Description

Upgrading from commerce 4 to 5 on Postgres 16:

```
*** applying m231110_081143_inventory_movement_table
Exception: SQLSTATE[42883]: Undefined function: 7 ERROR:  operator does not exist: boolean = integer
LINE 3: WHERE "primary"=1
                       ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
The SQL being executed was: SELECT "id"
FROM "commerce_stores"
WHERE "primary"=1
```
