### PR TITLE
Example template - fix list of transactions for offsite gateways and style failed transactions

### DIFF
--- a/example-templates/src/shop/customer/order.twig
+++ b/example-templates/src/shop/customer/order.twig
@@ -285,27 +285,50 @@
         </h3>
         <table class="w-full">
           <tbody>
-          {% for transaction in order.transactions %}
-            <tr>
-              <td>
-                <span class="mr-1 uppercase text-xs border rounded-sm px-2 py-1 tracking-wide{{ transaction.status == 'success' ? ' text-green-500 border-green-500' : '' }}">
-                  {{- transaction.status -}}
-                </span>
-              </td>
-              <td class="text-left align-text-top pt-3 pr-3 {% if transaction.getParent() %}pl-5{% endif %}">
-                <span>
-                  {{- transaction.amountAsCurrency }} {{ transaction.currency }} {{ transaction.type -}}
-                </span>
-                <br>
-                <span class="text-gray-600 text-sm">
-                  ({{ transaction.paymentAmountAsCurrency }} {{ transaction.paymentCurrency }} {{ 'paid'|t }})
-                </span>
-              </td>
-              <td class="text-left align-text-top pt-3 pr-3 text-right">
-                {{ transaction.dateCreated|datetime }}
-              </td>
-            </tr>
-          {% endfor %}
+            {% set parentTransactions = craft.commerce.transactions.getAllTopLevelTransactionsByOrderId(order.id) %}
+            {% for transaction in parentTransactions %}
+              <tr>
+                <td>
+                  <span class="mr-1 uppercase text-xs border rounded-sm px-2 py-1 tracking-wide{{ transaction.status == 'success' ? ' text-green-500 border-green-500' : '' }} tracking-wide{{ transaction.status == 'failed' ? ' text-red-500 border-red-500' : '' }}">
+                    {{- transaction.status -}}
+                  </span>
+                </td>
+                <td class="text-left align-text-top pt-3 pr-3">
+                  <span>
+                    {{- transaction.amountAsCurrency }} {{ transaction.currency }} {{ transaction.type -}}
+                  </span>
+                  <br>
+                  <span class="text-gray-600 text-sm">
+                    ({{ transaction.paymentAmountAsCurrency }} {{ transaction.paymentCurrency }} {{ 'paid'|t }})
+                  </span>
+                </td>
+                <td class="text-left align-text-top pt-3 pr-3 text-right">
+                  {{ transaction.dateCreated|datetime }}
+                </td>
+              </tr>
+              {% set childTransactions = craft.commerce.transactions.getChildrenByTransactionId(transaction.id) %}
+              {% for transaction in childTransactions %}
+                <tr>
+                  <td>
+                    <span class="mr-1 uppercase text-xs border rounded-sm px-2 py-1 tracking-wide{{ transaction.status == 'success' ? ' text-green-500 border-green-500' : '' }} tracking-wide{{ transaction.status == 'failed' ? ' text-red-500 border-red-500' : '' }}">
+                      {{- transaction.status -}}
+                    </span>
+                  </td>
+                  <td class="text-left align-text-top pt-3 pr-3 pl-5">
+                    <span>
+                      {{- transaction.amountAsCurrency }} {{ transaction.currency }} {{ transaction.type -}}
+                    </span>
+                    <br>
+                    <span class="text-gray-600 text-sm">
+                      ({{ transaction.paymentAmountAsCurrency }} {{ transaction.paymentCurrency }} {{ 'paid'|t }})
+                    </span>
+                  </td>
+                  <td class="text-left align-text-top pt-3 pr-3 text-right">
+                    {{ transaction.dateCreated|datetime }}
+                  </td>
+                </tr>
+              {% endfor %}
+            {% endfor %}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
### Description
In the example templates, the order's transactions are listed based on the results of `order.transactions`. For offsite gateways, this may not always work correctly, and there is a possibility that a child transaction is listed below another parent transaction. This PR aims to ensure that child transactions are listed below their related parent transaction. another improvement is failed transactions are styled in red.


