### PR TITLE
Fixed a PHP error that would occur when creating or editing a shipping rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where a Twig error would occur when creating or editing a shipping rule. ([#4321](https://github.com/craftcms/commerce/issues/4321))
+
 ## 5.6.6.1 - 2026-06-18
 
 - Fixed a bug where Date Range widget settings could break when settings were reopened. ([#4306](https://github.com/craftcms/commerce/issues/4306))

--- a/src/controllers/ShippingRulesController.php
+++ b/src/controllers/ShippingRulesController.php
@@ -14,7 +14,6 @@ use craft\commerce\models\ShippingRule;
 use craft\commerce\models\ShippingRuleCategory;
 use craft\commerce\Plugin;
 use craft\commerce\records\ShippingRuleCategory as ShippingRuleCategoryRecord;
-use craft\helpers\Cp;
 use craft\helpers\Json;
 use craft\helpers\Localization;
 use craft\helpers\MoneyHelper;
@@ -86,12 +85,9 @@ class ShippingRulesController extends BaseShippingSettingsController
         $condition->mainTag = 'div';
         $condition->name = 'condition';
         $condition->id = 'condition';
-        $conditionField = Cp::fieldHtml($condition->getBuilderHtml(), [
-            'label' => Craft::t('app', 'Address Condition'),
-        ]);
 
         $variables['newShippingZoneFields'] = $this->getView()->namespaceInputs(
-            $this->getView()->renderTemplate('commerce/store-management/shipping/shippingzones/_fields', ['conditionField' => $conditionField])
+            $this->getView()->renderTemplate('commerce/store-management/shipping/shippingzones/_fields', ['condition' => $condition])
         );
         $variables['newShippingZoneJs'] = $this->getView()->clearJsBuffer(false);
         $this->getView()->setNamespace(null);


### PR DESCRIPTION
The #4313 fix changed `_fields.twig` to reference `condition.builderHtml` directly, but `ShippingRulesController` was still passing the old pre-rendered `conditionField` string. This passes the `condition` object instead, matching what `ShippingZonesController` already does.