### PR TITLE
Memoize inventory query results

### DIFF
--- a/src/base/Purchasable.php
+++ b/src/base/Purchasable.php
@@ -994,6 +994,10 @@ abstract class Purchasable extends Element implements PurchasableInterface, HasS
      */
     public function getStock(): int
     {
+        if (!$this->inventoryTracked) {
+            return 0;
+        }
+
         if ($this->_stock === null) {
             $this->_stock = $this->_getStock();
         }
@@ -1008,6 +1012,10 @@ abstract class Purchasable extends Element implements PurchasableInterface, HasS
      */
     public function getInventoryLevels(): Collection
     {
+        if (!$this->inventoryTracked) {
+            return collect([]);
+        }
+
         return Plugin::getInstance()->getInventory()->getInventoryLevelsForPurchasable($this);
     }
 

--- a/src/elements/db/PurchasableQuery.php
+++ b/src/elements/db/PurchasableQuery.php
@@ -670,6 +670,10 @@ abstract class PurchasableQuery extends ElementQuery
             ->createCatalogPricesQuery(userId: $customerId)
             ->addSelect(['cp.purchasableId', 'cp.storeId']);
 
+        if (!$this->id !== null) {
+            $catalogPricesQuery->andWhere(['cp.purchasableId' => $this->id]);
+        }
+
         $this->subQuery->leftJoin(['sitestores' => Table::SITESTORES], '[[elements_sites.siteId]] = [[sitestores.siteId]]');
         $this->subQuery->leftJoin(['purchasables_stores' => Table::PURCHASABLES_STORES], '[[purchasables_stores.storeId]] = [[sitestores.storeId]] AND [[purchasables_stores.purchasableId]] = [[commerce_purchasables.id]]');
 

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -580,6 +580,10 @@ class LineItem extends Model
      */
     public function getFulfilledTotalQuantity(): int
     {
+        if (!$this->purchasable->inventoryTracked) {
+            return 0;
+        }
+
         if ($order = $this->getOrder()) {
             return Plugin::getInstance()->getInventory()->getInventoryFulfillmentLevels($order)
                 ->filter(fn($fulfillment) => $fulfillment->getLineItem()->id === $this->id)

--- a/src/services/Inventory.php
+++ b/src/services/Inventory.php
@@ -46,6 +46,21 @@ use yii\db\Expression;
 class Inventory extends Component
 {
     /**
+     * @var array<non-empty-string, InventoryLevel>
+     */
+    private array $_inventoryLevelCache = [];
+
+    /**
+     * @var array<non-empty-string, Collection<string|int, InventoryTransaction>>
+     */
+    private array $_inventoryTransactionsCache = [];
+
+    /**
+     * @var array<int, Collection<string|int, InventoryFulfillmentLevel>>
+     */
+    private array $_inventoryFulfillmentCache = [];
+
+    /**
      * @param Purchasable $purchasable
      * @return Collection<InventoryLevel>
      */
@@ -125,6 +140,12 @@ class Inventory extends Component
         $inventoryItemId = $inventoryItem instanceof InventoryItem ? $inventoryItem->id : $inventoryItem;
         $inventoryLocationId = $inventoryLocation instanceof InventoryLocation ? $inventoryLocation->id : $inventoryLocation;
 
+        $cacheKey = "{$inventoryItemId}|{$inventoryLocationId}|" . ($withTrashed ? '1' : '0');
+
+        if (isset($this->_inventoryLevelCache[$cacheKey])) {
+            return $this->_inventoryLevelCache[$cacheKey];
+        }
+
         $result = $this->getInventoryLevelQuery(withTrashed: $withTrashed)
             ->andWhere([
                 'inventoryLocationId' => $inventoryLocationId,
@@ -135,8 +156,11 @@ class Inventory extends Component
             return null;
         }
 
-        return $this->_populateInventoryLevel($result);
+        $this->_inventoryLevelCache[$cacheKey] = $this->_populateInventoryLevel($result);
+        return $this->_inventoryLevelCache[$cacheKey];
     }
+
+
 
     /**
      * @param InventoryItem $inventoryItem
@@ -199,6 +223,7 @@ class Inventory extends Component
     {
         return new InventoryFulfillmentLevel($data);
     }
+
 
     /**
      * @param InventoryLocation $inventoryLocation
@@ -620,15 +645,22 @@ class Inventory extends Component
      */
     public function getInventoryTransactions(InventoryItem $inventoryItem, InventoryLocation $inventoryLocation): Collection
     {
-        $transactions = $this->getTransactionQuery()
+        $itemId = $inventoryItem->id;
+        $locationId = $inventoryLocation->id;
+        $cacheKey = "$itemId|$locationId";
+
+        if (isset($this->_inventoryTransactionsCache[$cacheKey])) {
+            return $this->_inventoryTransactionsCache[$cacheKey];
+        }
+
+        $rows = $this->getTransactionQuery()
             ->where(['inventoryItemId' => $inventoryItem->id, 'inventoryLocationId' => $inventoryLocation->id])
             ->all();
 
-        foreach ($transactions as $key => $transaction) {
-            $transactions[$key] = $this->_populateInventoryTransaction($transaction);
-        }
+        $transactions = collect($rows)->map(fn(array $row) => $this->_populateInventoryTransaction($row));
 
-        return collect($transactions);
+        $this->_inventoryTransactionsCache[$cacheKey] = $transactions;
+        return $this->_inventoryTransactionsCache[$cacheKey];
     }
 
     /**
@@ -639,10 +671,14 @@ class Inventory extends Component
      */
     public function getInventoryFulfillmentLevels(Order $order): Collection
     {
-        // We don’t limit this to the orders store locations since we want to show all locations that have historical inventory for the order.
-        $locations = Plugin::getInstance()->getInventoryLocations()->getAllInventoryLocations();
+        $orderId = $order->id;
+        if (isset($this->_inventoryFulfillmentCache[$orderId])) {
+            return $this->_inventoryFulfillmentCache[$orderId];
+        }
 
+        $locations = Plugin::getInstance()->getInventoryLocations()->getAllInventoryLocations();
         $inventoryFulfillmentLevels = [];
+
         foreach ($locations as $location) {
             $data = (new Query())
                 ->select([
@@ -657,7 +693,7 @@ class Inventory extends Component
                 ])
                 ->from(['it' => Table::INVENTORYTRANSACTIONS])
                 ->andWhere([
-                    '[[li.orderId]]' => $order->id,
+                    '[[li.orderId]]' => $orderId,
                     '[[it.inventoryLocationId]]' => $location->id,
                 ])
                 ->andWhere(['or',
@@ -681,7 +717,9 @@ class Inventory extends Component
             }
         }
 
-        return collect($inventoryFulfillmentLevels);
+
+        $this->_inventoryFulfillmentCache[$orderId] = collect($inventoryFulfillmentLevels);
+        return $this->_inventoryFulfillmentCache[$orderId];
     }
 
     /**


### PR DESCRIPTION
### Description

This PR attempts to improve performance of operations such as Add to Cart by memoizing inventory levels per request, which are otherwise queried multiple times each, and also preventing inventory look ups where a variant isn't inventory tracked.

### Related issues

