### PR TITLE
[4.x] fix(manual-gateway): Fixed a PHP error that could occur when getOnlyAllowForZeroPriceOrders was not set

### DIFF
--- a/src/gateways/Manual.php
+++ b/src/gateways/Manual.php
@@ -241,7 +241,7 @@ class Manual extends Gateway
      */
     public function getOnlyAllowForZeroPriceOrders(bool $parse = true): bool|string
     {
-        return $parse ? App::parseBooleanEnv($this->_onlyAllowForZeroPriceOrders) : $this->_onlyAllowForZeroPriceOrders;
+        return $parse ? (App::parseBooleanEnv($this->_onlyAllowForZeroPriceOrders) ?? false) : $this->_onlyAllowForZeroPriceOrders;
     }
 
     /**


### PR DESCRIPTION
Ensures boolean env parsing fallback to false to prevent PHP errors in Manual Gateway.


### Description

TypeError: craft\commerce\gateways\Manual::getOnlyAllowForZeroPriceOrders(): Return value must be of type string|bool, null returned



