### PR TITLE
[5.x] Purchsable should have shippingCategoryId and taxCategoryId attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed a bug where purchasable cache was not cleared when stock was updated.
 - Fixed a PHP error that could occur when sending emails. ([#4017](https://github.com/craftcms/commerce/issues/4017))
 - Fixed a SQL error that could occur when upgrading to Commerce 5. ([#4044](https://github.com/craftcms/commerce/issues/4044))
+- Fixed a bug where `shippingCategoryId` and `taxCategoryId` were not marked as Purchasable attributes. ([#4046](https://github.com/craftcms/commerce/issues/4046))
 
 ## 5.3.13 - 2025-05-21
 

--- a/src/base/Purchasable.php
+++ b/src/base/Purchasable.php
@@ -264,6 +264,8 @@ abstract class Purchasable extends Element implements PurchasableInterface, HasS
         $names[] = 'stock';
         $names[] = 'inventoryTracked';
         $names[] = 'allowOutOfStockPurchases';
+        $names[] = 'shippingCategoryId';
+        $names[] = 'taxCategoryId';
 
         return $names;
     }


### PR DESCRIPTION
### Description

The `shippingCategoryId` and `taxCategoryId` Purchasable attributes should be mass assignable (for example feedme mass assigns with unsafe on, and these were not being set)

### Related issues

#4046
