### PR TITLE
[5.4] Add default options to variant fields

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -3,6 +3,7 @@
 ### Store Management
 
 - It is now possible to set a variant’s status from the Product Edit screen. ([#3953](https://github.com/craftcms/commerce/discussions/3953))
+- It is now possible to set a variant’s default `isPromotable`, `inventoryTracked`, `allowOutOfStockPurchases`, and `availableForPurchase` properties from the variant field layout. ([#3571](https://github.com/craftcms/commerce/issues/3571))
 - Coupons that are not valid due to order, customer, or address conditions will now return a relevant explanation for coupon disqualification within the coupon error. ([#3935](https://github.com/craftcms/commerce/issues/3935))
 - Shipping methods and shipping rules now support flexible customer matching, based on a customer condition. ([#3925](https://github.com/craftcms/commerce/issues/3925))
 - Added an Order condition builder to gateways. ([#3913](https://github.com/craftcms/commerce/discussions/3913))

--- a/src/fieldlayoutelements/PurchasableAvailableForPurchaseField.php
+++ b/src/fieldlayoutelements/PurchasableAvailableForPurchaseField.php
@@ -12,6 +12,7 @@ use craft\base\ElementInterface;
 use craft\commerce\base\Purchasable;
 use craft\commerce\helpers\Purchasable as PurchasableHelper;
 use craft\fieldlayoutelements\BaseNativeField;
+use craft\helpers\Cp;
 use yii\base\InvalidArgumentException;
 
 /**
@@ -33,6 +34,11 @@ class PurchasableAvailableForPurchaseField extends BaseNativeField
     public string $attribute = 'availableForPurchase';
 
     /**
+     * @var bool Whether the field should be checked by default when creating a new purchasable.
+     */
+    public bool $defaultAvailableForPurchase = false;
+
+    /**
      * @inheritdoc
      */
     public function __construct(array $config = [])
@@ -50,9 +56,21 @@ class PurchasableAvailableForPurchaseField extends BaseNativeField
             throw new InvalidArgumentException(static::class . ' can only be used in purchasable field layouts.');
         }
 
-        return PurchasableHelper::availableForPurchaseInputHtml($element->availableForPurchase, [
+        return PurchasableHelper::availableForPurchaseInputHtml($element->getIsFresh() ? $this->defaultAvailableForPurchase : $element->availableForPurchase, [
             'disabled' => $static,
         ]);
+    }
+
+    public function settingsHtml(): string
+    {
+        return parent::settingsHtml() . Cp::lightswitchHtml(
+            [
+                'id' => 'defaultAvailableForPurchase',
+                'name' => 'defaultAvailableForPurchase',
+                'label' => Craft::t('app', 'Default Value'),
+                'on' => $this->defaultAvailableForPurchase,
+            ]
+        );
     }
 
     /**

--- a/src/fieldlayoutelements/PurchasablePromotableField.php
+++ b/src/fieldlayoutelements/PurchasablePromotableField.php
@@ -59,7 +59,7 @@ class PurchasablePromotableField extends BaseNativeField
             'id' => 'promotable',
             'name' => 'promotable',
             'small' => true,
-            'on' => $element->getIsDraft() ? $this->defaultPromotable : $element->promotable,
+            'on' => $element->getIsFresh() ? $this->defaultPromotable : $element->promotable,
             'disabled' => $static,
         ]);
     }

--- a/src/fieldlayoutelements/PurchasablePromotableField.php
+++ b/src/fieldlayoutelements/PurchasablePromotableField.php
@@ -33,6 +33,11 @@ class PurchasablePromotableField extends BaseNativeField
     public string $attribute = 'promotable';
 
     /**
+     * @var bool Whether the field should be checked by default when creating a new purchasable.
+     */
+    public bool $defaultPromotable = false;
+
+    /**
      * @inheritdoc
      */
     public function __construct(array $config = [])
@@ -54,9 +59,21 @@ class PurchasablePromotableField extends BaseNativeField
             'id' => 'promotable',
             'name' => 'promotable',
             'small' => true,
-            'on' => $element->promotable,
+            'on' => $element->getIsDraft() ? $this->defaultPromotable : $element->promotable,
             'disabled' => $static,
         ]);
+    }
+
+    public function settingsHtml(): string
+    {
+        return parent::settingsHtml() . Cp::lightswitchHtml(
+            [
+                'id' => 'defaultPromotable',
+                'name' => 'defaultPromotable',
+                'label' => Craft::t('app', 'Default Value'),
+                'on' => $this->defaultPromotable,
+            ]
+        );
     }
 
     /**

--- a/src/fieldlayoutelements/PurchasableStockField.php
+++ b/src/fieldlayoutelements/PurchasableStockField.php
@@ -38,6 +38,16 @@ class PurchasableStockField extends BaseNativeField
     public string $attribute = 'stock';
 
     /**
+     * @var bool Whether inventory should be tracked by default when creating a new purchasable.
+     */
+    public bool $defaultInventoryTracked = false;
+
+    /**
+     * @var bool Whether out of stock purchases should be allowed by default when creating a new purchasable.
+     */
+    public bool $defaultAllowOutOfStockPurchases = false;
+
+    /**
      * @inheritdoc
      */
     public function __construct(array $config = [])
@@ -119,80 +129,79 @@ JS, [
 
             $inventoryLevelTableRows .= Html::beginTag('tr') .
                 Html::beginTag('td') .
-                    $inventoryLevel->getInventoryLocation()->name .
+                $inventoryLevel->getInventoryLocation()->name .
                 Html::endTag('td') .
                 Html::beginTag('td') .
-                    Html::beginTag('div', ['class' => 'flex']) .
-                        Html::tag('div', (string)$inventoryLevel->availableTotal, [
-                            'id' => $updatedValueId,
-                        ]) .
-                        (!$static ? Html::tag('div',Html::button(Craft::t('commerce', ''),
-                            [
-                                'class' => 'btn menubtn action-btn',
-                                'id' => $editUpdateQuantityInventoryItemId,
-                            ])) : '') .
-                    Html::endTag('div') .
+                Html::beginTag('div', ['class' => 'flex']) .
+                Html::tag('div', (string)$inventoryLevel->availableTotal, [
+                    'id' => $updatedValueId,
+                ]) .
+                (!$static ? Html::tag('div', Html::button(Craft::t('commerce', ''),
+                    [
+                        'class' => 'btn menubtn action-btn',
+                        'id' => $editUpdateQuantityInventoryItemId,
+                    ])) : '') .
+                Html::endTag('div') .
                 Html::endTag('td') .
                 (!$static ? Html::beginTag('td') .
                     (Craft::$app->getUser()->checkPermission('commerce-manageInventoryStockLevels') ?
-                    Html::a(
-                        Craft::t('commerce', 'Manage'),
-                        UrlHelper::cpUrl('commerce/inventory/levels/' . $inventoryLevel->getInventoryLocation()->handle, [
-                            'inventoryItemId' => $inventoryLevel->getInventoryItem()->id,
-                        ]),
-                        [
-                            'target' => '_blank',
-                            'class' => 'btn small',
-                            'id' => $editUpdateQuantityInventoryItemId,
-                            'aria-label' => Craft::t('app', 'Open in a new tab'),
-                            'data-icon' => 'external',
-                        ]
-                    ) : '') : '') .
+                        Html::a(
+                            Craft::t('commerce', 'Manage'),
+                            UrlHelper::cpUrl('commerce/inventory/levels/' . $inventoryLevel->getInventoryLocation()->handle, [
+                                'inventoryItemId' => $inventoryLevel->getInventoryItem()->id,
+                            ]),
+                            [
+                                'target' => '_blank',
+                                'class' => 'btn small',
+                                'id' => $editUpdateQuantityInventoryItemId,
+                                'aria-label' => Craft::t('app', 'Open in a new tab'),
+                                'data-icon' => 'external',
+                            ]
+                        ) : '') : '') .
                 Html::endTag('td') .
                 Html::endTag('tr');
         }
 
         $inventoryLevelsTable = Html::beginTag('table', ['class' => 'data fullwidth', 'style' => 'margin-top:5px;']) .
             Html::beginTag('thead') .
-                Html::beginTag('tr') .
-                    Html::beginTag('th') .
-                        Craft::t('commerce', 'Location') .
-                    Html::endTag('th') .
-                        Html::beginTag('th') .
-                    Craft::t('commerce', 'Available') .
-                        Html::endTag('th') .
+            Html::beginTag('tr') .
+            Html::beginTag('th') .
+            Craft::t('commerce', 'Location') .
+            Html::endTag('th') .
+            Html::beginTag('th') .
+            Craft::t('commerce', 'Available') .
+            Html::endTag('th') .
 
 
-                    (!$static ? Html::beginTag('th') .
-                        Craft::t('commerce', 'Manage') .
-                    Html::endTag('th') : '') .
+            (!$static ? Html::beginTag('th') .
+                Craft::t('commerce', 'Manage') .
+                Html::endTag('th') : '') .
 
 
-
-                Html::endTag('tr') .
+            Html::endTag('tr') .
             Html::endTag('thead') .
 
             Html::beginTag('tbody') .
-                $inventoryLevelTableRows .
-                Html::beginTag('tr') .
-                    Html::beginTag('td', ['colspan' => '2']) .
-                        $availableStockLabel .
-                    Html::endTag('td') .
+            $inventoryLevelTableRows .
+            Html::beginTag('tr') .
+            Html::beginTag('td', ['colspan' => '2']) .
+            $availableStockLabel .
+            Html::endTag('td') .
 
-                    (!$static ? Html::beginTag('td') .
-                        Html::a(
-                            Craft::t('commerce', 'Edit'),
-                            '#',
-                            [
-                                'class' => 'btn small',
-                                'id' => $editInventoryItemId,
-                                'aria-label' => Craft::t('app', 'Edit Inventory Item'),
-                                'data-icon' => 'edit',
-                            ]
-                        ) .
-                    Html::endTag('td') : '') .
+            (!$static ? Html::beginTag('td') .
+                Html::a(
+                    Craft::t('commerce', 'Edit'),
+                    '#',
+                    [
+                        'class' => 'btn small',
+                        'id' => $editInventoryItemId,
+                        'aria-label' => Craft::t('app', 'Edit Inventory Item'),
+                        'data-icon' => 'edit',
+                    ]
+                ) .
+                Html::endTag('td') : '') .
 
-                Html::endTag('tr') .
+            Html::endTag('tr') .
             Html::endTag('tbody') .
             Html::endTag('table');
 
@@ -201,7 +210,7 @@ JS, [
             'id' => 'store-inventory-item-tracked',
             'name' => 'inventoryTracked',
             'small' => true,
-            'on' => $element->inventoryTracked,
+            'on' => $element->getIsFresh() ? $this->defaultInventoryTracked : $element->inventoryTracked,
             'toggle' => $inventoryItemTrackedId,
             'disabled' => $static,
         ];
@@ -211,18 +220,36 @@ JS, [
             'id' => 'store-backorder-allowed',
             'name' => 'allowOutOfStockPurchases',
             'small' => true,
-            'on' => $element->getIsOutOfStockPurchasingAllowed(),
+            'on' => $element->getIsFresh() ? $this->defaultAllowOutOfStockPurchases : $element->getIsOutOfStockPurchasingAllowed(),
             'disabled' => $static,
         ];
 
 
         return Html::beginTag('div') .
-                Cp::lightswitchHtml($storeInventoryTrackedLightswitchConfig) .
-                Html::beginTag('div', ['id' => $inventoryItemTrackedId, 'class' => 'hidden']) .
-                    $inventoryLevelsTable .
-                    Cp::lightswitchFieldHtml($storeAllowOutOfStockPurchasesLightswitchConfig) .
-                Html::endTag('div') .
+            Cp::lightswitchHtml($storeInventoryTrackedLightswitchConfig) .
+            Html::beginTag('div', ['id' => $inventoryItemTrackedId, 'class' => 'hidden']) .
+            $inventoryLevelsTable .
+            Cp::lightswitchFieldHtml($storeAllowOutOfStockPurchasesLightswitchConfig) .
+            Html::endTag('div') .
             Html::endTag('div');
+    }
+
+    public function settingsHtml(): string
+    {
+        $lightSwitches = Cp::lightswitchHtml([
+                'id' => 'defaultInventoryTracked',
+                'name' => 'defaultInventoryTracked',
+                'label' => Craft::t('commerce', 'Track Inventory'),
+                'on' => $this->defaultInventoryTracked,
+            ]) .
+            Cp::lightswitchHtml([
+                'id' => 'defaultAllowOutOfStockPurchases',
+                'name' => 'defaultAllowOutOfStockPurchases',
+                'label' => Craft::t('commerce', 'Allow out of stock purchases'),
+                'on' => $this->defaultAllowOutOfStockPurchases,
+            ]);
+
+        return parent::settingsHtml() . Cp::fieldHtml($lightSwitches, ['label' => Craft::t('app', 'Default Value')]);
     }
 
     /**


### PR DESCRIPTION
### Description

- [x] Allow the `promotable` option to have a default in field layout settings.
- [x] Default "Available for purchasable"
- [x] Default "Stock/Inventory tracked" with a default "Allow Out Of Stock Purchases" options too.

### Related issues

#3571

