### PR TITLE
Adjust CP request handling for console requests

### DIFF
--- a/src/services/Carts.php
+++ b/src/services/Carts.php
@@ -457,14 +457,21 @@ class Carts extends Component
 
         $request = Craft::$app->getRequest();
         $isCpRequest = $request->getIsCpRequest();
-        $request->setIsCpRequest(false);
-        $url = UrlHelper::actionUrl('commerce/cart/load-cart', [
-            'number' => $cart->number,
-            'code' => $token,
-        ]);
-        $request->setIsCpRequest($isCpRequest);
 
-        return $url;
+        if ($isCpRequest) {
+            $request->setIsCpRequest(false);
+        }
+
+        try {
+            return UrlHelper::actionUrl('commerce/cart/load-cart', [
+                'number' => $cart->number,
+                'code' => $token,
+            ]);
+        } finally {
+            if ($isCpRequest) {
+                $request->setIsCpRequest($isCpRequest);
+            }
+        }
     }
 
     /**

--- a/src/services/Pdfs.php
+++ b/src/services/Pdfs.php
@@ -510,18 +510,18 @@ class Pdfs extends Component
 
         $request = Craft::$app->getRequest();
         $isCpRequest = $request->getIsCpRequest();
-        
-        if (!$request->getIsConsoleRequest()) {
+
+        if ($isCpRequest) {
             $request->setIsCpRequest(false);
         }
-        
-        $url = UrlHelper::actionUrl('commerce/downloads/pdf', $params);
-        
-        if (!$request->getIsConsoleRequest()) {
-            $request->setIsCpRequest($isCpRequest);
+
+        try {
+            return UrlHelper::actionUrl('commerce/downloads/pdf', $params);
+        } finally {
+            if ($isCpRequest) {
+                $request->setIsCpRequest($isCpRequest);
+            }
         }
-        
-        return $url;
     }
 
     /**

--- a/src/services/Pdfs.php
+++ b/src/services/Pdfs.php
@@ -510,10 +510,17 @@ class Pdfs extends Component
 
         $request = Craft::$app->getRequest();
         $isCpRequest = $request->getIsCpRequest();
-        $request->setIsCpRequest(false);
+        
+        if (!$request->getIsConsoleRequest()) {
+            $request->setIsCpRequest(false);
+        }
+        
         $url = UrlHelper::actionUrl('commerce/downloads/pdf', $params);
-        $request->setIsCpRequest($isCpRequest);
-
+        
+        if (!$request->getIsConsoleRequest()) {
+            $request->setIsCpRequest($isCpRequest);
+        }
+        
         return $url;
     }
 


### PR DESCRIPTION
### Description

Calling Order::getPdfUrl() from the console throws `'Calling unknown method: craft\console\Request::setIsCpRequest()'` because `setIsCpRequest()` is only defined on `craft\web\Request`, not `craft\console\Request`.

This guards it so `setIsCpRequest` is skipped outside a web request.

Test command to run:

```
public function actionTestCpRequest(): int {
  $order = Order::find()->isCompleted(true)->orderBy('id desc')->one();

  if (!$order) {
    $this->stdout("No completed order found to test with.\n");
    return ExitCode::UNSPECIFIED_ERROR;
  }

  $url = $order->getPdfUrl();
  $this->stdout("URL: $url\n");
  return ExitCode::OK;
}
```

### Related issues
Via Support