### PR TITLE
[5.x] Fixed Edit Order page error when viewing order with deleted purchasable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where modified parameters in the `\craft\commerce\events\CreateSubscriptionEvent` were not being passed to the gateway.
 - Fixed a bug where aggregate store stock levels weren’t being updated when inventory was updated. ([#3668](https://github.com/craftcms/commerce/issues/3668))
 - The `commerce/reset-data` command now clears inventory transactions.
+- Fixed a PHP error that could occur when viewing the Edit Order page after deleting a purchasable. ([#3677](https://github.com/craftcms/commerce/issues/3677))
 
 ## 5.1.1 - 2024-09-10
 

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -802,7 +802,8 @@ class LineItem extends Model
      */
     public function getHasFreeShipping(): bool
     {
-        if ($this->type === LineItemType::Purchasable) {
+        // For purchasable line item types try and get the live data
+        if ($this->type === LineItemType::Purchasable && $this->getPurchasable()) {
             return $this->getPurchasable()->hasFreeShipping();
         }
 
@@ -959,7 +960,8 @@ class LineItem extends Model
      */
     public function getIsPromotable(): bool
     {
-        if ($this->type === LineItemType::Purchasable) {
+        // For purchasable line item types try and get the live data
+        if ($this->type === LineItemType::Purchasable && $this->getPurchasable()) {
             return $this->getPurchasable()->getIsPromotable();
         }
 
@@ -1083,7 +1085,7 @@ class LineItem extends Model
         }
 
         if (!$this->getPurchasable()) {
-            return true; // we have a default tax category so assume so.
+            return $this->_isTaxable ?? true; // we have a default tax category so assume so.
         }
 
         return $this->getPurchasable()->getIsTaxable();
@@ -1109,7 +1111,7 @@ class LineItem extends Model
         }
 
         if (!$this->getPurchasable()) {
-            return true; // we have a default shipping category so assume so.
+            return $this->_isShippable ?? true; // we have a default shipping category so assume so.
         }
 
         return Plugin::getInstance()->getPurchasables()->isPurchasableShippable($this->getPurchasable(), $this->getOrder());

--- a/src/services/LineItems.php
+++ b/src/services/LineItems.php
@@ -275,12 +275,11 @@ class LineItems extends Component
         $lineItemRecord->isShippable = null;
         $lineItemRecord->isTaxable = null;
 
-        if ($lineItem->type === LineItemType::Custom) {
-            $lineItemRecord->hasFreeShipping = $lineItem->getHasFreeShipping();
-            $lineItemRecord->isPromotable = $lineItem->getIsPromotable();
-            $lineItemRecord->isShippable = $lineItem->getIsShippable();
-            $lineItemRecord->isTaxable = $lineItem->getIsTaxable();
-        }
+        // Save this information for all line item types, even though live lookups will happen for line items with purchasables
+        $lineItemRecord->hasFreeShipping = $lineItem->getHasFreeShipping();
+        $lineItemRecord->isPromotable = $lineItem->getIsPromotable();
+        $lineItemRecord->isShippable = $lineItem->getIsShippable();
+        $lineItemRecord->isTaxable = $lineItem->getIsTaxable();
 
         $lineItemRecord->purchasableId = $lineItem->purchasableId;
         $lineItemRecord->orderId = $lineItem->orderId;


### PR DESCRIPTION
### Description
A PHP error would be displayed when viewing an order with a line item that is associated with a deleted purchasable.


### Related issues
#3677