### PR TITLE
Add read-only mode to Carts::getCart()

### DIFF
--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -128,12 +128,33 @@ class Carts extends Component
      * Get the current cart for this session.
      *
      * @param bool $forceSave Force the cart.
+     * @param bool $readOnly Whether to retrieve the cart in read-only mode.
      * @throws ElementNotFoundException
      * @throws Exception
      * @throws Throwable
      */
-    public function getCart(bool $forceSave = false): Order
+    public function getCart(bool $forceSave = false, bool $readOnly = false): ?Order
     {
+        if ($readOnly) {
+            if (isset($this->_cart)) {
+                return $this->_cart;
+            }
+
+            if (!$this->getHasSessionCartNumber()) {
+                return null;
+            }
+
+            $request = Craft::$app->getRequest();
+            $number = $request->getCookies()->getValue($this->cartCookie['name'], false);
+            if (!$number) {
+                return null;
+            }
+
+            $this->_cartNumber = $number;
+            $this->_cart = $this->_getCart(false, false);
+            return $this->_cart;
+        }
+
         $this->loadCookie(); // TODO: need to see if this should be added to other runtime methods too
 
         $this->_getCartCount++; //useful when debugging
@@ -212,7 +233,7 @@ class Carts extends Component
     /**
      * Get the current cart for this session.
      */
-    private function _getCart(): ?Order
+    private function _getCart(bool $forgetInvalidCart = true, bool $checkAnonymousCartSession = true): ?Order
     {
         $number = $this->getSessionCartNumber();
         /** @var Order|null $cart */
@@ -227,7 +248,9 @@ class Carts extends Component
 
         // If the cart is already completed or trashed, forget the cart and start again.
         if ($cart && ($cart->isCompleted || $cart->trashed)) {
-            $this->forgetCart();
+            if ($forgetInvalidCart) {
+                $this->forgetCart();
+            }
             return null;
         }
 
@@ -237,7 +260,10 @@ class Carts extends Component
 
         // Did an anonymous user provide an email that belonged to a credentialed user?
         // See CartController::actionUpdate()
-        $anonymousCartWithCredentialedCustomer = $cart && Craft::$app->getSession()->get('commerce:anonymousCartWithCredentialedCustomer:' . $cart->number, false);
+        $anonymousCartWithCredentialedCustomer = false;
+        if ($checkAnonymousCartSession && $cart) {
+            $anonymousCartWithCredentialedCustomer = Craft::$app->getSession()->get('commerce:anonymousCartWithCredentialedCustomer:' . $cart->number, false);
+        }
 
         if ($cart && $cartCustomer && $cartCustomer->getIsCredentialed() &&
             (
@@ -248,7 +274,9 @@ class Carts extends Component
                 ($currentUser && $currentUser->id != $cartCustomer->id)
             )
         ) {
-            $this->forgetCart();
+            if ($forgetInvalidCart) {
+                $this->forgetCart();
+            }
             return null;
         }
 

--- a/tests/unit/services/CartsTest.php
+++ b/tests/unit/services/CartsTest.php
@@ -16,6 +16,7 @@ use craft\commerce\services\Stores;
 use craftcommercetests\fixtures\CustomerAddressFixture;
 use craftcommercetests\fixtures\CustomerFixture;
 use UnitTester;
+use yii\web\Cookie;
 
 /**
  * CartsTest.
@@ -139,5 +140,30 @@ class CartsTest extends Unit
         // Reset data
         Craft::$app->getUser()->setIdentity($originalIdentity);
         Craft::$app->getElements()->deleteElement($cart, true);
+    }
+
+    public function testGetCartReadOnlyModeDoesNotStartCartSession(): void
+    {
+        $cartNumber = Plugin::getInstance()->getCarts()->generateCartNumber();
+
+        $order = new Order();
+        $order->number = $cartNumber;
+        Craft::$app->getElements()->saveElement($order, false);
+
+        $carts = $this->make(Carts::class, [
+            'setSessionCartNumber' => function() {
+                self::fail('Read-only cart retrieval should not update the cart session.');
+            },
+        ]);
+        Plugin::getInstance()->set('carts', $carts);
+        Craft::$app->getRequest()->getCookies()->add(new Cookie([
+            'name' => $carts->cartCookie['name'],
+            'value' => $cartNumber,
+        ]));
+
+        $cart = Plugin::getInstance()->getCarts()->getCart(readOnly: true);
+
+        self::assertNotNull($cart);
+        self::assertSame($cartNumber, $cart->number);
     }
 }


### PR DESCRIPTION
## Why
Calling craft.commerce.carts.getCart() for display-only UI (like a header cart badge) currently initializes the cart session and sets a cart cookie when none exists. On Cloudflare-cached pages this creates avoidable cache fragmentation and unnecessary Set-Cookie responses.

This change adds a read-only retrieval path so templates/controllers can check for an existing cart without starting a new cart session.

## What changed
- Added readOnly parameter to Carts::getCart()
- getCart(readOnly: true):
  - returns the existing cart if one is already associated with the request cookie
  - returns null when no cart cookie/cart exists
  - does not create a new cart number
  - does not call setSessionCartNumber()
- Added a unit test that asserts read-only mode does not write session cart state

## Example use cases
Use read-only mode when you need to read cart state but must avoid mutating session/cookie state:

PHP example:
$cart = Plugin::getInstance()->getCarts()->getCart(readOnly: true);
$count = $cart?->totalQty ?? 0;

Twig example:
{% set cart = craft.commerce.carts.getCart(false, true) %}
{{ cart ? cart.totalQty : 0 }}

Typical scenarios:
- Cached global header cart count on product/category/marketing pages
- Edge-cached storefront pages where Set-Cookie should be avoided for anonymous traffic
- Read-only telemetry or analytics that checks current cart presence

Use regular getCart() for cart/checkout flows that are expected to create or mutate cart state.
