### PR TITLE
Fix Event type error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## 5.4.5.1 - 2025-08-20
+
+- Fixed a PHP type error.
+
 ## 5.4.5 - 2025-08-20
 
 - Fixed a bug where order indexes didn’t have customizable table columns when an order status’ source was selected.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,7 +8,6 @@
 namespace craft\commerce;
 
 use Craft;
-use craft\base\Event;
 use craft\base\Model;
 use craft\base\Plugin as BasePlugin;
 use craft\ckeditor\events\DefineLinkOptionsEvent;
@@ -168,6 +167,7 @@ use craft\web\Application;
 use craft\web\twig\variables\CraftVariable;
 use Exception;
 use Illuminate\Support\Collection;
+use yii\base\Event;
 use yii\console\ExitCode;
 use yii\web\User;
 


### PR DESCRIPTION
Looks like 5.4.5 introduced an event type mismatch during init.

Handlers for `craft\web\twig\variables\CraftVariable::EVENT_INIT` must be an instance of `yii\base\Event`, so our subclass is rejected.

I believe this is safe to revert, because we aren't relying on any of our class’s specialized features (`new Event(...)` or `Event::once()`)?

Reported in #4106, and observed locally. Thanks, @jan-thoma!