### PR TITLE
Fixed debug panel triggers cart recalculation against primary site in multi-site setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where the debug toolbar could trigger cart recalculation under the primary site context in multi-site setups, causing line items valid only on secondary sites to be removed from the cart. ([#4317](https://github.com/craftcms/commerce/issues/4317))
 - Fixed a bug where the widget Date Range field could break when reopening settings after saving a custom date range. ([#4306](https://github.com/craftcms/commerce/issues/4306))
 - Fixed a bug where new orders created in the control panel would default to a non-primary Order Site in multi-site/single-store setups. ([#4310](https://github.com/craftcms/commerce/issues/4310))
 - Fixed a PHP error that could occur when opening a product with a provisional draft. ([#4314](https://github.com/craftcms/commerce/issues/4314))

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1178,7 +1178,6 @@ class Plugin extends BasePlugin
             $module->panels['commerce'] = new CommercePanel([
                 'id' => 'commerce',
                 'module' => $module,
-                'cart' => !Craft::$app->getRequest()->getIsCpRequest() ? Plugin::getInstance()->getCarts()->getCart() : null,
             ]);
         });
     }

--- a/src/debug/CommercePanel.php
+++ b/src/debug/CommercePanel.php
@@ -10,6 +10,7 @@ namespace craft\commerce\debug;
 use Craft;
 use craft\commerce\elements\Order;
 use craft\commerce\events\CommerceDebugPanelDataEvent;
+use craft\commerce\Plugin;
 use yii\debug\Panel;
 
 /**
@@ -80,6 +81,10 @@ class CommercePanel extends Panel
     {
         $nav = [];
         $content = [];
+
+        if (!Craft::$app->getRequest()->getIsCpRequest()) {
+            $this->cart = Plugin::getInstance()->getCarts()->getCart();
+        }
 
         if ($this->cart) {
             $nav[] = 'Cart';


### PR DESCRIPTION
In `_registerDebugPanels()`, the `CommercePanel` was passed the result of `getCart()` eagerly inside an `EVENT_BEFORE_REQUEST` handler. At that point in the request lifecycle, Craft's routing hasn't run yet, so `getCurrentSite()` returns the primary site. `getCart()` detects the mismatch between the cart's `orderSiteId` (a secondary site) and the current site (primary), overwrites `orderSiteId`, and saves — triggering a recalculation under the wrong site that removes line items only enabled on the secondary site.

The fix defers the `getCart()` call from `EVENT_BEFORE_REQUEST` to `CommercePanel::save()`, which Yii2 invokes after the action runs (when the site context is correctly established).

Fixes #4317.