### PR TITLE
Product link type

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -331,16 +331,16 @@
         },
         {
             "name": "craftcms/cms",
-            "version": "5.3.0.3",
+            "version": "5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craftcms/cms.git",
-                "reference": "4542d22c4fadcc941a182b9d0aa423c37978716f"
+                "reference": "215a98e93a15c1e7537f42e19815d763b715d0ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craftcms/cms/zipball/4542d22c4fadcc941a182b9d0aa423c37978716f",
-                "reference": "4542d22c4fadcc941a182b9d0aa423c37978716f",
+                "url": "https://api.github.com/repos/craftcms/cms/zipball/215a98e93a15c1e7537f42e19815d763b715d0ee",
+                "reference": "215a98e93a15c1e7537f42e19815d763b715d0ee",
                 "shasum": ""
             },
             "require": {
@@ -453,7 +453,7 @@
                 "rss": "https://github.com/craftcms/cms/releases.atom",
                 "source": "https://github.com/craftcms/cms"
             },
-            "time": "2024-08-06T21:34:36+00:00"
+            "time": "2024-08-07T17:44:10+00:00"
         },
         {
             "name": "craftcms/plugin-installer",
@@ -11421,5 +11421,5 @@
         "php": "^8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -48,6 +48,7 @@ use craft\commerce\gql\interfaces\elements\Variant as GqlVariantInterface;
 use craft\commerce\gql\queries\Product as GqlProductQueries;
 use craft\commerce\gql\queries\Variant as GqlVariantQueries;
 use craft\commerce\helpers\ProjectConfigData;
+use craft\commerce\linktypes\Product as ProductLinkType;
 use craft\commerce\migrations\Install;
 use craft\commerce\models\Settings;
 use craft\commerce\plugin\Routes;
@@ -136,6 +137,7 @@ use craft\events\RegisterGqlQueriesEvent;
 use craft\events\RegisterGqlSchemaComponentsEvent;
 use craft\events\RegisterGqlTypesEvent;
 use craft\events\RegisterUserPermissionsEvent;
+use craft\fields\Link;
 use craft\fixfks\controllers\RestoreController;
 use craft\gql\ElementQueryConditionBuilder;
 use craft\helpers\ArrayHelper;
@@ -307,6 +309,7 @@ class Plugin extends BasePlugin
             $this->_registerWidgets();
             $this->_registerElementExports();
             $this->_defineFieldLayoutElements();
+            $this->_registerLinkTypes();
             $this->_registerRedactorLinkOptions();
             $this->_registerCKEditorLinkOptions();
         } else {
@@ -442,6 +445,20 @@ class Plugin extends BasePlugin
     private function _addTwigExtensions(): void
     {
         Craft::$app->view->registerTwigExtension(new Extension());
+    }
+
+    /**
+     * Register Link types
+     */
+    private function _registerLinkTypes(): void
+    {
+        if (!class_exists(Link::class)) {
+            return;
+        }
+
+        Event::on(Link::class, Link::EVENT_REGISTER_LINK_TYPES, function(RegisterComponentTypesEvent $event) {
+            $event->types[] = ProductLinkType::class;
+        });
     }
 
     /**

--- a/src/linktypes/Product.php
+++ b/src/linktypes/Product.php
@@ -48,4 +48,5 @@ class Product extends BaseElementLinkType
         }
 
         return $sources;
-    }}
+    }
+}

--- a/src/linktypes/Product.php
+++ b/src/linktypes/Product.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\commerce\linktypes;
+
+use Craft;
+use craft\commerce\elements\Product as ProductElement;
+use craft\commerce\Plugin;
+use craft\fields\linktypes\BaseElementLinkType;
+
+/**
+ * Product link type.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.1.0
+ */
+class Product extends BaseElementLinkType
+{
+    protected static function elementType(): string
+    {
+        return ProductElement::class;
+    }
+
+    protected function availableSourceKeys(): array
+    {
+        $sources = [];
+        $productTypes = Plugin::getInstance()->getProductTypes()->getAllProductTypes();
+        $sites = Craft::$app->getSites()->getAllSites();
+
+        foreach ($productTypes as $productType) {
+            $siteSettings = $productType->getSiteSettings();
+            foreach ($sites as $site) {
+                if (isset($siteSettings[$site->id]) && $siteSettings[$site->id]->hasUrls) {
+                    $sources[] = "productType:$productType->uid";
+                    break;
+                }
+            }
+        }
+
+        $sources = array_values(array_unique($sources));
+
+        if (!empty($sources)) {
+            array_unshift($sources, '*');
+        }
+
+        return $sources;
+    }}


### PR DESCRIPTION
Adds a new “Product” link type option to Link fields in Craft 5.3+.