### PR TITLE
Fix setting custom fields in variant collection

### DIFF
--- a/src/elements/VariantCollection.php
+++ b/src/elements/VariantCollection.php
@@ -35,9 +35,16 @@ class VariantCollection extends ElementCollection
                 continue;
             }
 
+            $attributes = $item;
+
             $item = \Craft::createObject(Variant::class, [
-                'config' => ['attributes' => $item],
+                'config' => ['attributes' => $attributes],
             ]);
+
+            // Set custom fields if provided
+            if (isset($attributes['fields'])) {
+                $item->setFieldValues($attributes['fields']);
+            }
         }
 
         /** @var static $collection */


### PR DESCRIPTION
### Description

Now also sets custom field values in variant collection, not only attributes

### Related issues

Fixes #3927 
