### PR TITLE
[5.x] Fix duplicate order reference generation on order complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where purchasable cache was not cleared when stock was updated.
 - Fixed a PHP error that could occur when sending emails. ([#4017](https://github.com/craftcms/commerce/issues/4017))
 - Fixed a SQL error that could occur when upgrading to Commerce 5. ([#4044](https://github.com/craftcms/commerce/issues/4044))
+- Fixed a bug where duplicate order references could be generated. ([#4050](https://github.com/craftcms/commerce/issues/4050))
 
 ## 5.3.13 - 2025-05-21
 

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -1814,7 +1814,29 @@ class Order extends Element implements HasStoreInterface
             $referenceTemplate = $this->getStore()->getOrderReferenceFormat();
 
             try {
-                $this->reference = Craft::$app->getView()->renderObjectTemplate($referenceTemplate, $this);
+                $baseReference = Craft::$app->getView()->renderObjectTemplate($referenceTemplate, $this);
+                
+                // Check if this reference already exists and append suffix if needed
+                $suffix = 0;
+                $testReference = $baseReference;
+
+                while (true) {
+                    $existingReference = (new Query())
+                        ->select('id')
+                        ->from([Table::ORDERS])
+                        ->where(['reference' => $testReference])
+                        ->exists();
+                    
+                    if (!$existingReference) {
+                        // Reference is unique, use it
+                        $this->reference = $testReference;
+                        break;
+                    }
+                    
+                    // Reference exists, increment suffix and try again
+                    $suffix++;
+                    $testReference = $baseReference . '-' . $suffix;
+                }
             } catch (Throwable $exception) {
                 $mutex->release($lockName);
                 Craft::error('Unable to generate order completion reference for order ID: ' . $this->id . ', with format: ' . $referenceTemplate . ', error: ' . $exception->getMessage());


### PR DESCRIPTION
### Description

This just ensures that the same order reference cant be created on order complete using the reference format. It doesn't add a global unique validator to the attribute, and no unique constraint on the column.


