### PR TITLE
[5.x] Fix error: undefined array key for gateway change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ node_modules/
 /tests/_craft/config/project
 .env
 /CLAUDE.md
+*-private.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Fixed a bug where newly created variants weren’t visible on Edit product screens. 
-- Fixed a SQL error that could occur when viewing product indexes. 
+- Fixed a SQL error that could occur when viewing product indexes.
+- Fixed a PHP error that occurred when applying project config changes after updating. ([#4185](https://github.com/craftcms/commerce/issues/4185))
 
 ## 5.5.0.1 - 2025-11-24
 

--- a/src/services/Gateways.php
+++ b/src/services/Gateways.php
@@ -295,6 +295,11 @@ class Gateways extends Component
         $gatewayUid = $event->tokenMatches[0];
         $data = $event->newValue;
 
+        // Bail if the data is not a valid gateway config array
+        if (!is_array($data)) {
+            return;
+        }
+
         $transaction = Craft::$app->getDb()->beginTransaction();
         try {
             $gatewayRecord = $this->_getGatewayRecord($gatewayUid);


### PR DESCRIPTION
### Description

This matches the pattern used in `craft\services\Fields::handleChangedField()`.

### Related issues

Fixes #4185