### PR TITLE
Fixes another piece of this migration for Postgres

### DIFF
--- a/src/migrations/m231110_081143_inventory_movement_table.php
+++ b/src/migrations/m231110_081143_inventory_movement_table.php
@@ -124,7 +124,7 @@ class m231110_081143_inventory_movement_table extends Migration
         $primaryStore = (new Query())
             ->select(['id'])
             ->from(Table::STORES)
-            ->where(['primary' => 1])
+            ->where(['primary' => true])
             ->one();
 
         // if no primaryStore found, use first one


### PR DESCRIPTION
### Description

Hey! Best I can tell, there was one more spot that `['primary' => 1]` needed to change to `['primary' => true]` for Postgres in the migration in #3588.

I ran into this independently, but this resolves the issue for me.