### PR TITLE
Fixed widgets based on thisWeek date range

### DIFF
--- a/src/base/Stat.php
+++ b/src/base/Stat.php
@@ -43,17 +43,17 @@ abstract class Stat implements StatInterface, HasStoreInterface
      */
     public function __construct(string $dateRange = null, mixed $startDate = null, mixed $endDate = null, ?int $storeId = null)
     {
+        $user = Craft::$app->getUser()->getIdentity();
+        if ($user) {
+            $this->weekStartDay = $user->getPreference('weekStartDay') ?? $this->weekStartDay;
+        }
+
         $this->dateRange = $dateRange ?? $this->dateRange;
         if ($this->dateRange && $this->dateRange != self::DATE_RANGE_CUSTOM) {
             $this->_setDates();
         } else {
             $this->setStartDate($startDate);
             $this->setEndDate($endDate);
-        }
-
-        $user = Craft::$app->getUser()->getIdentity();
-        if ($user) {
-            $this->weekStartDay = $user->getPreference('weekStartDay') ?? $this->weekStartDay;
         }
 
         $this->storeId = $storeId ?? $this->storeId;


### PR DESCRIPTION
### Description
Hi.
I noticed that changing Week Start Day on user preferences does not apply to widgets based on thisWeek and a week always start from Monday on widgets because `$this->weekStartDay` is set after `$this->_setDates();`.
This fix moves `$this->weekStartDay` to top of `__construct` function. 
I tested this and it seems it works for `Total Orders` widget and its charts start correctly from the day that user is selected as week start day.
