### PR TITLE
[5.5] Adds a force option to reset-data command

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -6,7 +6,7 @@
 
 ### Development
 
-- Added the `--force` option to the `commerce/reset-data` command. ([#4116](https://github.com/craftcms/commerce/pull/4116))
+- Added the `--force` option to the `commerce/reset-data` command. ([#4115](https://github.com/craftcms/commerce/discussions/4115))
 
 ### Extensibility
 

--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -1,0 +1,13 @@
+# WIP Release Notes for Craft Commerce
+
+### Store Management
+
+### Administration
+
+### Development
+
+- Added the `--force` option to the `commerce/reset-data` command. ([#4116](https://github.com/craftcms/commerce/pull/4116))
+
+### Extensibility
+
+### System

--- a/src/console/controllers/ResetDataController.php
+++ b/src/console/controllers/ResetDataController.php
@@ -25,22 +25,41 @@ use yii\console\ExitCode;
 class ResetDataController extends Controller
 {
     /**
+     * @var bool Whether to force the reset without confirmation
+     */
+    public bool $force = false;
+
+    /**
+     * @inheritdoc
+     */
+    public function options($actionID): array
+    {
+        $options = parent::options($actionID);
+        $options[] = 'force';
+        return $options;
+    }
+
+    /**
      * Reset Commerce data.
      */
     public function actionIndex(): int
     {
-        $reset = $this->prompt('Resetting Commerce data will permanently delete all orders, subscriptions, payment sources, customers, addresses and reset discount usages ... do you wish to continue?', [
-            'required' => true,
-            'default' => 'no',
-            'validator' => function($input) {
-                if (!in_array($input, ['yes', 'no'])) {
-                    $this->stderr('You must answer either "yes" or "no".' . PHP_EOL, Console::FG_RED);
-                    return false;
-                }
+        if ($this->force) {
+            $reset = 'yes';
+        } else {
+            $reset = $this->prompt('Resetting Commerce data will permanently delete all orders, subscriptions, payment sources, customers, addresses and reset discount usages ... do you wish to continue?', [
+                'required' => true,
+                'default' => 'no',
+                'validator' => function($input) {
+                    if (!in_array($input, ['yes', 'no'])) {
+                        $this->stderr('You must answer either "yes" or "no".' . PHP_EOL, Console::FG_RED);
+                        return false;
+                    }
 
-                return true;
-            },
-        ]);
+                    return true;
+                },
+            ]);
+        }
 
         if ($reset == 'yes') {
             $transaction = Craft::$app->getDb()->beginTransaction();


### PR DESCRIPTION
### Description

Adds a `--force` to the data reset command to avoid confirmation prompt.

### Related issues

https://github.com/craftcms/commerce/discussions/4115