### PR TITLE
FIxed PHP error when sending emails with orders that could not be serialized.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a PHP error that could occur when sending emails. ([#4017](https://github.com/craftcms/commerce/issues/4017))
+
 ## 5.3.13 - 2025-05-21
 
 - Fixed a bug where the “Recipient”, “BCC’d Recipient”, and “CC’d Recipient” email settings weren’t working properly if set to environment variables. ([#4004](https://github.com/craftcms/commerce/issues/4004), [#4002](https://github.com/craftcms/commerce/issues/4002))

--- a/src/queue/jobs/SendEmail.php
+++ b/src/queue/jobs/SendEmail.php
@@ -37,23 +37,19 @@ class SendEmail extends BaseJob implements RetryableJobInterface
     public int $orderHistoryId;
 
     /**
-     * @var Order|null
-     */
-    private ?Order $_order = null;
-
-
-    /**
      * @inheritDoc
      */
     public function execute($queue): void
     {
         $this->setProgress($queue, 0.2);
 
-        if (!$this->_getOrder()) {
+        $order = $this->_getOrder();
+
+        if (!$order) {
             throw new InvalidConfigException('Invalid order ID: ' . $this->orderId);
         }
 
-        $email = Plugin::getInstance()->getEmails()->getEmailById($this->commerceEmailId, $this->_getOrder()->getStore()->id);
+        $email = Plugin::getInstance()->getEmails()->getEmailById($this->commerceEmailId, $order->getStore()->id);
         if (!$email) {
             throw new InvalidConfigException('Invalid email ID: ' . $this->commerceEmailId);
         }
@@ -62,7 +58,7 @@ class SendEmail extends BaseJob implements RetryableJobInterface
         $this->setProgress($queue, 0.5);
 
         $error = '';
-        if (!Plugin::getInstance()->getEmails()->sendEmail($email, $this->_getOrder(), $orderHistory, $this->orderData, $error)) {
+        if (!Plugin::getInstance()->getEmails()->sendEmail($email, $order, $orderHistory, $this->orderData, $error)) {
             throw new EmailException($error);
         }
 
@@ -74,11 +70,7 @@ class SendEmail extends BaseJob implements RetryableJobInterface
      */
     private function _getOrder(): ?Order
     {
-        if ($this->_order === null) {
-            $this->_order = Order::find()->id($this->orderId)->one();
-        }
-
-        return $this->_order;
+        return Order::find()->id($this->orderId)->one();
     }
 
     /**


### PR DESCRIPTION
No need to use a private variable (which is being serialized).

### Related issues

#4017

