### PR TITLE
Don't log uncategorized exceptions

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -968,14 +968,14 @@ class Plugin extends BasePlugin
         try {
             FileHelper::createDirectory($path);
         } catch (\Exception $e) {
-            Craft::error($e->getMessage());
+            Craft::$app->getErrorHandler()->logException($e);
         }
 
         Event::on(ClearCaches::class, ClearCaches::EVENT_REGISTER_CACHE_OPTIONS, static function(RegisterCacheOptionsEvent $e) use ($path) {
             try {
                 FileHelper::createDirectory($path);
             } catch (\Exception $e) {
-                Craft::error($e->getMessage());
+                Craft::$app->getErrorHandler()->logException($e);
             }
 
             $e->options[] = [

--- a/src/elements/traits/OrderValidatorsTrait.php
+++ b/src/elements/traits/OrderValidatorsTrait.php
@@ -46,7 +46,7 @@ trait OrderValidatorsTrait
             // this will confirm the payment source is valid and belongs to the orders customer
             $this->getPaymentSource();
         } catch (InvalidConfigException $e) {
-            Craft::error($e->getMessage());
+            Craft::$app->getErrorHandler()->logException($e);
             $validator->addError($this, $attribute, Craft::t('commerce', 'Invalid payment source ID: {value}'));
         }
     }

--- a/src/services/Payments.php
+++ b/src/services/Payments.php
@@ -319,7 +319,7 @@ class Payments extends Component
                 $this->_saveTransaction($transaction);
             }
 
-            Craft::error($e->getMessage());
+            Craft::$app->getErrorHandler()->logException($e);
             throw new PaymentException($e->getMessage(), $e->getCode(), $e);
         }
     }
@@ -550,7 +550,7 @@ class Payments extends Component
             $child->message = $e->getMessage();
             $this->_saveTransaction($child);
 
-            Craft::error($e->getMessage());
+            Craft::$app->getErrorHandler()->logException($e);
         }
 
         return $child;


### PR DESCRIPTION
### Description
You might argue these logs shouldn't be there at all, since the exceptions are already thrown – but short of that, this at least gives the logs a category so they can be filtered out.

Without this, you'll get error logs for expected things like "Insufficient funds" with no good way to filter them.