### PR TITLE
Purchasable line items missing their CP edit URL on order edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where purchasable line items were missing their CP edit URL on the Edit Order page. ([#3792](https://github.com/craftcms/commerce/issues/3792))
+
 ## 5.2.7 - 2024-11
 
 - Fixed an error that occurred on the Orders index page when running Craft CMS 5.5.4 or later. ([#3793](https://github.com/craftcms/commerce/issues/3793))

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -743,6 +743,14 @@ class Variant extends Purchasable implements NestedElementInterface
     /**
      * @inheritdoc
      */
+    public function getCpEditUrl(): ?string
+    {
+        return $this->getOwner() ? $this->getOwner()->getCpEditUrl() : '';
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getUrl(): ?string
     {
         $productUrl = $this->getOwner()?->getUrl();

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -745,7 +745,7 @@ class Variant extends Purchasable implements NestedElementInterface
      */
     public function getCpEditUrl(): ?string
     {
-        return $this->getOwner() ? $this->getOwner()->getCpEditUrl() : '';
+        return $this->getOwner() ? $this->getOwner()->getCpEditUrl() : null;
     }
 
     /**


### PR DESCRIPTION
### Description



### Related issues
#3792
