### PR TITLE
[5.2] Promotional pricing query methods

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -4,6 +4,12 @@
 
 ### Administration
 
+### Development
+- Added the `hasPromotionalPrice` purchasable query param.
+- Added the `hasPromotionalPrice` GraphQL variant query argument.
+
 ### Extensibility
+- Added `craft\commerce\elements\db\Purchasable::$hasPromotionalPrice`.
+- Added `craft\commerce\elements\db\Purchasable::hasPromotionalPrice()`.
 
 ### System

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -5,11 +5,11 @@
 ### Administration
 
 ### Development
-- Added the `hasPromotionalPrice` purchasable query param.
-- Added the `hasPromotionalPrice` GraphQL variant query argument.
+- Added the `onPromotion` purchasable query param.
+- Added the `onPromotion` GraphQL variant query argument.
 
 ### Extensibility
-- Added `craft\commerce\elements\db\Purchasable::$hasPromotionalPrice`.
-- Added `craft\commerce\elements\db\Purchasable::hasPromotionalPrice()`.
+- Added `craft\commerce\elements\db\Purchasable::$onPromotion`.
+- Added `craft\commerce\elements\db\Purchasable::onPromotion()`.
 
 ### System

--- a/src/elements/db/ProductQuery.php
+++ b/src/elements/db/ProductQuery.php
@@ -574,7 +574,8 @@ class ProductQuery extends ElementQuery
      *
      * | Value | Fetches {elements}…
      * | - | -
-     * | a [[VariantQuery|VariantQuery]] object | with variants that match the query.
+     * | a [[VariantQuery]] object | with variants that match the query.
+     * | a configuration [[array]] for a [[VariantQuery]] | with variants that match the criteria.
      *
      * @param VariantQuery|array $value The property value
      * @return static self reference

--- a/src/elements/db/PurchasableQuery.php
+++ b/src/elements/db/PurchasableQuery.php
@@ -55,7 +55,7 @@ abstract class PurchasableQuery extends ElementQuery
      * @var bool|null
      * @since 5.2.0
      */
-    public bool|null $hasPromotionalPrice = null;
+    public bool|null $onPromotion = null;
 
     /**
      * @var mixed|null
@@ -642,9 +642,9 @@ abstract class PurchasableQuery extends ElementQuery
      * @return static self reference
      * @since 5.2.0
      */
-    public function hasPromotionalPrice(bool|null $value = true): static
+    public function onPromotion(bool|null $value = true): static
     {
-        $this->hasPromotionalPrice = $value;
+        $this->onPromotion = $value;
         return $this;
     }
 
@@ -742,8 +742,8 @@ abstract class PurchasableQuery extends ElementQuery
             $this->subQuery->andWhere(Db::parseNumericParam('catalogprices.promotionalPrice', $this->promotionalPrice));
         }
 
-        if (isset($this->hasPromotionalPrice)) {
-            if ($this->hasPromotionalPrice) {
+        if (isset($this->onPromotion)) {
+            if ($this->onPromotion) {
                 $this->subQuery->andWhere(new Expression('[[catalogprices.promotionalPrice]] < [[catalogprices.price]]'));
             } else {
                 // Commerce normalizes these when selecting/aggregating, so the values will actually be the same when a promotional price doesn't exist. This means it's not technically possible to distinguish between an *unset* promotional price and a promotional price that ended up being the same as the regular price. It’s also ambiguous when a pricing rule sets a `promotionalPrice` based on the original `price`!

--- a/src/elements/db/PurchasableQuery.php
+++ b/src/elements/db/PurchasableQuery.php
@@ -744,10 +744,10 @@ abstract class PurchasableQuery extends ElementQuery
 
         if (isset($this->hasPromotionalPrice)) {
             if ($this->hasPromotionalPrice) {
-                $this->subQuery->andWhere(new Expression('catalogprices.promotionalPrice < catalogprices.price'));
+                $this->subQuery->andWhere(new Expression('[[catalogprices.promotionalPrice]] < [[catalogprices.price]]'));
             } else {
                 // Commerce normalizes these when selecting/aggregating, so the values will actually be the same when a promotional price doesn't exist. This means it's not technically possible to distinguish between an *unset* promotional price and a promotional price that ended up being the same as the regular price. It’s also ambiguous when a pricing rule sets a `promotionalPrice` based on the original `price`!
-                $this->subQuery->andWhere(new Expression('catalogprices.price = catalogprices.promotionalPrice'));
+                $this->subQuery->andWhere(new Expression('[[catalogprices.price]] = [[catalogprices.promotionalPrice]]'));
             }
         }
 

--- a/src/elements/db/PurchasableQuery.php
+++ b/src/elements/db/PurchasableQuery.php
@@ -52,6 +52,16 @@ abstract class PurchasableQuery extends ElementQuery
     public mixed $promotionalPrice = null;
 
     /**
+     * @var bool|null
+     */
+    public bool|null $hasPromotionalPrice = null;
+
+    /**
+     * @var bool|null
+     */
+    public bool|null $isOnPromotion = null;
+
+    /**
      * @var mixed|null
      */
     public mixed $salePrice = null;
@@ -624,6 +634,62 @@ abstract class PurchasableQuery extends ElementQuery
     }
 
     /**
+     * Return only purchasables with an active promotional price via catalog pricing rules (or which *do not* have an active promotional price).
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `true` | with a promotional price.
+     * | `false` | without a promotional price.
+     * | `null` | without taking into consideration the relationship between their price and promotional price.
+     *
+     * @param bool|null $value The property value
+     * @return static self reference
+     */
+    public function hasPromotionalPrice(bool|null $value = true): static
+    {
+        $this->hasPromotionalPrice = $value;
+        return $this;
+    }
+
+    /**
+     * Return only purchasables with a promotional price less than their price. This respects catalog pricing, and matches the return value from [[Purchasable::getIsOnPromotion()]].
+     *
+     * This method does not compare catalog prices against *base* prices, so even if a price is reduced by a rule, the purchasable will only be returned when the promotional price is less. In the same way, passing `false` *can* return purchasables with prices lower than their base price!
+     *
+     * | Value | Fetches {elements}…
+     * | - | -
+     * | `true` | with a promotional price less than its price.
+     * | `false` | with no promotional price, or a promotional price that is equal to its price.
+     * | `null` | without considering the relationship between their price and promotional price.
+     *
+     * Combine with [[forCustomer()]] to check whether a specific user (or a guest) would be eligible for promotional pricing.
+     *
+     * ---
+     *
+     * ```twig
+     * {# Fetch {elements} that are on promotion: #}
+     * {% set {elements-var} = {twig-method}
+     *   .isOnPromotion(true)
+     *   .all() %}
+     * ```
+     *
+     * ```php
+     * // Fetch {elements} that are on promotion:
+     * ${elements-var} = {php-method}
+     *     ->isOnPromotion(true)
+     *     ->all();
+     * ```
+     * 
+     * @param bool|null $value The property value
+     * @return static self reference
+     */
+    public function isOnPromotion(bool|null $value = true): static
+    {
+        $this->isOnPromotion = $value;
+        return $this;
+    }
+
+    /**
      * @inheritdoc
      */
     protected function afterPrepare(): bool
@@ -716,6 +782,25 @@ abstract class PurchasableQuery extends ElementQuery
         if (isset($this->promotionalPrice)) {
             $this->subQuery->andWhere(Db::parseNumericParam('catalogprices.promotionalPrice', $this->promotionalPrice));
         }
+
+        if (isset($this->hasPromotionalPrice)) {
+            if ($this->hasPromotionalPrice) {
+                $this->subQuery->andWhere(new Expression('catalogprices.price != catalogprices.promotionalPrice'));
+            } else {
+                // Commerce normalizes these when selecting/aggregating, so the values will actually be the same when a promotional price doesn't exist. This means it's not technically possible to distinguish between an *unset* promotional price and a promotional price that ended up being the same as the regular price. It’s also ambiguous when a pricing rule sets a `promotionalPrice` based on the original `price`!
+                $this->subQuery->andWhere(new Expression('catalogprices.price = catalogprices.promotionalPrice'));
+            }
+        }
+
+        if (isset($this->isOnPromotion)) {
+            if ($this->isOnPromotion) {
+                $this->subQuery->andWhere(new Expression('catalogprices.price > catalogprices.promotionalPrice'));
+            } else {
+                // Effective price is less than or equal to effective promotional price (`price` should never be less than `promotionalPrice` based on how they’re aggregated in the pricing subquery—but semantically, this matches what we’re trying to do):
+                $this->subQuery->andWhere(new Expression('catalogprices.price <= catalogprices.promotionalPrice'));
+            }
+        }
+
 
         if (isset($this->salePrice)) {
             $this->subQuery->andWhere(Db::parseNumericParam('catalogprices.salePrice' , $this->salePrice));

--- a/src/elements/db/PurchasableQuery.php
+++ b/src/elements/db/PurchasableQuery.php
@@ -679,7 +679,7 @@ abstract class PurchasableQuery extends ElementQuery
      *     ->isOnPromotion(true)
      *     ->all();
      * ```
-     * 
+     *
      * @param bool|null $value The property value
      * @return static self reference
      */

--- a/src/gql/arguments/elements/Variant.php
+++ b/src/gql/arguments/elements/Variant.php
@@ -83,8 +83,8 @@ class Variant extends ElementArguments
                 'type' => Type::listOf(QueryArgument::getType()),
                 'description' => 'Narrows the query results based on the variant’s promotional price.',
             ],
-            'hasPromotionalPrice' => [
-                'name' => 'hasPromotionalPrice',
+            'onPromotion' => [
+                'name' => 'onPromotion',
                 'type' => Type::boolean(),
                 'description' => 'Narrows the query results based on whether the variant has a promotional price.',
             ],

--- a/src/gql/arguments/elements/Variant.php
+++ b/src/gql/arguments/elements/Variant.php
@@ -83,6 +83,11 @@ class Variant extends ElementArguments
                 'type' => Type::listOf(QueryArgument::getType()),
                 'description' => 'Narrows the query results based on the variant’s promotional price.',
             ],
+            'hasPromotionalPrice' => [
+                'name' => 'hasPromotionalPrice',
+                'type' => Type::boolean(),
+                'description' => 'Narrows the query results based on whether the variant has a promotional price.',
+            ],
             'forCustomer' => [
                 'name' => 'forCustomer',
                 'type' => IntFalse::getType(),

--- a/tests/unit/elements/variant/PricingCatalogTest.php
+++ b/tests/unit/elements/variant/PricingCatalogTest.php
@@ -157,7 +157,17 @@ class PricingCatalogTest extends Unit
     }
 
     /**
+     * @param string $sku
+     * @param array|null $rules
+     * @param float|int|null $salePrice
+     * @param float|int|null $promotionalPrice
+     * @param float|int|null $price
      * @return void
+     * @throws Exception
+     * @throws InvalidConfigException
+     * @throws StaleObjectException
+     * @throws Throwable
+     * @throws \yii\db\Exception
      * @dataProvider variantCatalogPricesDataProvider
      * @since 5.2.0
      */

--- a/tests/unit/elements/variant/PricingCatalogTest.php
+++ b/tests/unit/elements/variant/PricingCatalogTest.php
@@ -171,12 +171,12 @@ class PricingCatalogTest extends Unit
      * @dataProvider variantCatalogPricesDataProvider
      * @since 5.2.0
      */
-    public function testVariantHasPromotionalPrice(string $sku, ?array $rules, float|int|null $salePrice, float|int|null $promotionalPrice, float|int|null $price): void
+    public function testVariantOnPromotion(string $sku, ?array $rules, float|int|null $salePrice, float|int|null $promotionalPrice, float|int|null $price): void
     {
         $catalogPricingRules = $this->_createCatalogPricingRules($rules);
 
-        $variantHasPromotionalPrice = Variant::find()->hasPromotionalPrice()->one();
-        $variantHasntPromotionalPrice = Variant::find()->hasPromotionalPrice(false)->one();
+        $variantHasPromotionalPrice = Variant::find()->onPromotion()->one();
+        $variantHasntPromotionalPrice = Variant::find()->onPromotion(false)->one();
 
         if ($promotionalPrice !== null) {
             self::assertInstanceof(Variant::class, $variantHasPromotionalPrice);


### PR DESCRIPTION
### Description

Adds `PurchasableQuery::hasPromotionalPrice()` to aid in discovering purchasables with a promotional price less than their regular price. This is designed as a replacement for the `hasSales()` query parameter for legacy Commerce applications.

```twig
{% set variantsWithPromotionalPrices = craft.variants()
  .hasPromotionalPrice(true) %}

{% set productsOnSale = craft.products()
  .hasVariant(variantsWithPromotionalPrices)
  .all() %}
```

Our [Listing Products On Sale](https://craftcms.com/knowledge-base/listing-products-on-sale) Knowledge Base article covers some DIY versions of this method—and a few advanced arithmetic queries! (I'll update this after this PR is merged.)

We've talked internally about what being “on promotion” actually means—currently, the comparisons are done against catalog pricing—but there are definitely developers and store managers who would expect that the system looks at the _base_ prices (i.e. base price > price, or base price > promotional price), not just the fully-resolved catalog prices!

The _existence_ of a base promotional price is a bit more challenging to detect (as far as query complexity goes), but I am pretty confident that the result would be the same… whether you check for an empty `basePromotionalPrice` or `price = promotionalPrice` would net the same results, due to the way purchasable prices are translated into the catalog pricing table (and then normalized/aggregated during the query).