### PR TITLE
[5.5] Add variant and customer specific rules to catalog pricing rule condition builders

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -8,6 +8,8 @@
 - Logged-in users who own the order or have appropriate permissions bypass the email verification flow and can download PDFs directly.
 - Added a new system email message for sending PDF download links to customers.
 - It is now possible to select multiple products in variant conditions. ([#4166](https://github.com/craftcms/commerce/pull/4166))
+- It is now possible to select multiple specific variants in pricing rule’s “Match Variant” condition. ([#4167](https://github.com/craftcms/commerce/issues/4167))
+- It is now possible to select multiple specific users in pricing rule’s “Match Customer” condition. ([#4167](https://github.com/craftcms/commerce/issues/4167))
 
 ### Administration
 - Added billing and shipping address conditions to gateways. ([#4100](https://github.com/craftcms/commerce/pull/4100))
@@ -28,6 +30,9 @@
 - Added `craft\commerce\controllers\DownloadsController::actionEmailChallenge()`.
 - Added `craft\commerce\controllers\DownloadsController::actionPdfChallenge()`.
 - Added `craft\commerce\controllers\DownloadsController::actionPdfSent()`.
+- Added `craft\commerce\elements\conditions\customers\CatalogPricingRuleCustomerConditionRule`.
+- Added `craft\commerce\elements\conditions\variants\CatalogPricingRuleVariantConditionRule`.
+- Added `craft\commerce\elements\conditions\variants\VariantConditionRule`.
 - Added `craft\commerce\elements\Order::$dateFirstPaid`.
 - Added `craft\commerce\elements\Order::getMaskedEmail()`.
 - Added `craft\commerce\elements\db\OrderQuery::$dateFirstPaid`.

--- a/src/elements/conditions/customers/CatalogPricingRuleCustomerCondition.php
+++ b/src/elements/conditions/customers/CatalogPricingRuleCustomerCondition.php
@@ -24,9 +24,17 @@ class CatalogPricingRuleCustomerCondition extends UserCondition
      */
     protected function selectableConditionRules(): array
     {
-        return array_filter(parent::selectableConditionRules(), static fn($type) => !in_array($type, [
-            LastLoginDateConditionRule::class,
-            SiteConditionRule::class,
-        ], true));
+        return array_merge(
+            array_filter(parent::selectableConditionRules(), static fn($type) => !in_array($type, [
+                // Remove rules that don't make sense in this context
+                LastLoginDateConditionRule::class,
+                SiteConditionRule::class,
+            ], true)
+            ),
+            // Add additional rules
+            [
+                CatalogPricingRuleCustomerConditionRule::class,
+            ]
+        );
     }
 }

--- a/src/elements/conditions/customers/CatalogPricingRuleCustomerConditionRule.php
+++ b/src/elements/conditions/customers/CatalogPricingRuleCustomerConditionRule.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace  craft\commerce\elements\conditions\customers;
+
+use Craft;
+use craft\base\conditions\BaseElementSelectConditionRule;
+use craft\base\ElementInterface;
+use craft\elements\conditions\ElementConditionRuleInterface;
+use craft\elements\db\ElementQueryInterface;
+use craft\elements\db\UserQuery;
+use craft\elements\User;
+
+/**
+ * Customer Condition Rule
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.5.0
+ */
+class CatalogPricingRuleCustomerConditionRule extends BaseElementSelectConditionRule implements ElementConditionRuleInterface
+{
+    /**
+     * @inheritdoc
+     */
+    protected function elementType(): string
+    {
+        return User::class;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLabel(): string
+    {
+        return Craft::t('commerce', 'Customer');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getExclusiveQueryParams(): array
+    {
+        return ['id'];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function modifyQuery(ElementQueryInterface $query): void
+    {
+        /** @var UserQuery $query */
+        $query->id($this->getElementIds());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function matchElement(ElementInterface $element): bool
+    {
+        /** @var User $element */
+        return $this->matchValue($element->getId());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function allowMultiple(): bool
+    {
+        return true;
+    }
+}

--- a/src/elements/conditions/orders/CustomerConditionRule.php
+++ b/src/elements/conditions/orders/CustomerConditionRule.php
@@ -25,7 +25,7 @@ use yii\db\Expression;
  *
  * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
  * @since 4.2.0
- * @TODO change the class that the `CustomerConditionRule` extends
+ * @TODO change the class that the `CustomerConditionRule` extends. Doesn't use the `BaseElementSelectConditionRule` because `allowMultiple()` was added later and it doesn't allow for negative matching.
  */
 class CustomerConditionRule extends BaseMultiSelectConditionRule implements ElementConditionRuleInterface
 {

--- a/src/elements/conditions/variants/CatalogPricingRuleVariantCondition.php
+++ b/src/elements/conditions/variants/CatalogPricingRuleVariantCondition.php
@@ -15,4 +15,13 @@ namespace craft\commerce\elements\conditions\variants;
  */
 class CatalogPricingRuleVariantCondition extends VariantCondition
 {
+    /**
+     * @inheritdoc
+     */
+    protected function selectableConditionRules(): array
+    {
+        return array_merge(parent::selectableConditionRules(), [
+            CatalogPricingRuleVariantConditionRule::class,
+        ]);
+    }
 }

--- a/src/elements/conditions/variants/CatalogPricingRuleVariantConditionRule.php
+++ b/src/elements/conditions/variants/CatalogPricingRuleVariantConditionRule.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace  craft\commerce\elements\conditions\variants;
+
+/**
+ * Catalog Pricing Rule Match Variant - Variants Condition Rule
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.5.0
+ */
+class CatalogPricingRuleVariantConditionRule extends VariantConditionRule
+{
+}

--- a/src/elements/conditions/variants/VariantConditionRule.php
+++ b/src/elements/conditions/variants/VariantConditionRule.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace  craft\commerce\elements\conditions\variants;
+
+use Craft;
+use craft\base\conditions\BaseElementSelectConditionRule;
+use craft\base\ElementInterface;
+use craft\commerce\elements\db\VariantQuery;
+use craft\commerce\elements\Variant;
+use craft\elements\conditions\ElementConditionRuleInterface;
+use craft\elements\db\ElementQueryInterface;
+
+/**
+ * Variants Condition Rule
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ * @since 5.5.0
+ */
+class VariantConditionRule extends BaseElementSelectConditionRule implements ElementConditionRuleInterface
+{
+    /**
+     * @inheritdoc
+     */
+    protected function elementType(): string
+    {
+        return Variant::class;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLabel(): string
+    {
+        return Craft::t('commerce', 'Product Variant');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getExclusiveQueryParams(): array
+    {
+        return ['id'];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function modifyQuery(ElementQueryInterface $query): void
+    {
+        /** @var VariantQuery $query */
+        $query->id($this->getElementIds());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function matchElement(ElementInterface $element): bool
+    {
+        /** @var Variant $element */
+        return $this->matchValue($element->getId());
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function allowMultiple(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @inerhitdoc
+     */
+    protected function elementSelectConfig(): array
+    {
+        return array_merge(parent::elementSelectConfig(), [
+            'showSiteMenu' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
### Description
Now "Match Variant" condition's product rule allows multiple selections we have also added a "Product Variant" rule that allows multiple selections.

In the "Match Customer" condition we have added a "Customer" rule for allowing the selection of specific customers to also help with the creation of tailored pricing rules.


### Related issues
#4167
