### PR TITLE
Trigger variant URL events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where `craft\commerce\elements\Variant::getUrl()` did not trigger the standard element url events.
+
 ## 5.4.3 - 2025-07-23
 
 - Fixed a PHP error that could occur when upgrading to Commerce 5. ([#4077](https://github.com/craftcms/commerce/issues/4077))

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -782,6 +782,11 @@ class Variant extends Purchasable implements NestedElementInterface
      */
     public function getUrl(): ?string
     {
+        if ($url = parent::getUrl()) {
+            return $url;
+        }
+        
+        // Default URL is the product's URL with the variant ID as a query parameter
         $productUrl = $this->getOwner()?->getUrl();
         return $productUrl ? UrlHelper::urlWithParams($productUrl, ['variant' => $this->id]) : null;
     }


### PR DESCRIPTION
### Description

This ensures that the base element `\craft\base\Element::EVENT_BEFORE_DEFINE_URL` and `\craft\base\Element::EVENT_DEFINE_URL` events are called.

Example of switching the variant URL to use the variant SKU instead of the variant ID in the url param:

```php
Event::on(Variant::class, Variant::EVENT_DEFINE_URL, function(DefineUrlEvent $event) {
    $event->handled = true;
    $event->url = UrlHelper::urlWithParams(
        $event->sender->getOwner()->getUrl(),
        ['variant' => $event->sender->getSkuAsText()]
    );
});
```

### Related

https://discord.com/channels/456442477667418113/666747438794670140/1397886087090933875