### PR TITLE
Fix missing hydration of metadata for pricing rule

### DIFF
--- a/src/services/CatalogPricingRules.php
+++ b/src/services/CatalogPricingRules.php
@@ -345,6 +345,7 @@ class CatalogPricingRules extends Component
                 'purchasableCondition',
                 'storeId',
                 'variantCondition',
+                'metadata',
             ])
             ->from(Table::CATALOG_PRICING_RULES);
     }


### PR DESCRIPTION
### Description

The `CatalogPricing` model offers a way to get and set metadata. When saving, the metadata is written to the database. But when loading the model, the metadata is currently missing. This PR adds the missing `metadata` column when loading the data from the database.