### PR TITLE
when getting variants for NestedElementsController, include disabled too

### DIFF
--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -105,6 +105,22 @@ class Product extends Element implements HasStoreInterface
     /**
      * @inheritdoc
      */
+    public function __get($name)
+    {
+        // in v6 consider having Product::getVariants() return ElementQueryInterface, so this can be removed
+        if ($name === 'variants') {
+            $actionSegments = Craft::$app->getRequest()->actionSegments;
+            if (isset($actionSegments[0]) && $actionSegments[0] === 'nested-elements') {
+                return $this->getVariants(true);
+            }
+        }
+
+        return parent::__get($name);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public static function displayName(): string
     {
         return Craft::t('commerce', 'Product');


### PR DESCRIPTION
### Description
When the `nested-elements/reorder` action is called for product variants, the `beforeAction()` method calls `getVariants()` via [magic getter](https://github.com/craftcms/cms/blob/5.5.0.1/src/controllers/NestedElementsController.php#L69) and a collection of elements is returned. By default, `getVariants()` doesn’t grab disabled elements. 

For reordering to work in that case, the disabled elements have to be returned, too.

(I opted to amend the getter for the other NestedElementsController action, too (delete). Commerce doesn’t seem to use it at the moment, but just in case.)


### Related issues
#3769 
