### PR TITLE
SKU not stored on variant table anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improved the performance of retrieving the cart over Ajax.
 - Fixed a PHP error that could occur when viewing variant indexes and using Craft CMS 5.6.17 or earlier. ([#4060](https://github.com/craftcms/commerce/issues/4060))
 - Fixed a bug where currency based order condition rules incorrectly showed up as custom fields.
+- Fixed a SQL error that could occur when restoring Variants that were previously soft-deleted. ([#4065](https://github.com/craftcms/commerce/issues/4065))
 
 ## 5.4.0 - 2025-06-23
 

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -1225,19 +1225,6 @@ class Variant extends Purchasable implements NestedElementInterface
             // Set new SKU in memory
             $this->sku = $this->getSku() . '-1';
 
-            // Update variant table with new SKU
-            Craft::$app->getDb()->createCommand()->update(Table::VARIANTS,
-                ['sku' => $this->sku],
-                ['id' => $this->getId()]
-            )->execute();
-
-            if ($this->isDefault) {
-                Craft::$app->getDb()->createCommand()->update(Table::PRODUCTS,
-                    ['defaultSku' => $this->sku],
-                    ['id' => $this->primaryOwnerId]
-                )->execute();
-            }
-
             // Update purchasable table with new SKU
             Craft::$app->getDb()->createCommand()->update(Table::PURCHASABLES,
                 ['sku' => $this->sku],

--- a/src/elements/db/ProductQuery.php
+++ b/src/elements/db/ProductQuery.php
@@ -781,28 +781,32 @@ class ProductQuery extends ElementQuery
 
         $this->_applyProductTypeIdParam();
 
+        if (isset($this->defaultHeight) || isset($this->defaultLength) || isset($this->defaultWidth) || isset($this->defaultWeight) || isset($this->defaultSku)) {
+            $this->subQuery->leftJoin(['purchasables' => Table::PURCHASABLES], '[[purchasables.id]] = [[commerce_products.defaultVariantId]]');
+        }
+
         if (isset($this->defaultPrice)) {
             $this->subQuery->andWhere(Db::parseParam('catalogprices.price', $this->defaultPrice));
         }
 
         if (isset($this->defaultHeight)) {
-            $this->subQuery->andWhere(Db::parseParam('commerce_products.defaultHeight', $this->defaultHeight));
+            $this->subQuery->andWhere(Db::parseParam('purchasables.height', $this->defaultHeight));
         }
 
         if (isset($this->defaultLength)) {
-            $this->subQuery->andWhere(Db::parseParam('commerce_products.defaultLength', $this->defaultLength));
+            $this->subQuery->andWhere(Db::parseParam('purchasables.length', $this->defaultLength));
         }
 
         if (isset($this->defaultWidth)) {
-            $this->subQuery->andWhere(Db::parseParam('commerce_products.defaultWidth', $this->defaultWidth));
+            $this->subQuery->andWhere(Db::parseParam('purchasables.width', $this->defaultWidth));
         }
 
         if (isset($this->defaultWeight)) {
-            $this->subQuery->andWhere(Db::parseParam('commerce_products.defaultWeight', $this->defaultWeight));
+            $this->subQuery->andWhere(Db::parseParam('purchasables.weight', $this->defaultWeight));
         }
 
         if (isset($this->defaultSku)) {
-            $this->subQuery->andWhere(Db::parseParam('commerce_products.defaultSku', $this->defaultSku));
+            $this->subQuery->andWhere(Db::parseParam('purchasables.sku', $this->defaultSku));
         }
 
         $this->_applyHasVariantParam();


### PR DESCRIPTION
Fixes https://github.com/craftcms/commerce/issues/4065

No need to change it on the product table as the product query get the defaultSku from the purchasable table.

### Description



### Related issues

