### PR TITLE
[5.7] Add read-only mode to retrieving carts

### DIFF
--- a/CHANGELOG-WIP.md
+++ b/CHANGELOG-WIP.md
@@ -31,12 +31,15 @@
 ## Development
 
 - Product permissions have been refined into separate "View", "Create", "Save", and "Delete" permissions.
+- Added a `cart/peek-cart` controller action, which returns the existing cart for the current request without creating a new cart or setting cookies — useful for cached pages such as a header cart badge, where `Set-Cookie` responses should be avoided. ([#4263](https://github.com/craftcms/commerce/pull/4263))
 
 ## Extensibility
 
 - Added `craft\commerce\services\ProductTypes::getViewableProductTypes()`.
 - Added `craft\commerce\services\ProductTypes::getViewableProductTypeIds()`.
 - Added `craft\commerce\services\ProductTypes::getCreatableProductTypeIds()`.
+- Added `craft\commerce\services\Carts::peekCart()`.
+- Added `craft\commerce\controllers\CartController::actionPeekCart()`.
 - Deprecated `craft\commerce\services\ProductTypes::hasPermission()`. Use `$user->can()` directly instead.
 - Deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()`. Use `getViewableProductTypes()` instead.
 - Deprecated `craft\commerce\services\ProductTypes::getEditableProductTypeIds()`. Use `getViewableProductTypeIds()` instead.

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -85,7 +85,7 @@ class CartController extends BaseFrontEndController
         return array_merge(parent::behaviors(), [
             'rateLimiter' => [
                 'class' => RateLimiter::class,
-                'only' => ['get-cart', 'get-static-cart', 'update-cart', 'load-cart', 'complete'],
+                'only' => ['get-cart', 'peek-cart', 'update-cart', 'load-cart', 'complete'],
                 'enableRateLimitHeaders' => false,
                 'user' => function() {
                     // Only apply rate limiting when a cart number is explicitly passed
@@ -123,11 +123,11 @@ class CartController extends BaseFrontEndController
      * Returns the existing cart for this session without creating one, setting cookies, or touching the session.
      * Returns null (as empty cart data) if no cart exists for the current session.
      */
-    public function actionGetStaticCart(): Response
+    public function actionPeekCart(): Response
     {
         $this->requireAcceptsJson();
 
-        $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+        $cart = Plugin::getInstance()->getCarts()->peekCart();
 
         return $this->asSuccess(data: [
             $this->_cartVariable => $cart ? $this->cartArray($cart) : null,

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -85,7 +85,7 @@ class CartController extends BaseFrontEndController
         return array_merge(parent::behaviors(), [
             'rateLimiter' => [
                 'class' => RateLimiter::class,
-                'only' => ['get-cart', 'update-cart', 'load-cart', 'complete'],
+                'only' => ['get-cart', 'get-static-cart', 'update-cart', 'load-cart', 'complete'],
                 'enableRateLimitHeaders' => false,
                 'user' => function() {
                     // Only apply rate limiting when a cart number is explicitly passed

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -120,6 +120,21 @@ class CartController extends BaseFrontEndController
     }
 
     /**
+     * Returns the existing cart for this session without creating one, setting cookies, or touching the session.
+     * Returns null (as empty cart data) if no cart exists for the current session.
+     */
+    public function actionGetStaticCart(): Response
+    {
+        $this->requireAcceptsJson();
+
+        $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+
+        return $this->asSuccess(data: [
+            $this->_cartVariable => $cart ? $this->cartArray($cart) : null,
+        ]);
+    }
+
+    /**
      * Updates the cart by adding purchasables to the cart, updating line items, or updating various cart attributes.
      *
      * @throws BadRequestHttpException

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -219,18 +219,20 @@ class Carts extends Component
             return $this->_cart;
         }
 
-        if (!$this->getHasSessionCartNumber()) {
+        // check directly, calling getHasSessionCartNumber() would cause the cart number to be loaded from the cookie and set in the session, which we don't want to do here.
+        if ($this->_cartNumber === false) {
             return null;
         }
 
-        $number = Craft::$app->getRequest()->getCookies()->getValue($this->cartCookie['name'], false);
-        if (!$number) {
+        if (!$this->_cartNumber) {
+            $this->_cartNumber = Craft::$app->getRequest()->getCookies()->getValue($this->cartCookie['name'], false) ?: null;
+        }
+
+        if (!$this->_cartNumber) {
             return null;
         }
 
-        $this->_cartNumber = $number;
-        $this->_cart = $this->_getCart(false, false);
-        return $this->_cart;
+        return Order::find()->number($this->_cartNumber)->isCompleted(false)->one();
     }
 
     /**

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -128,33 +128,12 @@ class Carts extends Component
      * Get the current cart for this session.
      *
      * @param bool $forceSave Force the cart.
-     * @param bool $readOnly Whether to retrieve the cart in read-only mode.
      * @throws ElementNotFoundException
      * @throws Exception
      * @throws Throwable
      */
-    public function getCart(bool $forceSave = false, bool $readOnly = false): ?Order
+    public function getCart(bool $forceSave = false): Order
     {
-        if ($readOnly) {
-            if (isset($this->_cart)) {
-                return $this->_cart;
-            }
-
-            if (!$this->getHasSessionCartNumber()) {
-                return null;
-            }
-
-            $request = Craft::$app->getRequest();
-            $number = $request->getCookies()->getValue($this->cartCookie['name'], false);
-            if (!$number) {
-                return null;
-            }
-
-            $this->_cartNumber = $number;
-            $this->_cart = $this->_getCart(false, false);
-            return $this->_cart;
-        }
-
         $this->loadCookie(); // TODO: need to see if this should be added to other runtime methods too
 
         $this->_getCartCount++; //useful when debugging
@@ -227,6 +206,30 @@ class Carts extends Component
             Craft::$app->getElements()->saveElement($this->_cart, false);
         }
 
+        return $this->_cart;
+    }
+
+    /**
+     * Returns the existing cart for this session without creating one, setting cookies, or touching the session.
+     * Returns null if no cart cookie is present or no matching cart exists.
+     */
+    public function getStaticCart(): ?Order
+    {
+        if (isset($this->_cart)) {
+            return $this->_cart;
+        }
+
+        if (!$this->getHasSessionCartNumber()) {
+            return null;
+        }
+
+        $number = Craft::$app->getRequest()->getCookies()->getValue($this->cartCookie['name'], false);
+        if (!$number) {
+            return null;
+        }
+
+        $this->_cartNumber = $number;
+        $this->_cart = $this->_getCart(false, false);
         return $this->_cart;
     }
 

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -212,8 +212,10 @@ class Carts extends Component
     /**
      * Returns the existing cart for this session without creating one, setting cookies, or touching the session.
      * Returns null if no cart cookie is present or no matching cart exists.
+     *
+     * @since 5.7.0
      */
-    public function getStaticCart(): ?Order
+    public function peekCart(): ?Order
     {
         if (isset($this->_cart)) {
             return $this->_cart;
@@ -224,20 +226,44 @@ class Carts extends Component
         }
 
         if (!$this->_cartNumber) {
-            $this->_cartNumber = Craft::$app->getRequest()->getCookies()->getValue($this->cartCookie['name'], false) ?: null;
+            $cookieNumber = Craft::$app->getRequest()->getCookies()->getValue($this->cartCookie['name'], false);
+            if (!$cookieNumber) {
+                return null;
+            }
+            $this->_cartNumber = $cookieNumber;
         }
 
-        if (!$this->_cartNumber) {
+        /** @var Order|null $cart */
+        $cart = Order::find()
+            ->number($this->_cartNumber)
+            ->storeId(Plugin::getInstance()->getStores()->getCurrentStore()->id)
+            ->isCompleted(false)
+            ->trashed(false)
+            ->one();
+
+        if (!$cart) {
             return null;
         }
 
-        return Order::find()->number($this->_cartNumber)->isCompleted(false)->one();
+        // Don't return a cart that belongs to a credentialed user who isn't currently logged in
+        // as that user. Mirrors the privacy check in _getCart(), but without forgetting the cart
+        // (which would set a Set-Cookie header and defeat the purpose of this method).
+        $cartCustomer = $cart->getCustomer();
+        if ($cartCustomer && $cartCustomer->getIsCredentialed()) {
+            $currentUser = Craft::$app->getUser()->getIdentity();
+            if (!$currentUser || $currentUser->id != $cartCustomer->id) {
+                return null;
+            }
+        }
+
+        $this->_cart = $cart;
+        return $this->_cart;
     }
 
     /**
      * Get the current cart for this session.
      */
-    private function _getCart(bool $forgetInvalidCart = true, bool $checkAnonymousCartSession = true): ?Order
+    private function _getCart(): ?Order
     {
         $number = $this->getSessionCartNumber();
         /** @var Order|null $cart */
@@ -252,9 +278,7 @@ class Carts extends Component
 
         // If the cart is already completed or trashed, forget the cart and start again.
         if ($cart && ($cart->isCompleted || $cart->trashed)) {
-            if ($forgetInvalidCart) {
-                $this->forgetCart();
-            }
+            $this->forgetCart();
             return null;
         }
 
@@ -264,10 +288,7 @@ class Carts extends Component
 
         // Did an anonymous user provide an email that belonged to a credentialed user?
         // See CartController::actionUpdate()
-        $anonymousCartWithCredentialedCustomer = false;
-        if ($checkAnonymousCartSession && $cart) {
-            $anonymousCartWithCredentialedCustomer = Craft::$app->getSession()->get('commerce:anonymousCartWithCredentialedCustomer:' . $cart->number, false);
-        }
+        $anonymousCartWithCredentialedCustomer = $cart && Craft::$app->getSession()->get('commerce:anonymousCartWithCredentialedCustomer:' . $cart->number, false);
 
         if ($cart && $cartCustomer && $cartCustomer->getIsCredentialed() &&
             (
@@ -278,9 +299,7 @@ class Carts extends Component
                 ($currentUser && $currentUser->id != $cartCustomer->id)
             )
         ) {
-            if ($forgetInvalidCart) {
-                $this->forgetCart();
-            }
+            $this->forgetCart();
             return null;
         }
 

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -128,12 +128,33 @@ class Carts extends Component
      * Get the current cart for this session.
      *
      * @param bool $forceSave Force the cart.
+     * @param bool $readOnly Whether to retrieve the cart in read-only mode.
      * @throws ElementNotFoundException
      * @throws Exception
      * @throws Throwable
      */
-    public function getCart(bool $forceSave = false): Order
+    public function getCart(bool $forceSave = false, bool $readOnly = false): ?Order
     {
+        if ($readOnly) {
+            if (isset($this->_cart)) {
+                return $this->_cart;
+            }
+
+            if (!$this->getHasSessionCartNumber()) {
+                return null;
+            }
+
+            $request = Craft::$app->getRequest();
+            $number = $request->getCookies()->getValue($this->cartCookie['name'], false);
+            if (!$number) {
+                return null;
+            }
+
+            $this->_cartNumber = $number;
+            $this->_cart = $this->_getCart(false, false);
+            return $this->_cart;
+        }
+
         $this->loadCookie(); // TODO: need to see if this should be added to other runtime methods too
 
         $this->_getCartCount++; //useful when debugging
@@ -212,7 +233,7 @@ class Carts extends Component
     /**
      * Get the current cart for this session.
      */
-    private function _getCart(): ?Order
+    private function _getCart(bool $forgetInvalidCart = true, bool $checkAnonymousCartSession = true): ?Order
     {
         $number = $this->getSessionCartNumber();
         /** @var Order|null $cart */
@@ -227,7 +248,9 @@ class Carts extends Component
 
         // If the cart is already completed or trashed, forget the cart and start again.
         if ($cart && ($cart->isCompleted || $cart->trashed)) {
-            $this->forgetCart();
+            if ($forgetInvalidCart) {
+                $this->forgetCart();
+            }
             return null;
         }
 
@@ -237,7 +260,10 @@ class Carts extends Component
 
         // Did an anonymous user provide an email that belonged to a credentialed user?
         // See CartController::actionUpdate()
-        $anonymousCartWithCredentialedCustomer = $cart && Craft::$app->getSession()->get('commerce:anonymousCartWithCredentialedCustomer:' . $cart->number, false);
+        $anonymousCartWithCredentialedCustomer = false;
+        if ($checkAnonymousCartSession && $cart) {
+            $anonymousCartWithCredentialedCustomer = Craft::$app->getSession()->get('commerce:anonymousCartWithCredentialedCustomer:' . $cart->number, false);
+        }
 
         if ($cart && $cartCustomer && $cartCustomer->getIsCredentialed() &&
             (
@@ -248,7 +274,9 @@ class Carts extends Component
                 ($currentUser && $currentUser->id != $cartCustomer->id)
             )
         ) {
-            $this->forgetCart();
+            if ($forgetInvalidCart) {
+                $this->forgetCart();
+            }
             return null;
         }
 

--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -219,7 +219,6 @@ class Carts extends Component
             return $this->_cart;
         }
 
-        // check directly, calling getHasSessionCartNumber() would cause the cart number to be loaded from the cookie and set in the session, which we don't want to do here.
         if ($this->_cartNumber === false) {
             return null;
         }

--- a/tests/unit/services/CartsTest.php
+++ b/tests/unit/services/CartsTest.php
@@ -17,6 +17,7 @@ use craft\web\Request;
 use craftcommercetests\fixtures\CustomerAddressFixture;
 use craftcommercetests\fixtures\CustomerFixture;
 use UnitTester;
+use yii\web\Cookie;
 
 /**
  * CartsTest.
@@ -227,5 +228,30 @@ class CartsTest extends Unit
         // Reset data
         Craft::$app->getUser()->setIdentity($originalIdentity);
         Craft::$app->getElements()->deleteElement($cart, true);
+    }
+
+    public function testGetCartReadOnlyModeDoesNotStartCartSession(): void
+    {
+        $cartNumber = Plugin::getInstance()->getCarts()->generateCartNumber();
+
+        $order = new Order();
+        $order->number = $cartNumber;
+        Craft::$app->getElements()->saveElement($order, false);
+
+        $carts = $this->make(Carts::class, [
+            'setSessionCartNumber' => function() {
+                self::fail('Read-only cart retrieval should not update the cart session.');
+            },
+        ]);
+        Plugin::getInstance()->set('carts', $carts);
+        Craft::$app->getRequest()->getCookies()->add(new Cookie([
+            'name' => $carts->cartCookie['name'],
+            'value' => $cartNumber,
+        ]));
+
+        $cart = Plugin::getInstance()->getCarts()->getCart(readOnly: true);
+
+        self::assertNotNull($cart);
+        self::assertSame($cartNumber, $cart->number);
     }
 }

--- a/tests/unit/services/CartsTest.php
+++ b/tests/unit/services/CartsTest.php
@@ -230,7 +230,7 @@ class CartsTest extends Unit
         Craft::$app->getElements()->deleteElement($cart, true);
     }
 
-    public function testGetCartReadOnlyModeDoesNotStartCartSession(): void
+    public function testGetStaticCartDoesNotStartCartSession(): void
     {
         $cartNumber = Plugin::getInstance()->getCarts()->generateCartNumber();
 
@@ -240,7 +240,7 @@ class CartsTest extends Unit
 
         $carts = $this->make(Carts::class, [
             'setSessionCartNumber' => function() {
-                self::fail('Read-only cart retrieval should not update the cart session.');
+                self::fail('Static cart retrieval should not update the cart session.');
             },
         ]);
         Plugin::getInstance()->set('carts', $carts);
@@ -249,9 +249,18 @@ class CartsTest extends Unit
             'value' => $cartNumber,
         ]));
 
-        $cart = Plugin::getInstance()->getCarts()->getCart(readOnly: true);
+        $cart = Plugin::getInstance()->getCarts()->getStaticCart();
 
         self::assertNotNull($cart);
         self::assertSame($cartNumber, $cart->number);
+
+        Craft::$app->getElements()->deleteElement($order, true);
+    }
+
+    public function testGetStaticCartReturnsNullWithNoCookie(): void
+    {
+        $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+
+        self::assertNull($cart);
     }
 }

--- a/tests/unit/services/CartsTest.php
+++ b/tests/unit/services/CartsTest.php
@@ -17,7 +17,6 @@ use craft\web\Request;
 use craftcommercetests\fixtures\CustomerAddressFixture;
 use craftcommercetests\fixtures\CustomerFixture;
 use UnitTester;
-use yii\web\Cookie;
 
 /**
  * CartsTest.
@@ -232,7 +231,9 @@ class CartsTest extends Unit
 
     public function testGetStaticCartDoesNotStartCartSession(): void
     {
-        $cartNumber = Plugin::getInstance()->getCarts()->generateCartNumber();
+        $originalCarts = Plugin::getInstance()->getCarts();
+        $cartNumber = $originalCarts->generateCartNumber();
+        $cookieName = $originalCarts->cartCookie['name'];
 
         $order = new Order();
         $order->number = $cartNumber;
@@ -243,24 +244,50 @@ class CartsTest extends Unit
                 self::fail('Static cart retrieval should not update the cart session.');
             },
         ]);
+        $carts->cartCookie = ['name' => $cookieName];
         Plugin::getInstance()->set('carts', $carts);
-        Craft::$app->getRequest()->getCookies()->add(new Cookie([
-            'name' => $carts->cartCookie['name'],
+
+        $requestCookies = new \yii\web\CookieCollection();
+        $requestCookies->add(new \yii\web\Cookie([
+            'name' => $cookieName,
             'value' => $cartNumber,
         ]));
+        $originalRequest = Craft::$app->getRequest();
+        $requestMock = $this->make(Request::class, [
+            'getCookies' => $requestCookies,
+        ]);
+        Craft::$app->set('request', $requestMock);
 
-        $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+        try {
+            $cart = Plugin::getInstance()->getCarts()->getStaticCart();
 
-        self::assertNotNull($cart);
-        self::assertSame($cartNumber, $cart->number);
-
-        Craft::$app->getElements()->deleteElement($order, true);
+            self::assertNotNull($cart);
+            self::assertSame($cartNumber, $cart->number);
+        } finally {
+            Craft::$app->set('request', $originalRequest);
+            Craft::$app->getElements()->deleteElement($order, true);
+        }
     }
 
     public function testGetStaticCartReturnsNullWithNoCookie(): void
     {
-        $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+        $cookieName = Plugin::getInstance()->getCarts()->cartCookie['name'];
 
-        self::assertNull($cart);
+        $carts = $this->make(Carts::class);
+        $carts->cartCookie = ['name' => $cookieName];
+        Plugin::getInstance()->set('carts', $carts);
+
+        $originalRequest = Craft::$app->getRequest();
+        $requestMock = $this->make(Request::class, [
+            'getCookies' => new \yii\web\CookieCollection(),
+        ]);
+        Craft::$app->set('request', $requestMock);
+
+        try {
+            $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+            self::assertNull($cart);
+        } finally {
+            Craft::$app->set('request', $originalRequest);
+        }
     }
 }

--- a/tests/unit/services/CartsTest.php
+++ b/tests/unit/services/CartsTest.php
@@ -229,7 +229,7 @@ class CartsTest extends Unit
         Craft::$app->getElements()->deleteElement($cart, true);
     }
 
-    public function testGetStaticCartDoesNotStartCartSession(): void
+    public function testPeekCartDoesNotStartCartSession(): void
     {
         $originalCarts = Plugin::getInstance()->getCarts();
         $cartNumber = $originalCarts->generateCartNumber();
@@ -241,7 +241,7 @@ class CartsTest extends Unit
 
         $carts = $this->make(Carts::class, [
             'setSessionCartNumber' => function() {
-                self::fail('Static cart retrieval should not update the cart session.');
+                self::fail('Peek cart retrieval should not update the cart session.');
             },
         ]);
         $carts->cartCookie = ['name' => $cookieName];
@@ -259,7 +259,7 @@ class CartsTest extends Unit
         Craft::$app->set('request', $requestMock);
 
         try {
-            $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+            $cart = Plugin::getInstance()->getCarts()->peekCart();
 
             self::assertNotNull($cart);
             self::assertSame($cartNumber, $cart->number);
@@ -269,7 +269,7 @@ class CartsTest extends Unit
         }
     }
 
-    public function testGetStaticCartReturnsNullWithNoCookie(): void
+    public function testPeekCartReturnsNullWithNoCookie(): void
     {
         $cookieName = Plugin::getInstance()->getCarts()->cartCookie['name'];
 
@@ -284,7 +284,7 @@ class CartsTest extends Unit
         Craft::$app->set('request', $requestMock);
 
         try {
-            $cart = Plugin::getInstance()->getCarts()->getStaticCart();
+            $cart = Plugin::getInstance()->getCarts()->peekCart();
             self::assertNull($cart);
         } finally {
             Craft::$app->set('request', $originalRequest);


### PR DESCRIPTION
## Summary
- Rebased from PR #4246 (by @boboldehampsink) and brought up to date with 5.7
- Adds `Carts::peekCart()` and a `cart/peek-cart` controller action that returns the existing cart for the current request without creating a new cart, setting cookies, or touching the session
- Useful for cached pages (e.g. header cart badge) where `Set-Cookie` should be avoided

Returns `null` if no cart cookie is present, no matching cart exists, or the cart belongs to a credentialed user who isn't currently logged in as that user.

## Example use

### JavaScript

```js
fetch('/actions/commerce/cart/peek-cart', {
  headers: {
    'Accept': 'application/json',
  },
})
  .then(r => r.json())
  .then(console.log);

// -> { cart: { ... } }  when a cart exists
// -> { cart: null }     when no cart exists for the current request
```

### Twig

```twig
{% set cart = craft.commerce.carts.peekCart() %}
{% if cart %}
  <a href="/cart" class="cart-badge">
    Cart ({{ cart.totalQty }})
  </a>
{% endif %}
```

## Original PR
https://github.com/craftcms/commerce/pull/4246