### PR TITLE
[5.x] No need to eagerload for product default variant attributes anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Improved product index performance by not eager-loading variants for table attributes that are already fetched via SQL joins. ([#4236](https://github.com/craftcms/commerce/issues/4236))
+
 ## 5.5.4 - 2026-02-18
 
 - Fixed a bug where subscription plan edit screens weren’t showing their linked description entries, if the entries were disabled. ([#4229](https://github.com/craftcms/commerce/issues/4229))

--- a/src/elements/Product.php
+++ b/src/elements/Product.php
@@ -688,18 +688,10 @@ JS, [
      */
     public static function prepElementQueryForTableAttribute(ElementQueryInterface $elementQuery, string $attribute): void
     {
-        $variantAttributes = [
-            'variants',
-            'defaultPrice',
-            'defaultPromotionalPrice',
-            'defaultSku',
-            'defaultWeight',
-            'defaultLength',
-            'defaultWidth',
-            'defaultHeight',
-        ];
-
-        if (in_array($attribute, $variantAttributes, false)) {
+        // Only eager load variants for attributes that actually need them.
+        // Other variant-related attributes (defaultPrice, defaultSku, etc.) are already
+        // fetched via SQL JOINs in ProductQuery::beforePrepare()
+        if (in_array($attribute, ['variants', 'stock'], true)) {
             $elementQuery->andWith('variants');
         } else {
             parent::prepElementQueryForTableAttribute($elementQuery, $attribute);


### PR DESCRIPTION
### Description

Potential fix for https://github.com/craftcms/commerce/issues/4236


