### PR TITLE
WIP Fix fatal error in dashboard widgets when user has no editable sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Craft Commerce
 
+## Unreleased
+
+- Fixed a bug where the Commerce dashboard widgets could cause a PHP error for users without edit permissions on any site. ([#4347](https://github.com/craftcms/commerce/issues/4347))
+
 ## 5.7.2 - 2026-08-12
 
 - Fixed a bug where inactive carts’ search index rows weren’t being purged. ([#4344](https://github.com/craftcms/commerce/issues/4344))

--- a/src/widgets/AverageOrderTotal.php
+++ b/src/widgets/AverageOrderTotal.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\AverageOrderTotal as AverageOrderTotalStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -45,9 +46,9 @@ class AverageOrderTotal extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->_stat = new AverageOrderTotalStat(

--- a/src/widgets/NewCustomers.php
+++ b/src/widgets/NewCustomers.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\NewCustomers as NewCustomersStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -47,9 +48,9 @@ class NewCustomers extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->_stat = new NewCustomersStat(

--- a/src/widgets/Orders.php
+++ b/src/widgets/Orders.php
@@ -43,9 +43,9 @@ class Orders extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
     }
 

--- a/src/widgets/RepeatCustomers.php
+++ b/src/widgets/RepeatCustomers.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\RepeatCustomers as RepeatingCustomersStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -45,9 +46,9 @@ class RepeatCustomers extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->dateRange = !isset($this->dateRange) || !$this->dateRange ? RepeatingCustomersStat::DATE_RANGE_TODAY : $this->dateRange;

--- a/src/widgets/TopCustomers.php
+++ b/src/widgets/TopCustomers.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\TopCustomers as TopCustomersStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -60,9 +61,9 @@ class TopCustomers extends Widget
     public function init(): void
     {
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->_typeOptions = [

--- a/src/widgets/TopProductTypes.php
+++ b/src/widgets/TopProductTypes.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\TopProductTypes as TopProductTypesStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -60,9 +61,9 @@ class TopProductTypes extends Widget
     public function init(): void
     {
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->_typeOptions = [

--- a/src/widgets/TopProducts.php
+++ b/src/widgets/TopProducts.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\TopProducts as TopProductsStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -77,9 +78,9 @@ class TopProducts extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->_typeOptions = [

--- a/src/widgets/TopPurchasables.php
+++ b/src/widgets/TopPurchasables.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\TopPurchasables as TopPurchasablesStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -70,9 +71,9 @@ class TopPurchasables extends Widget
     public function init(): void
     {
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->nameField = isset($this->nameField) ?: 'description';

--- a/src/widgets/TotalOrders.php
+++ b/src/widgets/TotalOrders.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\TotalOrders as TotalOrdersStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -49,9 +50,9 @@ class TotalOrders extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->dateRange = !isset($this->dateRange) || !$this->dateRange ? TotalOrdersStat::DATE_RANGE_TODAY : $this->dateRange;

--- a/src/widgets/TotalOrdersByCountry.php
+++ b/src/widgets/TotalOrdersByCountry.php
@@ -11,6 +11,7 @@ use Craft;
 use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
+use craft\commerce\Plugin;
 use craft\commerce\stats\TotalOrdersByCountry as TotalOrdersByCountryStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -63,9 +64,9 @@ class TotalOrdersByCountry extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->_typeOptions = [

--- a/src/widgets/TotalRevenue.php
+++ b/src/widgets/TotalRevenue.php
@@ -12,6 +12,7 @@ use craft\base\Widget;
 use craft\commerce\base\StatWidgetTrait;
 use craft\commerce\behaviors\StoreBehavior;
 use craft\commerce\helpers\Currency;
+use craft\commerce\Plugin;
 use craft\commerce\stats\TotalRevenue as TotalRevenueStat;
 use craft\commerce\web\assets\commercewidgets\CommerceWidgetsAsset;
 use craft\commerce\web\assets\statwidgets\StatWidgetsAsset;
@@ -71,9 +72,9 @@ class TotalRevenue extends Widget
         parent::init();
 
         if (!(isset($this->storeId)) || !$this->storeId) {
-            /** @var Site|StoreBehavior $site */
+            /** @var Site|StoreBehavior|null $site */
             $site = Cp::requestedSite();
-            $this->storeId = $site->getStore()->id;
+            $this->storeId = $site?->getStore()->id ?? Plugin::getInstance()->getStores()->getPrimaryStore()->id;
         }
 
         $this->dateRange = !isset($this->dateRange) || !$this->dateRange ? TotalRevenueStat::DATE_RANGE_TODAY : $this->dateRange;


### PR DESCRIPTION
Cp::requestedSite() returns null when the current user has no editable sites, causing a fatal error on ->getStore() in every Commerce widget's init(). Fall back to the primary store in that case, matching the pattern used elsewhere in the codebase.

Fixes #4347

### Description



### Related issues

