### PR TITLE
Include billing and shipping address conditions in Gateway edit form

### DIFF
--- a/src/controllers/GatewaysController.php
+++ b/src/controllers/GatewaysController.php
@@ -160,11 +160,23 @@ class GatewaysController extends BaseAdminController
             'isFrontendEnabled' => $this->request->getParam('isFrontendEnabled'),
             'settings' => $this->request->getBodyParam('types.' . $type),
         ];
-        
+
         // Handle order condition if it's in the request
         $orderCondition = $this->request->getBodyParam('orderCondition');
         if ($orderCondition !== null) {
             $config['orderCondition'] = $orderCondition;
+        }
+
+        // Handle billing address condition if it's in the request
+        $billingAddressCondition = $this->request->getBodyParam('billingAddressCondition');
+        if ($billingAddressCondition !== null) {
+            $config['billingAddressCondition'] = $billingAddressCondition;
+        }
+
+        // Handle shipping address condition if it's in the request
+        $shippingAddressCondition = $this->request->getBodyParam('shippingAddressCondition');
+        if ($shippingAddressCondition !== null) {
+            $config['shippingAddressCondition'] = $shippingAddressCondition;
         }
 
         // For new gateway avoid NULL value.

--- a/src/templates/settings/gateways/_edit.twig
+++ b/src/templates/settings/gateways/_edit.twig
@@ -108,7 +108,6 @@
         disabled: readOnly,
     }) }}
 
-
     <hr>
     {% set orderConditionInput %}
         {{ gateway.getOrderCondition().getBuilderHtml(readOnly)|raw }}
@@ -119,6 +118,26 @@
         instructions: 'Create rules that allow this gateway to match the order.'|t('commerce'),
         errors: gateway.getErrors('orderCondition'),
     }, orderConditionInput) }}
+
+		{% set billingAddressConditionInput %}
+				{{ gateway.billingAddressCondition().getBuilderHtml(readOnly)|raw }}
+		{% endset %}
+
+		{{ forms.field({
+				label: 'Match Billing Address'|t('commerce'),
+				instructions: 'Create rules that allow this gateway to match the billing address.'|t('commerce'),
+				errors: gateway.getErrors('orderCondition'),
+		}, billingAddressConditionInput) }}
+
+		{% set shippingAddressConditionInput %}
+				{{ gateway.shippingAddressCondition().getBuilderHtml(readOnly)|raw }}
+		{% endset %}
+
+		{{ forms.field({
+				label: 'Match Shipping Address'|t('commerce'),
+				instructions: 'Create rules that allow this gateway to match the shipping address.'|t('commerce'),
+				errors: gateway.getErrors('orderCondition'),
+		}, shippingAddressConditionInput) }}
 
 {% endblock %}
 


### PR DESCRIPTION
### Description

We have a need to include gateways on orders by address. The billing and shipping address conditions already exist on the Gateway class, they're just not being rendered in the edit form, or included in the save action.

This PR updates the edit form to show both condition inputs, and updates the save action so that they can be persisted correctly.

<img width="688" height="484" alt="CleanShot 2026-03-20 at 13 57 32" src="https://github.com/user-attachments/assets/2dca51b6-0780-4f46-b07a-a78979d403e8" />


### Related issues


