### PR TITLE
[5.x] Conditionally add `purchasable` to line item’s extra fields, to prevent exceptions on to array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where product variant field layout tabs displayed incorrectly on variant slideouts. ([#4335](https://github.com/craftcms/commerce/issues/4335))
+- Fixed a PHP error that could occur when serializing a line item object. ([#4337](https://github.com/craftcms/commerce/issues/4337))
 
 ## 5.7.0 - 2026-07-16
 

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -677,7 +677,7 @@ class LineItem extends Model implements HasStoreInterface
             'snapshot',
             'taxCategory',
             'fulfilledTotalQuantity',
-        ], fn ($value) => $value !== null));
+        ], fn($value) => $value !== null));
     }
 
     /**

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -669,7 +669,7 @@ class LineItem extends Model implements HasStoreInterface
      */
     public function extraFields(): array
     {
-        return array_filter([
+        return array_values(array_filter([
             'lineItemStatus',
             'order',
             $this->type === LineItemType::Purchasable ? 'purchasable' : null,
@@ -677,7 +677,7 @@ class LineItem extends Model implements HasStoreInterface
             'snapshot',
             'taxCategory',
             'fulfilledTotalQuantity',
-        ]);
+        ], fn ($value) => $value !== null));
     }
 
     /**

--- a/src/models/LineItem.php
+++ b/src/models/LineItem.php
@@ -669,15 +669,15 @@ class LineItem extends Model implements HasStoreInterface
      */
     public function extraFields(): array
     {
-        return [
+        return array_filter([
             'lineItemStatus',
             'order',
-            'purchasable',
+            $this->type === LineItemType::Purchasable ? 'purchasable' : null,
             'shippingCategory',
             'snapshot',
             'taxCategory',
             'fulfilledTotalQuantity',
-        ];
+        ]);
     }
 
     /**

--- a/tests/unit/models/LineItemTest.php
+++ b/tests/unit/models/LineItemTest.php
@@ -213,4 +213,53 @@ class LineItemTest extends Unit
 
         self::assertEquals(20.00, $order->getTotal());
     }
+
+    /**
+     * @return void
+     * @since 5.1.0
+     */
+    public function testCustomLineItemToArrayDoesNotThrow(): void
+    {
+        $lineItem = new LineItem();
+        $lineItem->type = LineItemType::Custom;
+        $lineItem->description = 'Custom';
+        $lineItem->setSku('custom-sku');
+        $lineItem->setPrice(10.00);
+        $lineItem->qty = 2;
+
+        $order = new Order();
+        $order->number = Plugin::getInstance()->getCarts()->generateCartNumber();
+        $order->setLineItems([$lineItem]);
+
+        self::assertNotContains('purchasable', $lineItem->extraFields());
+
+        $data = $lineItem->toArray([], ['*']);
+        self::assertIsArray($data);
+
+        $data = $lineItem->toArray([], ['purchasable']);
+        self::assertIsArray($data);
+        self::assertArrayNotHasKey('purchasable', $data);
+    }
+
+    /**
+     * @return void
+     * @since 5.1.0
+     */
+    public function testPurchasableLineItemToArrayIncludesPurchasable(): void
+    {
+        $variant = Variant::find()->sku('rad-hood')->one();
+        $lineItem = new LineItem();
+        $lineItem->populateFromPurchasable($variant);
+        $lineItem->qty = 1;
+
+        $order = new Order();
+        $order->number = Plugin::getInstance()->getCarts()->generateCartNumber();
+        $order->setLineItems([$lineItem]);
+
+        self::assertContains('purchasable', $lineItem->extraFields());
+
+        $data = $lineItem->toArray([], ['purchasable']);
+        self::assertArrayHasKey('purchasable', $data);
+        self::assertNotNull($data['purchasable']);
+    }
 }


### PR DESCRIPTION
### Related issues
#4337
