### PR TITLE
Bugfix/4125 variant duplication and deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where catalog pricing rules could generate promotional prices for non-promotable purchasables. ([#4118](https://github.com/craftcms/commerce/issues/4118))
+- Fixed a bug where variants weren’t duplicating correctly. ([#4125](https://github.com/craftcms/commerce/issues/4125))
 - Fixed a SQL error that could occur when deleting a shipping method.
 
 ## 5.4.6 - 2025-09-04

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -1107,9 +1107,10 @@ class Product extends Element implements HasStoreInterface
                 return VariantCollection::make();
             }
 
-            if ($this->duplicateOf) {
-                /** @phpstan-ignore-next-line */
-                $query = self::createVariantQuery($this->duplicateOf)->status(null);
+            /** @var self|null $duplicatingProduct */
+            $duplicatingProduct = $this->duplicateOf;
+            if ($duplicatingProduct) {
+                $query = self::createVariantQuery($duplicatingProduct)->status(null);
             } else {
                 $query = self::createVariantQuery($this)->status(null);
             }

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -1108,6 +1108,7 @@ class Product extends Element implements HasStoreInterface
             }
 
             if ($this->duplicateOf) {
+                /** @phpstan-ignore-next-line */
                 $query = self::createVariantQuery($this->duplicateOf)->status(null);
             } else {
                 $query = self::createVariantQuery($this)->status(null);

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -1107,7 +1107,13 @@ class Product extends Element implements HasStoreInterface
                 return VariantCollection::make();
             }
 
-            $variants = self::createVariantQuery($this)->status(null)->collect();
+            if ($this->duplicateOf) {
+                $query = self::createVariantQuery($this->duplicateOf)->status(null);
+            } else {
+                $query = self::createVariantQuery($this)->status(null);
+            }
+
+            $variants = $query->collect();
 
             // Don't memoize empty collections in favour of a new query next time
             if ($variants->isEmpty()) {
@@ -1885,12 +1891,9 @@ class Product extends Element implements HasStoreInterface
      */
     private static function createVariantQuery(Product $product): VariantQuery
     {
-        $productId = $product->duplicateOf?->id ?? $product->id;
-        $productSiteId = $product->duplicateOf?->siteId ?? $product->siteId;
-
         $query = Variant::find()
-            ->productId($productId)
-            ->siteId($productSiteId)
+            ->productId($product->id)
+            ->siteId($product->siteId)
             ->orderBy(['sortOrder' => SORT_ASC]);
 
         if ($product->getIsRevision()) {

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -881,30 +881,31 @@ class Variant extends Purchasable implements NestedElementInterface
      */
     public static function eagerLoadingMap(array $sourceElements, string $handle): array|null|false
     {
-        if (in_array($handle, ['product', 'owner', 'primaryOwner'])) {
-            // Get the source element IDs
-            $sourceElementIds = [];
+        switch ($handle) {
+            case 'product':
+                // Get the source element IDs
+                $sourceElementIds = [];
 
-            foreach ($sourceElements as $sourceElement) {
-                $sourceElementIds[] = $sourceElement->id;
-            }
+                foreach ($sourceElements as $sourceElement) {
+                    $sourceElementIds[] = $sourceElement->id;
+                }
 
-            $map = (new Query())
-                ->select('id as source, primaryOwnerId as target')
-                ->from(Table::VARIANTS)
-                ->where(['in', 'id', $sourceElementIds])
-                ->all();
+                $map = (new Query())
+                    ->select('id as source, primaryOwnerId as target')
+                    ->from(Table::VARIANTS)
+                    ->where(['in', 'id', $sourceElementIds])
+                    ->all();
 
-            return [
-                'elementType' => Product::class,
-                'map' => $map,
-                'criteria' => [
-                    'status' => null,
-                ],
-            ];
+                return [
+                    'elementType' => Product::class,
+                    'map' => $map,
+                    'criteria' => [
+                        'status' => null,
+                    ],
+                ];
+            default:
+                return self::traitEagerLoadingMap($sourceElements, $handle);
         }
-
-        return self::traitEagerLoadingMap($sourceElements, $handle);
     }
 
     /**

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -904,7 +904,10 @@ class Variant extends Purchasable implements NestedElementInterface
                     ],
                 ];
             default:
-                return self::traitEagerLoadingMap($sourceElements, $handle);
+                return array_merge(
+                    self::traitEagerLoadingMap($sourceElements, $handle),
+                    ['elementType' => Product::class],
+                );
         }
     }
 
@@ -1042,18 +1045,24 @@ class Variant extends Purchasable implements NestedElementInterface
                         ->max('[[eo.sortOrder]]');
                     $this->sortOrder = $max ? $max + 1 : 1;
                 }
-                if ($isNew) {
-                    Db::insert(CraftTable::ELEMENTS_OWNERS, [
+
+                $ownerIds = array_unique([
+                    $ownerId,
+                    $this->getPrimaryOwnerId(),
+                ]);
+
+                if (!$isNew) {
+                    Db::delete(CraftTAble::ELEMENTS_OWNERS, [
                         'elementId' => $this->id,
-                        'ownerId' => $ownerId,
-                        'sortOrder' => $this->sortOrder,
+                        'ownerId' => $ownerIds,
                     ]);
-                } else {
-                    Db::update(CraftTable::ELEMENTS_OWNERS, [
-                        'sortOrder' => $this->sortOrder,
-                    ], [
+                }
+
+                foreach ($ownerIds as $ownerId) {
+                    Db::insert(CraftTAble::ELEMENTS_OWNERS, [
                         'elementId' => $this->id,
                         'ownerId' => $ownerId,
+                        'sortOrder' => $this->sortOrder,
                     ]);
                 }
             }

--- a/tests/unit/elements/product/ProductGetVariantsTest.php
+++ b/tests/unit/elements/product/ProductGetVariantsTest.php
@@ -113,7 +113,7 @@ class ProductGetVariantsTest extends Unit
     }
 
     /**
-     * Test that createVariantQuery does now use duplicateOf product ID when available
+     * Test that createVariantQuery does not use duplicateOf product ID when available
      */
     public function testCreateVariantQueryDoesNotUseDuplicateOfId(): void
     {

--- a/tests/unit/elements/product/ProductGetVariantsTest.php
+++ b/tests/unit/elements/product/ProductGetVariantsTest.php
@@ -27,7 +27,7 @@ class ProductGetVariantsTest extends Unit
      * @var \UnitTester
      */
     protected $tester;
-    
+
     /**
      * @return array
      */
@@ -47,7 +47,7 @@ class ProductGetVariantsTest extends Unit
     {
         $product = new Product();
         $variants = $product->getVariants();
-        
+
         self::assertInstanceOf(VariantCollection::class, $variants);
         self::assertTrue($variants->isEmpty());
     }
@@ -60,23 +60,23 @@ class ProductGetVariantsTest extends Unit
         $product = new Product();
         $product->id = 999999; // Non-existent ID
         $product->typeId = 2000;
-        
+
         // First call should return empty collection
         $variants1 = $product->getVariants();
         self::assertTrue($variants1->isEmpty());
-        
+
         // Access private _variants property to check if it was memoized
         $reflection = new ReflectionClass($product);
         $variantsProperty = $reflection->getProperty('_variants');
         $variantsProperty->setAccessible(true);
-        
+
         // Should be null, not an empty collection
         self::assertNull($variantsProperty->getValue($product));
-        
+
         // Second call should also return empty collection (new query)
         $variants2 = $product->getVariants();
         self::assertTrue($variants2->isEmpty());
-        
+
         // Still should not be memoized
         self::assertNull($variantsProperty->getValue($product));
     }
@@ -91,21 +91,21 @@ class ProductGetVariantsTest extends Unit
         $productFixture = $this->tester->grabFixture('products');
         $product = $productFixture->getElement('rad-hoodie');
         self::assertNotNull($product);
-        
+
         // First call
         $variants1 = $product->getVariants();
         self::assertFalse($variants1->isEmpty());
-        
+
         // Access private _variants property
         $reflection = new ReflectionClass($product);
         $variantsProperty = $reflection->getProperty('_variants');
         $variantsProperty->setAccessible(true);
-        
+
         // Should be memoized
         $memoizedVariants = $variantsProperty->getValue($product);
         self::assertInstanceOf(VariantCollection::class, $memoizedVariants);
         self::assertNotNull($memoizedVariants);
-        
+
         // Second call should return the memoized collection
         $variants2 = $product->getVariants();
         self::assertCount($variants1->count(), $variants2);
@@ -113,40 +113,40 @@ class ProductGetVariantsTest extends Unit
     }
 
     /**
-     * Test that createVariantQuery uses duplicateOf product ID when available
+     * Test that createVariantQuery does now use duplicateOf product ID when available
      */
-    public function testCreateVariantQueryUsesDuplicateOfId(): void
+    public function testCreateVariantQueryDoesNotUseDuplicateOfId(): void
     {
         /** @var ProductFixture $productFixture */
         $productFixture = $this->tester->grabFixture('products');
         $originalProduct = $productFixture->getElement('rad-hoodie');
         self::assertNotNull($originalProduct);
-        
+
         // Create a duplicate product
         $duplicateProduct = new Product();
         $duplicateProduct->id = 999998;
         $duplicateProduct->typeId = $originalProduct->typeId;
         $duplicateProduct->siteId = 1002; // Different site
         $duplicateProduct->duplicateOf = $originalProduct;
-        
+
         // Use reflection to access private createVariantQuery method
         $reflection = new ReflectionClass(Product::class);
         $method = $reflection->getMethod('createVariantQuery');
         $method->setAccessible(true);
-        
+
         /** @var VariantQuery $query */
         $query = $method->invoke(null, $duplicateProduct);
-        
+
         // Use reflection to check the query's ownerId and siteId
         $queryReflection = new ReflectionClass($query);
         $ownerIdProperty = $queryReflection->getProperty('ownerId');
         $ownerIdProperty->setAccessible(true);
         $siteIdProperty = $queryReflection->getProperty('siteId');
         $siteIdProperty->setAccessible(true);
-        
+
         // Should use the original product's ID and siteId
-        self::assertEquals($originalProduct->id, $ownerIdProperty->getValue($query));
-        self::assertEquals($originalProduct->siteId, $siteIdProperty->getValue($query));
+        self::assertNotEquals($originalProduct->id, $ownerIdProperty->getValue($query));
+        self::assertNotEquals($originalProduct->siteId, $siteIdProperty->getValue($query));
     }
 
     /**
@@ -158,25 +158,25 @@ class ProductGetVariantsTest extends Unit
         $productFixture = $this->tester->grabFixture('products');
         $product = $productFixture->getElement('hypercolor-tshirt');
         self::assertNotNull($product);
-        
+
         // Create a disabled variant
         $disabledVariant = new Variant();
         $disabledVariant->title = 'Disabled Variant';
         $disabledVariant->sku = 'disabled-variant-sku';
         $disabledVariant->enabled = false;
         $disabledVariant->setOwner($product);
-        
+
         // Add to product's variants
         $variants = $product->getVariants()->all();
         $variants[] = $disabledVariant;
         $product->setVariants($variants);
-        
+
         // Test without includeDisabled (default)
         $enabledVariants = $product->getVariants(false);
         foreach ($enabledVariants as $variant) {
             self::assertTrue($variant->enabled);
         }
-        
+
         // Test with includeDisabled
         $allVariants = $product->getVariants(true);
         $hasDisabledVariant = false;


### PR DESCRIPTION
### Description
**issue 1** (described in the original report):
When duplicating a variant, the duplicate was only created against the canonical product and not the product’s provisional draft.

Fixed by relying on the nested element trait eager loading map logic for `owner` and `primaryOwner`.

**issue 2**:
When you delete a variant, it appears to be deleted in the provisional draft, but when you attempt to fully save the product, the deleted variant comes back.
(This only started happening after implementing a fix for the first issue.)

Fixed, by adjusting the change we made here: https://github.com/craftcms/commerce/commit/fc5564717396d3662927effb2baf56e957e42d2b

@nfourtythree, feel free to adjust it in any way you like. Also, LMK if you’d like to chat.


### Related issues
#4125
