### PR TITLE
Fixed #3692 define additional buttons not displaying on order edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where additional buttons defined with `Order::EVENT_DEFINE_ADDITIONAL_BUTTONS` weren’t displayed on the Edit Order screen. ([#3692](https://github.com/craftcms/commerce/issues/3692))
+
 ## 5.1.3 - 2024-10-02
 
 - Fixed a bug where variants weren’t respecting their product’s propagation method.

--- a/src/templates/orders/_edit.twig
+++ b/src/templates/orders/_edit.twig
@@ -181,6 +181,12 @@
     <input type="hidden" name="orderId" value="{{ order.id }}">
     {{ redirectInput('commerce/orders/'~order.id) }}
 
+    {% if order.getAdditionalButtons() %}
+      <div id="order-additional-buttons" class="flex">
+        {{ order.getAdditionalButtons()|raw }}
+      </div>
+    {% endif %}
+
     <div id="order-secondary-actions" class="flex">
         {% hook "cp.commerce.order.edit.order-secondary-actions" %}
         <div id="order-secondary-actions-app"></div>


### PR DESCRIPTION
### Related issues
#3692 