### PR TITLE
Improve shipping methods performance

### DIFF
--- a/src/services/ShippingMethods.php
+++ b/src/services/ShippingMethods.php
@@ -125,7 +125,6 @@ class ShippingMethods extends Component
 
         /** @var ShippingMethod $method */
         foreach ($event->shippingMethods as $method) {
-
             if ($method->getIsEnabled() && $method->matchOrder($order)) {
                 $matchingMethods[$method->getHandle()] = [
                     'method' => $method,

--- a/src/services/ShippingMethods.php
+++ b/src/services/ShippingMethods.php
@@ -125,12 +125,11 @@ class ShippingMethods extends Component
 
         /** @var ShippingMethod $method */
         foreach ($event->shippingMethods as $method) {
-            $totalPrice = $method->getPriceForOrder($order);
 
             if ($method->getIsEnabled() && $method->matchOrder($order)) {
                 $matchingMethods[$method->getHandle()] = [
                     'method' => $method,
-                    'price' => $totalPrice, // Store the price so we can sort on it before returning
+                    'price' => $method->getPriceForOrder($order), // Store the price so we can sort on it before returning
                 ];
             }
         }


### PR DESCRIPTION
### Description

Currently commerce already calculates shipping methods total price before checking if it is enabled or matches the order. We have a lot of disabled shipping methods and this causes performance issues. Looking at the code I see no reason to move this line after the enabled/match checks.

