### PR TITLE
Fix: Plugin::$instance->currencies->numericCodeFor should return numeric code

### DIFF
--- a/src/services/Currencies.php
+++ b/src/services/Currencies.php
@@ -126,6 +126,6 @@ class Currencies extends Component
             $currency = $this->getCurrencyByIso($currency);
         }
 
-        return $this->_isoCurrencies->subunitFor($currency);
+        return $this->_isoCurrencies->numericCodeFor($currency);
     }
 }


### PR DESCRIPTION
Obviously, a Copy & Paste error