### PR TITLE
Docs: PDF Event Name

### DIFF
--- a/src/services/Pdfs.php
+++ b/src/services/Pdfs.php
@@ -106,7 +106,7 @@ class Pdfs extends Component
     public const EVENT_AFTER_SAVE_PDF = 'afterSavePdf';
 
     /**
-     * @event PdfEvent The event that is triggered before an order’s PDF is rendered.
+     * @event PdfRenderEvent The event that is triggered before an order’s PDF is rendered.
      *
      * Event handlers can customize PDF rendering by modifying several properties on the event object:
      *
@@ -136,7 +136,7 @@ class Pdfs extends Component
     public const EVENT_BEFORE_RENDER_PDF = 'beforeRenderPdf';
 
     /**
-     * @event PdfEvent The event that is triggered after an order’s PDF has been rendered.
+     * @event PdfRenderEvent The event that is triggered after an order’s PDF has been rendered.
      *
      * Event handlers can override Commerce’s PDF generation by setting the `pdf` property on the event to a custom-rendered PDF string. The event properties will be the same as those from `beforeRenderPdf`, but `pdf` will contain a rendered PDF string and is the only one for which setting a value will make any difference for the resulting PDF output.
      *


### PR DESCRIPTION
Got [a report in the docs repo](https://github.com/craftcms/docs/issues/624) that the `craft\commerce\services\Pdfs::EVENT_BEFORE_RENDER_PDF` and `EVENT_AFTER_RENDER_PDF` events were showing an incorrect class in the event code generator.

I think this is the appropriate fix, per Docubot’s handling!