### PR TITLE
Fixes Postgres error with base discount type migration

### DIFF
--- a/src/migrations/m231201_100454_update_discount_base_discount_type.php
+++ b/src/migrations/m231201_100454_update_discount_base_discount_type.php
@@ -16,7 +16,7 @@ class m231201_100454_update_discount_base_discount_type extends Migration
     public function safeUp(): bool
     {
         // Disable all the discounts that are using the incorrect `baseDiscountType`
-        $this->update(Table::DISCOUNTS, ['enabled' => false], ['baseDiscountType' => '!= value'], updateTimestamp: false);
+        $this->update(Table::DISCOUNTS, ['enabled' => false], ['not', ['baseDiscountType' => 'value']], updateTimestamp: false);
 
         // Remove `baseDiscountType` column
         $this->dropColumn(Table::DISCOUNTS, 'baseDiscountType');


### PR DESCRIPTION
### Description

Hey! When upgrading a site using Postgres with no discounts in place, I’m running into this error with the base discount type migration:

```sh
*** applying m231201_100454_update_discount_base_discount_type
    > update in {{%commerce_discounts}} ...Exception: SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input value for enum "craft_commerce_discounts_baseDiscountType": "!= value"
The SQL being executed was: UPDATE "craft_commerce_discounts" SET "enabled"=FALSE WHERE "baseDiscountType"='!= value' (/var/www/html/vendor/yiisoft/yii2/db/Schema.php:676)
#0 /var/www/html/vendor/yiisoft/yii2/db/Command.php(1325): yii\db\Schema->convertException(Object(PDOException), 'UPDATE "craft_c...')
#1 /var/www/html/vendor/yiisoft/yii2/db/Command.php(1120): yii\db\Command->internalExecute('UPDATE "craft_c...')
#2 /var/www/html/vendor/craftcms/cms/src/db/Migration.php(252): yii\db\Command->execute()
#3 /var/www/html/vendor/craftcms/commerce/src/migrations/m231201_100454_update_discount_base_discount_type.php(19): craft\db\Migration->update('{{%commerce_dis...', Array, Array, Array, false)
#4 /var/www/html/vendor/craftcms/cms/src/db/Migration.php(50): craft\commerce\migrations\m231201_100454_update_discount_base_discount_type->safeUp()
#5 /var/www/html/vendor/yiisoft/yii2/console/controllers/BaseMigrateController.php(758): craft\db\Migration->up()
#6 /var/www/html/vendor/craftcms/cms/src/console/controllers/MigrateController.php(382): yii\console\controllers\BaseMigrateController->migrateUp('m231201_100454_...')
#7 [internal function]: craft\console\controllers\MigrateController->actionAll()
#8 /var/www/html/vendor/yiisoft/yii2/base/InlineAction.php(57): call_user_func_array(Array, Array)
#9 /var/www/html/vendor/yiisoft/yii2/base/Controller.php(178): yii\base\InlineAction->runWithParams(Array)
#10 /var/www/html/vendor/yiisoft/yii2/console/Controller.php(180): yii\base\Controller->runAction('all', Array)
#11 /var/www/html/vendor/craftcms/cms/src/console/controllers/MigrateController.php(195): yii\console\Controller->runAction('all', Array)
#12 /var/www/html/vendor/yiisoft/yii2/base/Module.php(552): craft\console\controllers\MigrateController->runAction('all', Array)
#13 /var/www/html/vendor/yiisoft/yii2/console/Application.php(180): yii\base\Module->runAction('migrate/all', Array)
#14 /var/www/html/vendor/craftcms/cms/src/console/Application.php(91): yii\console\Application->runAction('migrate/all', Array)
#15 /var/www/html/vendor/yiisoft/yii2/console/Application.php(147): craft\console\Application->runAction('migrate/all', Array)
#16 /var/www/html/vendor/craftcms/cms/src/console/Application.php(122): yii\console\Application->handleRequest(Object(craft\console\Request))
#17 /var/www/html/vendor/yiisoft/yii2/base/Application.php(384): craft\console\Application->handleRequest(Object(craft\console\Request))
#18 /var/www/html/craft(13): yii\base\Application->run()
#19 {main}
*** failed to apply m231201_100454_update_discount_base_discount_type (time: 0.006s)
```

The change I made in this PR resolved the error for me, but I’m not clear enough on the original intent of the migration to know if this is actually what was supposed to be happening.

Thanks!
