### PR TITLE
Fix bug where shipping rule's categories conditions were not being saved in non-primary stores.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where shipping rules weren’t saving their shipping category conditions in non-primary stores.
+
 ## 5.3.3 - 2025-02-19
 
 - Fixed a bug where line item totals could be formatted in the wrong currency on Edit Order pages. ([#3891](https://github.com/craftcms/commerce/issues/3891)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where shipping rules weren’t saving their shipping category conditions in non-primary stores.
+- Fixed a bug where shipping rules weren’t saving their shipping category conditions in non-primary stores. ([#3851](https://github.com/craftcms/commerce/issues/3851))
 
 ## 5.3.3 - 2025-02-19
 

--- a/src/services/ShippingRuleCategories.php
+++ b/src/services/ShippingRuleCategories.php
@@ -25,11 +25,6 @@ use yii\db\StaleObjectException;
 class ShippingRuleCategories extends Component
 {
     /**
-     * @var ShippingRuleCategory[][]
-     */
-    private array $_shippingRuleCategoriesByRuleId = [];
-
-    /**
      * Returns an array of shipping rules categories per the rule's ID.
      *
      * @param int $ruleId the rule's ID
@@ -37,19 +32,18 @@ class ShippingRuleCategories extends Component
      */
     public function getShippingRuleCategoriesByRuleId(int $ruleId): array
     {
-        if (empty($this->_shippingRuleCategoriesByRuleId)) {
-            $rows = $this->_createShippingRuleCategoriesQuery()
-                ->all();
+        $rules = [];
 
-            foreach ($rows as $row) {
-                if (!isset($this->_shippingRuleCategoriesByRuleId[$row['shippingRuleId']])) {
-                    $this->_shippingRuleCategoriesByRuleId[$row['shippingRuleId']] = [];
-                }
-                $this->_shippingRuleCategoriesByRuleId[$row['shippingRuleId']][$row['shippingCategoryId']] = new ShippingRuleCategory($row);
-            }
+        $rows = $this->_createShippingRuleCategoriesQuery()
+            ->where(['shippingRuleId' => $ruleId])
+            ->all();
+
+        foreach ($rows as $row) {
+            $id = $row['shippingCategoryId'];
+            $rules[$id] = new ShippingRuleCategory($row);
         }
 
-        return $this->_shippingRuleCategoriesByRuleId[$ruleId] ?? [];
+        return $rules;
     }
 
     /**

--- a/src/services/ShippingRules.php
+++ b/src/services/ShippingRules.php
@@ -147,7 +147,7 @@ class ShippingRules extends Component
         ShippingRuleCategoryRecord::deleteAll(['shippingRuleId' => $model->id]);
 
         // Generate a rule category record for all categories regardless of data submitted
-        foreach (Plugin::getInstance()->getShippingCategories()->getAllShippingCategories() as $shippingCategory) {
+        foreach (Plugin::getInstance()->getShippingCategories()->getAllShippingCategories($model->storeId) as $shippingCategory) {
             $ruleCategory = $model->getShippingRuleCategories()[$shippingCategory->id] ?? null;
             if ($ruleCategory) {
                 $ruleCategory = new ShippingRuleCategory([


### PR DESCRIPTION
### Description

Fix bug where shipping rule's categories conditions were not being saved in non-primary stores.

### Related issues

https://github.com/craftcms/commerce/issues/3851