### PR TITLE
Update generics for ProductQuery and VariantQuery

### DIFF
--- a/src/elements/db/ProductQuery.php
+++ b/src/elements/db/ProductQuery.php
@@ -25,6 +25,10 @@ use yii\db\Expression;
 /**
  * ProductQuery represents a SELECT SQL statement for products in a way that is independent of DBMS.
  *
+ * @template TKey of array-key
+ * @template TElement of Product
+ * @extends ElementQuery<TKey,TElement>
+ *
  * @method Product[]|array all($db = null)
  * @method Product|array|null one($db = null)
  * @method Product|array|null nth(int $n, Connection $db = null)

--- a/src/elements/db/PurchasableQuery.php
+++ b/src/elements/db/PurchasableQuery.php
@@ -22,6 +22,10 @@ use yii\db\Expression;
 /**
  * PurchasableQuery represents a SELECT SQL statement for purchasables in a way that is independent of DBMS.
  *
+ * @template TKey of array-key
+ * @template TElement of Purchasable
+ * @extends ElementQuery<TKey,TElement>
+ *
  * @method Purchasable[]|array all($db = null)
  * @method Purchasable|array|null one($db = null)
  * @method Purchasable|array|null nth(int $n, Connection $db = null)

--- a/src/elements/db/VariantQuery.php
+++ b/src/elements/db/VariantQuery.php
@@ -29,7 +29,6 @@ use yii\db\Expression;
 /**
  * VariantQuery represents a SELECT SQL statement for variants in a way that is independent of DBMS.
  *
- *
  * @template TKey of array-key
  * @template TElement of Variant
  *


### PR DESCRIPTION
### Description

Updates generic definitions for product and variant queries so that type definitions like this will work:

```php
/**
 * @template TKey of array-key
 * @template TElement of Element
 * @param ElementQuery<TKey, TElement> $query
 */
public function doSomethingWithQuery(ElementQuery $query): void
{
	// ...
}


doSomethingWithQuery(Variant::find());
doSomethingWithQuery(Product::find());
```

### Related issues

N/A
