### PR TITLE
Fix currency formatting behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where line items totals could be formatted in the wrong currency on Edit Order pages. ([#3891](https://github.com/craftcms/commerce/issues/3891)) 
+
 ## 5.3.2.2 - 2025-02-10
 
 - Fixed a bug where carts’ adjustment totals could be calculated incorrectly. ([#3888](https://github.com/craftcms/commerce/issues/3888))

--- a/src/elements/Donation.php
+++ b/src/elements/Donation.php
@@ -57,7 +57,6 @@ class Donation extends Purchasable
 
         $behaviors['currencyAttributes'] = [
             'class' => CurrencyAttributeBehavior::class,
-            'defaultCurrency' => $this->_order->currency ?? Plugin::getInstance()->getPaymentCurrencies()->getPrimaryPaymentCurrencyIso(),
             'currencyAttributes' => $this->currencyAttributes(),
         ];
 

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1302,7 +1302,6 @@ class Order extends Element implements HasStoreInterface
 
         $behaviors['currencyAttributes'] = [
             'class' => CurrencyAttributeBehavior::class,
-            'defaultCurrency' => $this->currency ?? Plugin::getInstance()->getPaymentCurrencies()->getPrimaryPaymentCurrencyIso(),
             'currencyAttributes' => $this->currencyAttributes(),
         ];
 

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -266,7 +266,7 @@ class LineItem extends Model
 
         $behaviors['currencyAttributes'] = [
             'class' => CurrencyAttributeBehavior::class,
-            'defaultCurrency' => Plugin::getInstance()->getPaymentCurrencies()->getPrimaryPaymentCurrencyIso(),
+            'defaultCurrency' => $this->getOrder()?->currency ?? null,
             'currencyAttributes' => $this->currencyAttributes(),
         ];
 

--- a/src/models/OrderAdjustment.php
+++ b/src/models/OrderAdjustment.php
@@ -96,7 +96,7 @@ class OrderAdjustment extends Model
 
         $behaviors['currencyAttributes'] = [
             'class' => CurrencyAttributeBehavior::class,
-            'defaultCurrency' => Plugin::getInstance()->getPaymentCurrencies()->getPrimaryPaymentCurrencyIso(),
+            'defaultCurrency' => $this->getCurrency(),
             'currencyAttributes' => $this->currencyAttributes(),
         ];
 
@@ -137,13 +137,13 @@ class OrderAdjustment extends Model
         return $attributes;
     }
 
-    protected function getCurrency(): string
+    /**
+     * @return ?string
+     * @throws InvalidConfigException
+     */
+    protected function getCurrency(): ?string
     {
-        if (!isset($this->_order->currency)) {
-            throw new InvalidConfigException('Order doesn’t have a currency.');
-        }
-
-        return $this->_order->currency;
+        return $this->getOrder()?->currency;
     }
 
     /**


### PR DESCRIPTION
Moved the default to the currency behavior
Removed setting the default with defining the currency behaviour when the object has the `HasStore` interface.

Fixes https://github.com/craftcms/commerce/issues/3891