### PR TITLE
Fixes custom Stripe button text param in example templates

### DIFF
--- a/example-templates/dist/shop/checkout/pay-static.twig
+++ b/example-templates/dist/shop/checkout/pay-static.twig
@@ -179,7 +179,7 @@
                         },
                         order: cart,
                         submitButtonClasses: 'cursor-pointer rounded px-4 py-2 inline-block bg-blue-500 hover:bg-blue-600 text-white hover:text-white my-2',
-                        submitButtonLabel: 'Pay',
+                        submitButtonText: 'Pay',
                         errorMessageClasses: 'bg-red-200 text-red-600 my-2 p-2 rounded',
                       } %}
                     {% endif %}

--- a/example-templates/dist/shop/checkout/payment.twig
+++ b/example-templates/dist/shop/checkout/payment.twig
@@ -90,7 +90,7 @@
                   },
                   order: cart,
                   submitButtonClasses: 'cursor-pointer rounded px-4 py-2 inline-block bg-blue-500 hover:bg-blue-600 text-white hover:text-white my-2',
-                  submitButtonLabel: 'Pay',
+                  submitButtonText: 'Pay',
                   errorMessageClasses: 'bg-red-200 text-red-600 my-2 p-2 rounded',
                 } %}
               {% endif %}

--- a/example-templates/src/shop/checkout/pay-static.twig
+++ b/example-templates/src/shop/checkout/pay-static.twig
@@ -179,7 +179,7 @@
                         },
                         order: cart,
                         submitButtonClasses: 'cursor-pointer rounded px-4 py-2 inline-block bg-blue-500 hover:bg-blue-600 text-white hover:text-white my-2',
-                        submitButtonLabel: 'Pay',
+                        submitButtonText: 'Pay',
                         errorMessageClasses: 'bg-red-200 text-red-600 my-2 p-2 rounded',
                       } %}
                     {% endif %}

--- a/example-templates/src/shop/checkout/payment.twig
+++ b/example-templates/src/shop/checkout/payment.twig
@@ -90,7 +90,7 @@
                   },
                   order: cart,
                   submitButtonClasses: '[[classes.btn.base]] [[classes.btn.mainColor]] my-2',
-                  submitButtonLabel: 'Pay',
+                  submitButtonText: 'Pay',
                   errorMessageClasses: 'bg-red-200 text-red-600 my-2 p-2 rounded',
                 } %}
               {% endif %}


### PR DESCRIPTION
### Description

Hey! Best I was able to tell, you need to customize the Stripe button text using `submitButtonText`, not `submitButtonLabel`.

[It’s correct](https://github.com/craftcms/commerce-stripe?tab=readme-ov-file#submitbuttonclasses-and-submitbuttontext) in the Stripe gateway README, but not in these example templates. The default is already “Pay” so it’s not obvious until you try and change it.