### PR TITLE
[5.x] Variant eager loading - only array merge for owner and primaryOwner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a PHP error that could occur when querying variants. ([#4129](https://github.com/craftcms/commerce/pull/4129))
+
 ## 5.4.7 - 2025-10-08
 
 - Fixed a bug where catalog pricing rules could generate promotional prices for non-promotable purchasables. ([#4118](https://github.com/craftcms/commerce/issues/4118))

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -903,11 +903,14 @@ class Variant extends Purchasable implements NestedElementInterface
                         'status' => null,
                     ],
                 ];
-            default:
+            case 'owner':
+            case 'primaryOwner':
                 return array_merge(
                     self::traitEagerLoadingMap($sourceElements, $handle),
                     ['elementType' => Product::class],
                 );
+            default:
+                return self::traitEagerLoadingMap($sourceElements, $handle);
         }
     }
 


### PR DESCRIPTION
### Description
Part 2 of the https://github.com/craftcms/commerce/pull/4129.

We only want to merge in the `elementType` for the `owner` and `primaryOwner` handles.


### Related issues

