### PR TITLE
Fix case-sensitive inventory search on PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug where inventory search was case-sensitive on PostgreSQL. ([#4326](https://github.com/craftcms/commerce/issues/4326))
 - Fixed a bug where a Twig error would occur when creating or editing a shipping rule. ([#4321](https://github.com/craftcms/commerce/issues/4321))
 
 ## 5.6.6.1 - 2026-06-18

--- a/src/controllers/InventoryController.php
+++ b/src/controllers/InventoryController.php
@@ -243,7 +243,8 @@ class InventoryController extends BaseCpController
         $inventoryQuery->andWhere(['not', ['elements.id' => null]]);
 
         if ($search) {
-            $inventoryQuery->andWhere(['or', ['like', 'purchasables.description', $search], ['like', 'purchasables.sku', $search]]);
+            $likeOperator = Craft::$app->getDb()->getIsPgsql() ? 'ilike' : 'like';
+            $inventoryQuery->andWhere(['or', [$likeOperator, 'purchasables.description', $search], [$likeOperator, 'purchasables.sku', $search]]);
         }
 
         $sort = $this->request->getParam('sort');


### PR DESCRIPTION
Fixes #4326.

Uses `ILIKE` instead of `LIKE` on PostgreSQL for the inventory level search, consistent with how search is handled in `DiscountsController` and `OrdersController`.