### PR TITLE
Allow non-Craft queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed a SQL error that could occur when updating. ([#3600](https://github.com/craftcms/commerce/pull/3600), [#3601](https://github.com/craftcms/commerce/pull/3601))
 - Fixed a bug where payment modals did not calculate additional payment currencies on Edit Order pages.
 - Fixed a PHP error that occurred when retrieving an order that referenced a deleted payment currency.
+- Fixed a PHP error that occurred when using a non-Craft queue driver. ([#3619](https://github.com/craftcms/commerce/pull/3619))
 
 ## 5.0.14 - 2024-07-24
 

--- a/src/services/CatalogPricing.php
+++ b/src/services/CatalogPricing.php
@@ -23,7 +23,6 @@ use craft\helpers\ArrayHelper;
 use craft\helpers\Console;
 use craft\helpers\Db;
 use craft\helpers\Queue as QueueHelper;
-use craft\queue\Queue;
 use craft\queue\QueueInterface;
 use DateTime;
 use Illuminate\Support\Collection;
@@ -31,6 +30,7 @@ use yii\base\Component;
 use yii\base\InvalidConfigException;
 use yii\db\Exception;
 use yii\db\Expression;
+use yii\queue\Queue;
 
 /**
  * Catalog Pricing service.

--- a/src/services/CatalogPricing.php
+++ b/src/services/CatalogPricing.php
@@ -45,6 +45,12 @@ class CatalogPricing extends Component
      */
     private ?array $_allCatalogPrices = null;
 
+    /**
+     * @param Queue|QueueInterface|null $queue
+     * @param float $progress
+     * @param string|null $label
+     * @return void
+     */
     private function setQueueProgress(Queue|QueueInterface|null $queue, float $progress, ?string $label = null): void
     {
         if ($queue instanceof QueueInterface) {

--- a/src/services/CatalogPricing.php
+++ b/src/services/CatalogPricing.php
@@ -64,7 +64,7 @@ class CatalogPricing extends Component
     public function generateCatalogPrices(?array $purchasableIds = null, ?array $catalogPricingRules = null, bool $showConsoleOutput = false, Queue|QueueInterface $queue = null): void
     {
         $chunkSize = 1000;
-        $this->setQueueProgress(10, 'Retrieving purchasables');
+        $this->setQueueProgress($queue, 10, 'Retrieving purchasables');
 
         $isAllPurchasables = $purchasableIds === null;
         if ($isAllPurchasables) {
@@ -85,7 +85,7 @@ class CatalogPricing extends Component
             Console::stdout(PHP_EOL . 'Generating price data from catalog pricing rules... ');
         }
 
-        $this->setQueueProgress(20, 'Generating catalog pricing data');
+        $this->setQueueProgress($queue, 20, 'Generating catalog pricing data');
         $catalogPricing = [];
         foreach (Plugin::getInstance()->getStores()->getAllStores() as $store) {
             $priceByPurchasableId = (new Query())
@@ -151,7 +151,7 @@ class CatalogPricing extends Component
             Console::stdout(PHP_EOL . 'Created ' . count($catalogPricing) . ' rule price data in ' . round($cprExecutionLength, 2) . ' seconds' . PHP_EOL);
         }
 
-        $this->setQueueProgress(40, 'Clearing existing catalog prices');
+        $this->setQueueProgress($queue, 40, 'Clearing existing catalog prices');
         $transaction = Craft::$app->getDb()->beginTransaction();
         // Truncate the catalog pricing table
         if (!$isAllPurchasables || !empty($catalogPricingRules)) {
@@ -175,7 +175,7 @@ class CatalogPricing extends Component
 
         // If there are no specific catalog pricing rules passed in then copy the base prices into the catalog pricing table
         if (empty($catalogPricingRules)) {
-            $this->setQueueProgress(60, 'Copying base prices to catalog pricing');
+            $this->setQueueProgress($queue, 60, 'Copying base prices to catalog pricing');
             $total = count($purchasableIds);
             $baseStateTime = microtime(true);
             $count = 1;
@@ -219,7 +219,7 @@ class CatalogPricing extends Component
             }
         }
 
-        $this->setQueueProgress(80, 'Inserting catalog pricing');
+        $this->setQueueProgress($queue, 80, 'Inserting catalog pricing');
         // Batch through `$catalogPricing` and insert into the catalog pricing table
         if (!empty($catalogPricing)) {
             $count = 1;
@@ -254,7 +254,7 @@ class CatalogPricing extends Component
         }
 
         $transaction->commit();
-        $this->setQueueProgress(100);
+        $this->setQueueProgress($queue, 100);
     }
 
     /**


### PR DESCRIPTION
### Description

If you use a non-Craft queue component, e.g. `yii\queue\sqs\Queue`, you'll get an excption like this:

```
craft\commerce\services\CatalogPricing::generateCatalogPrices(): Argument #4 ($queue) must be of type craft\queue\Queue|craft\queue\QueueInterface|null, yii\queue\sqs\Queue given, called in /var/app/current/vendor/craftcms/commerce/src/queue/jobs/CatalogPricing.php on line 37
```