### PR TITLE
Fix tax adjustment type

### DIFF
--- a/src/adjusters/Tax.php
+++ b/src/adjusters/Tax.php
@@ -192,7 +192,7 @@ class Tax extends Component implements AdjusterInterface
                 // We need to display the adjustment that removed the included tax
                 $adjustment->name = Craft::t('site', $taxRate->name) . ' ' . Craft::t('commerce', 'Removed');
                 $adjustment->amount = $orderLevelAmountToBeRemovedByDiscount;
-                $adjustment->type = 'discount'; // TODO Not use a discount adjustment, but modify the price of the item instead. #COM-26
+                $adjustment->type = self::ADJUSTMENT_TYPE; // TODO Not use a discount adjustment, but modify the price of the item instead. #COM-26
                 $adjustment->included = false;
 
                 $adjustments[] = $adjustment;
@@ -241,7 +241,7 @@ class Tax extends Component implements AdjusterInterface
                         $adjustment->name = Craft::t('site', $taxRate->name) . ' ' . Craft::t('commerce', 'Removed');
                         $adjustment->amount = $amount;
                         $adjustment->setLineItem($item);
-                        $adjustment->type = 'discount';
+                        $adjustment->type = self::ADJUSTMENT_TYPE;
                         $adjustment->included = false;
 
                         $objectId = spl_object_hash($item); // We use this ID since some line items are not saved in the DB yet and have no ID.

--- a/tests/unit/adjusters/TaxTest.php
+++ b/tests/unit/adjusters/TaxTest.php
@@ -380,7 +380,7 @@ class TaxTest extends Unit
                 [
                     'adjustments' => [
                         [
-                            'type' => 'discount',
+                            'type' => 'tax',
                             'amount' => -9.09,
                             'included' => false,
                             'description' => '10%',
@@ -440,7 +440,7 @@ class TaxTest extends Unit
                 [
                     'adjustments' => [
                         [
-                            'type' => 'discount',
+                            'type' => 'tax',
                             'amount' => -9.09,
                             'included' => false,
                             'description' => '10%',


### PR DESCRIPTION
### Description
Makes the tax adjustment type `tax` instead of `discount`


### Related issues
https://github.com/craftcms/commerce/issues/4208