### PR TITLE
[5.x] Fix variants propagating to new site when choosing a new site for a product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improved the performance of loading the Edit Order page.
+- Fixed a bug where empty variant collections could be incorrectly memoized when duplicating a product. ([#4075](https://github.com/craftcms/commerce/issues/4075))
 - Fixed a bug where matching custom shipping methods that don’t use shipping rules weren’t having shipping adjustments applied to carts.
 
 ## 5.4.3 - 2025-07-23

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -1102,12 +1102,19 @@ class Product extends Element implements HasStoreInterface
      */
     public function getVariants(bool $includeDisabled = false): VariantCollection
     {
-        if (!isset($this->_variants)) {
+        if ($this->_variants === null) {
             if (!$this->id) {
                 return VariantCollection::make();
             }
 
-            $this->_variants = self::createVariantQuery($this)->status(null)->collect();
+            $variants = self::createVariantQuery($this)->status(null)->collect();
+
+            // Don't memoize empty collections in favour of a new query next time
+            if ($variants->isEmpty()) {
+                return $variants;
+            }
+
+            $this->_variants = $variants;
             $this->_variants->map(function(Variant $v) {
                 if (!$this->id) {
                     return $v;
@@ -1137,7 +1144,6 @@ class Product extends Element implements HasStoreInterface
      */
     public function getAllVariants(): VariantCollection
     {
-        $this->_variants = null;
         return $this->getVariants(true);
     }
 
@@ -1872,9 +1878,12 @@ class Product extends Element implements HasStoreInterface
      */
     private static function createVariantQuery(Product $product): VariantQuery
     {
+        $productId = $product->duplicateOf?->id ?? $product->id;
+        $productSiteId = $product->duplicateOf?->siteId ?? $product->siteId;
+
         $query = Variant::find()
-            ->productId($product->id)
-            ->siteId($product->siteId)
+            ->productId($productId)
+            ->siteId($productSiteId)
             ->orderBy(['sortOrder' => SORT_ASC]);
 
         if ($product->getIsRevision()) {

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -1137,6 +1137,7 @@ class Product extends Element implements HasStoreInterface
      */
     public function getAllVariants(): VariantCollection
     {
+        $this->_variants = null;
         return $this->getVariants(true);
     }
 

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -63,6 +63,8 @@ use yii\validators\Validator;
  * @property-read string $gqlTypeName
  * @property-read string $skuAsText
  * @property string $salePriceAsCurrency
+ * @method getOwner() Product|null
+ * @method getPrimaryOwner() Product|null
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 2.0
  */

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -73,6 +73,7 @@ class Variant extends Purchasable implements NestedElementInterface
         setPrimaryOwner as traitSetPrimaryOwner;
         setOwner as traitSetOwner;
         setEagerLoadedElements as traitSetEagerLoadedElements;
+        extraFields as traitExtraFields;
     }
 
     /**
@@ -242,6 +243,15 @@ class Variant extends Purchasable implements NestedElementInterface
         $attributes[] = 'productId';
 
         return $attributes;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function init(): void
+    {
+        parent::init();
+        $this->ownerType = Product::class;
     }
 
     /**
@@ -447,10 +457,11 @@ class Variant extends Purchasable implements NestedElementInterface
     /**
      * @inheritdoc
      */
-    public function attributes(): array
+    public function extraFields(): array
     {
-        $names = parent::attributes();
+        $names = $this->traitExtraFields();
         $names[] = 'product';
+
         return $names;
     }
 
@@ -557,59 +568,6 @@ class Variant extends Purchasable implements NestedElementInterface
         $this->fieldLayoutId = $owner->getType()->variantFieldLayoutId;
 
         $this->traitSetOwner($owner);
-    }
-
-    /**
-     * @inheritdoc
-     * @TODO remove implementation when `NestedElementTrait::getOwner()` is updated
-     */
-    public function getPrimaryOwner(): ?Product
-    {
-        if (!isset($this->_primaryOwner)) {
-            $primaryOwnerId = $this->getPrimaryOwnerId();
-            if (!$primaryOwnerId) {
-                return null;
-            }
-
-            $this->_primaryOwner = Craft::$app->getElements()->getElementById($primaryOwnerId, Product::class, $this->siteId, [
-                'trashed' => null,
-            ]) ?? false;
-            if (!$this->_primaryOwner) {
-                throw new InvalidConfigException("Invalid owner ID: $primaryOwnerId");
-            }
-        }
-
-        /** @phpstan-ignore-next-line */
-        return $this->_primaryOwner ?: null;
-    }
-
-    /**
-     * @inheritdoc
-     * @TODO remove implementation when `NestedElementTrait::getOwner()` is updated
-     */
-    public function getOwner(): ?Product
-    {
-        if (!isset($this->_owner)) {
-            $ownerId = $this->getOwnerId();
-            if (!$ownerId) {
-                return null;
-            }
-
-            // If ownerId and primaryOwnerId are the same, return the primary owner
-            if ($ownerId === $this->getPrimaryOwnerId()) {
-                return $this->getPrimaryOwner();
-            }
-
-            $this->_owner = Craft::$app->getElements()->getElementById($ownerId, Product::class, $this->siteId, [
-                'trashed' => null,
-            ]) ?? false;
-            if (!$this->_owner) {
-                throw new InvalidConfigException("Invalid owner ID: $ownerId");
-            }
-        }
-
-        /** @phpstan-ignore-next-line */
-        return $this->_owner ?: null;
     }
 
     /**

--- a/tests/unit/elements/product/ProductGetVariantsTest.php
+++ b/tests/unit/elements/product/ProductGetVariantsTest.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craftcommercetests\unit\elements\product;
+
+use Codeception\Test\Unit;
+use craft\commerce\elements\db\VariantQuery;
+use craft\commerce\elements\Product;
+use craft\commerce\elements\Variant;
+use craft\commerce\elements\VariantCollection;
+use craftcommercetests\fixtures\ProductFixture;
+use ReflectionClass;
+
+/**
+ * ProductGetVariantsTest
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.4
+ */
+class ProductGetVariantsTest extends Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    
+    /**
+     * @return array
+     */
+    public function _fixtures(): array
+    {
+        return [
+            'products' => [
+                'class' => ProductFixture::class,
+            ],
+        ];
+    }
+
+    /**
+     * Test that getVariants() returns empty collection when product has no ID
+     */
+    public function testGetVariantsReturnsEmptyCollectionForNewProduct(): void
+    {
+        $product = new Product();
+        $variants = $product->getVariants();
+        
+        self::assertInstanceOf(VariantCollection::class, $variants);
+        self::assertTrue($variants->isEmpty());
+    }
+
+    /**
+     * Test that getVariants() doesn't memoize empty collections
+     */
+    public function testGetVariantsDoesNotMemoizeEmptyCollections(): void
+    {
+        $product = new Product();
+        $product->id = 999999; // Non-existent ID
+        $product->typeId = 2000;
+        
+        // First call should return empty collection
+        $variants1 = $product->getVariants();
+        self::assertTrue($variants1->isEmpty());
+        
+        // Access private _variants property to check if it was memoized
+        $reflection = new ReflectionClass($product);
+        $variantsProperty = $reflection->getProperty('_variants');
+        $variantsProperty->setAccessible(true);
+        
+        // Should be null, not an empty collection
+        self::assertNull($variantsProperty->getValue($product));
+        
+        // Second call should also return empty collection (new query)
+        $variants2 = $product->getVariants();
+        self::assertTrue($variants2->isEmpty());
+        
+        // Still should not be memoized
+        self::assertNull($variantsProperty->getValue($product));
+    }
+
+    /**
+     * Test that getVariants() memoizes non-empty collections
+     */
+    public function testGetVariantsMemoizesNonEmptyCollections(): void
+    {
+        // Get a product that has variants from fixtures
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $product = $productFixture->getElement('rad-hoodie');
+        self::assertNotNull($product);
+        
+        // First call
+        $variants1 = $product->getVariants();
+        self::assertFalse($variants1->isEmpty());
+        
+        // Access private _variants property
+        $reflection = new ReflectionClass($product);
+        $variantsProperty = $reflection->getProperty('_variants');
+        $variantsProperty->setAccessible(true);
+        
+        // Should be memoized
+        $memoizedVariants = $variantsProperty->getValue($product);
+        self::assertInstanceOf(VariantCollection::class, $memoizedVariants);
+        self::assertNotNull($memoizedVariants);
+        
+        // Second call should return the memoized collection
+        $variants2 = $product->getVariants();
+        self::assertCount($variants1->count(), $variants2);
+        self::assertEquals($variants1->first()->id, $variants2->first()->id);
+    }
+
+    /**
+     * Test that createVariantQuery uses duplicateOf product ID when available
+     */
+    public function testCreateVariantQueryUsesDuplicateOfId(): void
+    {
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $originalProduct = $productFixture->getElement('rad-hoodie');
+        self::assertNotNull($originalProduct);
+        
+        // Create a duplicate product
+        $duplicateProduct = new Product();
+        $duplicateProduct->id = 999998;
+        $duplicateProduct->typeId = $originalProduct->typeId;
+        $duplicateProduct->siteId = 1002; // Different site
+        $duplicateProduct->duplicateOf = $originalProduct;
+        
+        // Use reflection to access private createVariantQuery method
+        $reflection = new ReflectionClass(Product::class);
+        $method = $reflection->getMethod('createVariantQuery');
+        $method->setAccessible(true);
+        
+        /** @var VariantQuery $query */
+        $query = $method->invoke(null, $duplicateProduct);
+        
+        // Use reflection to check the query's ownerId and siteId
+        $queryReflection = new ReflectionClass($query);
+        $ownerIdProperty = $queryReflection->getProperty('ownerId');
+        $ownerIdProperty->setAccessible(true);
+        $siteIdProperty = $queryReflection->getProperty('siteId');
+        $siteIdProperty->setAccessible(true);
+        
+        // Should use the original product's ID and siteId
+        self::assertEquals($originalProduct->id, $ownerIdProperty->getValue($query));
+        self::assertEquals($originalProduct->siteId, $siteIdProperty->getValue($query));
+    }
+
+    /**
+     * Test includeDisabled parameter
+     */
+    public function testGetVariantsIncludeDisabledParameter(): void
+    {
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $product = $productFixture->getElement('hypercolor-tshirt');
+        self::assertNotNull($product);
+        
+        // Create a disabled variant
+        $disabledVariant = new Variant();
+        $disabledVariant->title = 'Disabled Variant';
+        $disabledVariant->sku = 'disabled-variant-sku';
+        $disabledVariant->enabled = false;
+        $disabledVariant->setOwner($product);
+        
+        // Add to product's variants
+        $variants = $product->getVariants()->all();
+        $variants[] = $disabledVariant;
+        $product->setVariants($variants);
+        
+        // Test without includeDisabled (default)
+        $enabledVariants = $product->getVariants(false);
+        foreach ($enabledVariants as $variant) {
+            self::assertTrue($variant->enabled);
+        }
+        
+        // Test with includeDisabled
+        $allVariants = $product->getVariants(true);
+        $hasDisabledVariant = false;
+        foreach ($allVariants as $variant) {
+            if (!$variant->enabled) {
+                $hasDisabledVariant = true;
+                break;
+            }
+        }
+        self::assertTrue($hasDisabledVariant);
+    }
+}

--- a/tests/unit/elements/variant/VariantOwnerTest.php
+++ b/tests/unit/elements/variant/VariantOwnerTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craftcommercetests\unit\elements\variant;
+
+use Codeception\Test\Unit;
+use craft\commerce\elements\Product;
+use craft\commerce\elements\Variant;
+use craftcommercetests\fixtures\ProductFixture;
+use ReflectionClass;
+
+/**
+ * VariantOwnerTest
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.4.4
+ */
+class VariantOwnerTest extends Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    
+    /**
+     * @return array
+     */
+    public function _fixtures(): array
+    {
+        return [
+            'products' => [
+                'class' => ProductFixture::class,
+            ],
+        ];
+    }
+
+    /**
+     * Test that ownerType is set to Product in init()
+     */
+    public function testOwnerTypeIsSetInInit(): void
+    {
+        $variant = new Variant();
+        
+        // Access protected ownerType property
+        $reflection = new ReflectionClass($variant);
+        $ownerTypeProperty = $reflection->getProperty('ownerType');
+        $ownerTypeProperty->setAccessible(true);
+        
+        self::assertEquals(Product::class, $ownerTypeProperty->getValue($variant));
+    }
+
+    /**
+     * Test that 'product' is included in extraFields
+     */
+    public function testProductIncludedInExtraFields(): void
+    {
+        $variant = new Variant();
+        $extraFields = $variant->extraFields();
+        
+        self::assertContains('product', $extraFields);
+    }
+
+    /**
+     * Test getOwner returns Product instance
+     */
+    public function testGetOwnerReturnsProduct(): void
+    {
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $product = $productFixture->getElement('rad-hoodie');
+        self::assertNotNull($product);
+        
+        $variants = $product->getVariants();
+        self::assertFalse($variants->isEmpty());
+        
+        $variant = $variants->first();
+        $owner = $variant->getOwner();
+        
+        self::assertInstanceOf(Product::class, $owner);
+        self::assertEquals($product->id, $owner->id);
+    }
+
+    /**
+     * Test getPrimaryOwner returns Product instance
+     */
+    public function testGetPrimaryOwnerReturnsProduct(): void
+    {
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $product = $productFixture->getElement('rad-hoodie');
+        self::assertNotNull($product);
+        
+        $variants = $product->getVariants();
+        self::assertFalse($variants->isEmpty());
+        
+        $variant = $variants->first();
+        $primaryOwner = $variant->getPrimaryOwner();
+        
+        self::assertInstanceOf(Product::class, $primaryOwner);
+        self::assertEquals($product->id, $primaryOwner->id);
+    }
+
+    /**
+     * Test that getProduct() still works (backward compatibility)
+     */
+    public function testGetProductMethodStillWorks(): void
+    {
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $product = $productFixture->getElement('hypercolor-tshirt');
+        self::assertNotNull($product);
+        
+        $variants = $product->getVariants();
+        self::assertFalse($variants->isEmpty());
+        
+        $variant = $variants->first();
+        $productFromMethod = $variant->getProduct();
+        
+        self::assertInstanceOf(Product::class, $productFromMethod);
+        self::assertEquals($product->id, $productFromMethod->id);
+    }
+
+    /**
+     * Test setOwner works with Product
+     */
+    public function testSetOwnerWorksWithProduct(): void
+    {
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $product = $productFixture->getElement('rad-hoodie');
+        self::assertNotNull($product);
+        
+        $variant = new Variant();
+        $variant->setOwner($product);
+        
+        $owner = $variant->getOwner();
+        self::assertInstanceOf(Product::class, $owner);
+        self::assertEquals($product->id, $owner->id);
+    }
+
+    /**
+     * Test variant owner relationship with different sites
+     */
+    public function testVariantOwnerWithDifferentSites(): void
+    {
+        // Get a product that exists in multiple sites
+        /** @var ProductFixture $productFixture */
+        $productFixture = $this->tester->grabFixture('products');
+        $product = $productFixture->getElement('double-decker-bus-toy');
+        self::assertNotNull($product);
+        
+        // Get variants
+        $variants = $product->getVariants();
+        self::assertFalse($variants->isEmpty());
+        
+        $variant = $variants->first();
+        
+        // Test that owner is resolved correctly even for different sites
+        $owner = $variant->getOwner();
+        self::assertInstanceOf(Product::class, $owner);
+        self::assertEquals($product->id, $owner->id);
+        self::assertEquals($product->siteId, $owner->siteId);
+    }
+}


### PR DESCRIPTION
### Description
Key points in this PR

- avoid memorization of variants when using the `getAllVariants()` method. This method is use for the variant's nested element manager only and should always have the most up-to-date information.
- As Commerce requires Craft `5.6.0` it no longer needs to implement the `getOwner()` and `getPrimaryOwner()` methods on `Variant` and instead set the `ownerType` property to keep the performance degradation the copied code was previously circumventing.
- The side effect of doing this was that when updating a variant in the CP when the field layout updated and the success was being passed back. The variant was going through `toArray()`, because the `Variant` class was specifying `product` as an attribute rather than an extra field it was causing an infinite loop. Because `product` is related data this should be in `extraFields` to avoid n+1 queries, this would follow what entries do by having `author` in `extraFields` but `authorId` in `attributes`. The key thing to consider is if this is a change in behaviour?


### Related issues
#4075 
