### PR TITLE
[5.4] Added metadata display to catalog pricing rule edit screens

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -3,6 +3,7 @@
 ### Store Management
 - It is now possible to set a variant’s status from the Product Edit screen. ([#3953](https://github.com/craftcms/commerce/discussions/3953))
 - Added an Order condition builder to gateways. ([#3913](https://github.com/craftcms/commerce/discussions/3913))
+- Custom metadata is now displayed on the Catalog Pricing Rule Edit screen. ([#3975](https://github.com/craftcms/commerce/pull/3975))
 
 ### Extensibility
 - Added `craft\commerce\base\Gateway::setOrderCondition()`.

--- a/src/services/CatalogPricingRules.php
+++ b/src/services/CatalogPricingRules.php
@@ -340,6 +340,7 @@ class CatalogPricingRules extends Component
                 'enabled',
                 'id',
                 'isPromotionalPrice',
+                'metadata',
                 'name',
                 'productCondition',
                 'purchasableCondition',

--- a/src/templates/store-management/pricing-rules/_sidebar.twig
+++ b/src/templates/store-management/pricing-rules/_sidebar.twig
@@ -27,5 +27,20 @@
       <h5 class="heading">{{ "Updated at"|t('app') }}</h5>
       <div id="date-updated-value" class="value">{{ catalogPricingRule.dateUpdated|datetime('short') }}</div>
     </div>
+
+    {% if catalogPricingRule.metadata|length %}
+      {% for key, val in catalogPricingRule.metadata %}
+        <div class="data">
+          <h5 class="heading">{{ key|e }}</h5>
+          <div class="value">
+            {% if val is iterable %}
+              <pre><code>{{ val|json_encode|e }}</code></pre>
+            {% else %}
+              {{ val|e }}
+            {% endif %}
+          </div>
+        </div>
+      {% endfor %}
+    {% endif %}
   </div>
 {% endif %}


### PR DESCRIPTION
### Description
Add the display of any custom metadata stored on Catalog Pricing Rules


### Related issues
#3975
