### PR TITLE
[5.x] Memoize matching shipping rule per method per request

### DIFF
--- a/src/base/ShippingMethod.php
+++ b/src/base/ShippingMethod.php
@@ -82,6 +82,11 @@ abstract class ShippingMethod extends BaseModel implements ShippingMethodInterfa
     private ?ShippingMethodCustomerCondition $_customerCondition = null;
 
     /**
+     * @var array<string, ShippingRuleInterface|false> Per-request cache of matching rule per order number.
+     */
+    private array $_matchingRuleByOrderNumber = [];
+
+    /**
      * @var DateTime|null
      * @since 3.4
      */
@@ -274,14 +279,7 @@ abstract class ShippingMethod extends BaseModel implements ShippingMethodInterfa
             return false;
         }
 
-        /** @var ShippingRuleInterface $rule */
-        foreach ($this->getShippingRules()->all() as $rule) {
-            if ($rule->matchOrder($order)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->getMatchingShippingRule($order) !== null;
     }
 
     /**
@@ -289,14 +287,28 @@ abstract class ShippingMethod extends BaseModel implements ShippingMethodInterfa
      */
     public function getMatchingShippingRule(Order $order): ?ShippingRuleInterface
     {
+        if (array_key_exists($order->number, $this->_matchingRuleByOrderNumber)) {
+            return $this->_matchingRuleByOrderNumber[$order->number] ?: null;
+        }
+
         foreach ($this->getShippingRules() as $rule) {
             /** @var ShippingRuleInterface $rule */
             if ($rule->matchOrder($order)) {
+                $this->_matchingRuleByOrderNumber[$order->number] = $rule;
                 return $rule;
             }
         }
 
+        $this->_matchingRuleByOrderNumber[$order->number] = false;
         return null;
+    }
+
+    /**
+     * Clears the per-request matching rule cache. Called by ShippingMethods service after each match pass.
+     */
+    public function clearMatchingRuleCache(): void
+    {
+        $this->_matchingRuleByOrderNumber = [];
     }
 
     public function getPriceForOrder(Order $order): float

--- a/src/base/ShippingMethod.php
+++ b/src/base/ShippingMethod.php
@@ -291,7 +291,7 @@ abstract class ShippingMethod extends BaseModel implements ShippingMethodInterfa
             return $this->_matchingRuleByOrderNumber[$order->number] ?: null;
         }
 
-        foreach ($this->getShippingRules() as $rule) {
+        foreach ($this->_getShippingRulesForMatching() as $rule) {
             /** @var ShippingRuleInterface $rule */
             if ($rule->matchOrder($order)) {
                 $this->_matchingRuleByOrderNumber[$order->number] = $rule;
@@ -301,6 +301,15 @@ abstract class ShippingMethod extends BaseModel implements ShippingMethodInterfa
 
         $this->_matchingRuleByOrderNumber[$order->number] = false;
         return null;
+    }
+
+    /**
+     * Returns an iterable of shipping rules to evaluate during order matching.
+     * Override in subclasses to stream rules without loading all into memory.
+     */
+    protected function _getShippingRulesForMatching(): iterable
+    {
+        return $this->getShippingRules();
     }
 
     /**

--- a/src/models/ShippingMethod.php
+++ b/src/models/ShippingMethod.php
@@ -96,6 +96,18 @@ class ShippingMethod extends BaseShippingMethod implements Chippable, Colorable,
     /**
      * @inheritdoc
      */
+    protected function _getShippingRulesForMatching(): iterable
+    {
+        if ($this->id === null) {
+            return [];
+        }
+
+        return Plugin::getInstance()->getShippingRules()->getShippingRulesForMatchingByMethodId($this->id);
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getIsEnabled(): bool
     {
         return $this->enabled;

--- a/src/services/ShippingMethods.php
+++ b/src/services/ShippingMethods.php
@@ -138,12 +138,10 @@ class ShippingMethods extends Component
 
         /** @var ShippingMethod $method */
         foreach ($event->getShippingMethods() as $method) {
-            $totalPrice = $method->getPriceForOrder($order);
-
             if ($method->getIsEnabled() && $method->matchOrder($order)) {
                 $matchingMethods[$method->getHandle()] = [
                     'method' => $method,
-                    'price' => $totalPrice, // Store the price so we can sort on it before returning
+                    'price' => $method->getPriceForOrder($order), // Store the price so we can sort on it before returning
                 ];
             }
         }
@@ -157,8 +155,13 @@ class ShippingMethods extends Component
             $shippingMethods[$method->getHandle()] = $method; // Keep the key being the handle of the method for front-end use.
         }
 
-        // Clear the memoized data so next time we watch to match rules, we get fresh data.
+        // Clear the memoized data so next time we want to match rules, we get fresh data.
         $this->_serializedOrdersByNumber = [];
+        foreach ($event->getShippingMethods() as $method) {
+            if ($method instanceof ShippingMethod) {
+                $method->clearMatchingRuleCache();
+            }
+        }
 
         return $shippingMethods;
     }

--- a/src/services/ShippingRules.php
+++ b/src/services/ShippingRules.php
@@ -15,6 +15,7 @@ use craft\commerce\Plugin;
 use craft\commerce\records\ShippingRule as ShippingRuleRecord;
 use craft\commerce\records\ShippingRuleCategory as ShippingRuleCategoryRecord;
 use craft\db\Query;
+use Generator;
 use Illuminate\Support\Collection;
 use Throwable;
 use yii\base\Component;
@@ -53,11 +54,7 @@ class ShippingRules extends Component
         $allShippingRules = [];
 
         foreach ($results as $result) {
-            $result['orderCondition'] ??= '';
-            $allShippingRules[] = Craft::createObject([
-                'class' => ShippingRule::class,
-                'attributes' => $result,
-            ]);
+            $allShippingRules[] = $this->_createShippingRuleFromRow($result);
         }
 
         $this->_allShippingRules = collect($allShippingRules);
@@ -78,6 +75,38 @@ class ShippingRules extends Component
     public function getAllShippingRulesByShippingMethodId(int $id): Collection
     {
         return $this->getAllShippingRules()->where('methodId', $id);
+    }
+
+    /**
+     * Yields enabled ShippingRule models one at a time for the given method, for use during order matching.
+     *
+     * @return Generator<ShippingRule>
+     */
+    public function getShippingRulesForMatchingByMethodId(int $methodId): Generator
+    {
+        // Load category associations for all enabled rules of this method in one query.
+        $ruleIds = (new Query())
+            ->select(['id'])
+            ->from(Table::SHIPPINGRULES)
+            ->where(['methodId' => $methodId, 'enabled' => true])
+            ->column();
+
+        if (empty($ruleIds)) {
+            return;
+        }
+
+        $categoriesByRuleId = Plugin::getInstance()
+            ->getShippingRuleCategories()
+            ->getShippingRuleCategoriesByRuleIds($ruleIds);
+
+        foreach ($this->_createShippingRulesQuery()
+            ->where(['shippingrules.methodId' => $methodId, 'shippingrules.enabled' => true])
+            ->orderBy(['shippingrules.priority' => SORT_ASC])
+            ->each(200) as $row) {
+            $rule = $this->_createShippingRuleFromRow($row);
+            $rule->setShippingRuleCategories($categoriesByRuleId[$row['id']] ?? []);
+            yield $rule;
+        }
     }
 
     /**
@@ -241,6 +270,17 @@ class ShippingRules extends Component
             ->innerJoin(Table::SHIPPINGMETHODS . ' methods', '[[methods.id]] = [[shippingrules.methodId]]');
 
         return $query;
+    }
+
+    private function _createShippingRuleFromRow(array $row): ShippingRule
+    {
+        $row['orderCondition'] ??= '';
+        /** @var ShippingRule $rule */
+        $rule = Craft::createObject([
+            'class' => ShippingRule::class,
+            'attributes' => $row,
+        ]);
+        return $rule;
     }
 
     /**


### PR DESCRIPTION
### Description

Performance improvements for stores with a large number of shipping rules.

- `ShippingMethod::matchOrder()` and `getPriceForOrder()` both previously walked all shipping rules independently. The matching rule is now cached on the method instance per order so the rule list is only walked once.
- Instead of loading all shipping rules into memory upfront, rules are now streamed from the database in batches of 200 during matching. Each rule is instantiated, tested, then discarded — peak memory is proportional to the batch size rather than the total number of rules.
- Disabled rules are filtered out in SQL rather than in PHP.