### PR TITLE
[5.x] Fix Variant Search product condition rule returning no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where the “Variant Search” product condition rule wasn’t returning any results. ([#4339](https://github.com/craftcms/commerce/issues/4339))
+
 ## 5.7.0 - 2026-07-16
 
 ### Store Management

--- a/src/elements/conditions/products/ProductVariantSearchConditionRule.php
+++ b/src/elements/conditions/products/ProductVariantSearchConditionRule.php
@@ -54,7 +54,7 @@ class ProductVariantSearchConditionRule extends BaseTextConditionRule implements
      *
      * Note we can't use [[paramValue()]] here because it prepends the operator
      * (e.g. `=`) intended for [[\craft\helpers\Db::parseParam()]], which would
-     * corrupt the value once it's passed to [[ElementQuery::search()]].
+     * corrupt the value once it's passed to [[\craft\elements\db\ElementQuery::search()]].
      *
      * @return string
      */

--- a/src/elements/conditions/products/ProductVariantSearchConditionRule.php
+++ b/src/elements/conditions/products/ProductVariantSearchConditionRule.php
@@ -50,11 +50,17 @@ class ProductVariantSearchConditionRule extends BaseTextConditionRule implements
     }
 
     /**
-     * @inheritdoc
+     * Returns the raw search value.
+     *
+     * Note we can't use [[paramValue()]] here because it prepends the operator
+     * (e.g. `=`) intended for [[\craft\helpers\Db::parseParam()]], which would
+     * corrupt the value once it's passed to [[ElementQuery::search()]].
+     *
+     * @return string
      */
-    protected function paramValue(): ?string
+    private function searchValue(): string
     {
-        return trim(parent::paramValue());
+        return trim((string)$this->value);
     }
 
     /**
@@ -64,7 +70,7 @@ class ProductVariantSearchConditionRule extends BaseTextConditionRule implements
     {
         $variantQuery = Variant::find();
         $variantQuery->select(['commerce_variants.primaryOwnerId as id']);
-        $variantQuery->search($this->paramValue());
+        $variantQuery->search($this->searchValue());
 
         /** @var ProductQuery $query */
         $query->andWhere(['elements.id' => $variantQuery]);
@@ -84,7 +90,7 @@ class ProductVariantSearchConditionRule extends BaseTextConditionRule implements
 
         // Perform a variant query search to ensure it is the same process as `modifyQuery`
         $variantQuery = Variant::find();
-        $variantQuery->search($this->paramValue());
+        $variantQuery->search($this->searchValue());
         $variantQuery->id($variantIds);
 
         return $variantQuery->count() > 0;


### PR DESCRIPTION
The rule feeds its value into ElementQuery::search(), but it was using paramValue() from BaseTextConditionRule, which prepends the operator (e.g. "= ") intended for Db::parseParam(). That prefix corrupted the search query, so it matched nothing when used by a custom source (or filter).

### Related issues

#4339
