### PR TITLE
[5.x] Fix PHP error when parsing bad condition formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a PHP error that could occur with an invalid Postal Code condition rule twig formula. ([#3943](https://github.com/craftcms/commerce/issues/3943))
 - Fixed an SQL error that occurred when viewing variant element indexes containing product sources that have product types with structure sources. ([#3944](https://github.com/craftcms/commerce/issues/3944))
 - Fixed a bug where catalog pricing rules’ purchasables could be returned incorrectly. ([#3917](https://github.com/craftcms/commerce/issues/3917))
 - Fixed a PHP error that could occur when making a payment in payment modals on Edit Order pages. ([#3919](https://github.com/craftcms/commerce/issues/3919))

--- a/src/elements/conditions/addresses/PostalCodeFormulaConditionRule.php
+++ b/src/elements/conditions/addresses/PostalCodeFormulaConditionRule.php
@@ -57,13 +57,12 @@ class PostalCodeFormulaConditionRule extends BaseTextConditionRule implements El
         $formula = $this->value;
         $postalCode = $address->postalCode;
 
-        $result = (bool)$formulasService->evaluateCondition($formula, ['postalCode' => $postalCode], 'Postal code formula matching address');
-
-        if (!$result) {
+        try {
+            return (bool)$formulasService->evaluateCondition($formula, ['postalCode' => $postalCode], 'Postal code formula matching address');
+        } catch (\Throwable $e) {
+            Craft::error('Error evaluating postal code formula: ' . $formula,'commerce');
             return false;
         }
-
-        return true;
     }
 
     public function operators(): array


### PR DESCRIPTION
### Description

Formula will just return false if it has an invalid twig syntax.

Fixes https://github.com/craftcms/commerce/issues/3943

