### PR TITLE
Restore variants when product is restored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where soft-deleted variants were not being restored when the product was restored. ([#3815](https://github.com/craftcms/commerce/issues/3815)) 
+
 ## 5.3.1 - 2025-02-03
 
 - Improved logging when a user deletion is prevented due to the user having Commerce orders. ([#3686](https://github.com/craftcms/commerce/issues/3686))

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -1656,6 +1656,16 @@ class Product extends Element implements HasStoreInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function afterRestore(): void
+    {
+        $this->getVariantManager()->restoreNestedElements($this);
+
+        parent::afterRestore();
+    }
+
+    /**
      * @inheritdoc
      */
     protected function defineRules(): array

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1020,7 +1020,7 @@ class Install extends Migration
             'id' => $this->integer()->notNull(),
             'primaryOwnerId' => $this->integer(),
             'isDefault' => $this->boolean()->notNull()->defaultValue(false),
-            'deletedWithProduct' => $this->boolean()->notNull()->defaultValue(false),
+            'deletedWithProduct' => $this->boolean()->notNull()->defaultValue(false), // TODO: Remove in 6.0
             'dateCreated' => $this->dateTime()->notNull(),
             'dateUpdated' => $this->dateTime()->notNull(),
             'uid' => $this->uid(),


### PR DESCRIPTION
### Description

Fixes the restore of variants when their product is restored.

The old `deletedWithProduct` never worked. The column in the variants table never was populated. `deletedWithOwner` is the correct property.

I have deprecated the property and marked it to be removed in next break-point.

### Related issues

https://github.com/craftcms/commerce/issues/3815
