### PR TITLE
Error saving OrderHistory, userId must be initialized, fixed #3858

### DIFF
--- a/src/models/OrderHistory.php
+++ b/src/models/OrderHistory.php
@@ -56,7 +56,7 @@ class OrderHistory extends Model
     /**
      * @var int|null User ID
      */
-    public ?int $userId;
+    public ?int $userId = null;
 
     /**
      * @var string|null User name or email


### PR DESCRIPTION
### Description

When updating an Order Status through the console we are currently facing the following exception:
Typed property craft\commerce\models\OrderHistory::$userId must not be accessed before initialization

This fix sets the userId to null on initialization.

### Related issues
#3858
