### PR TITLE
Fix SKU format not resolving {id} for new variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Fixed a bug where the deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()` method could still be called. ([#4349](https://github.com/craftcms/commerce/issues/4349)) 
+- Fixed a bug where migrating from Craft Commerce 4 could fail with a database error if any line items had a negative sale price. ([#4352](https://github.com/craftcms/commerce/issues/4352))
+- Fixed a bug where a variant's `skuFormat` containing `{id}` would generate a SKU missing that value for new variants.
 
 ## 5.7.2 - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## Unreleased
 
-- Fixed a bug where the deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()` method could still be called. ([#4349](https://github.com/craftcms/commerce/issues/4349)) 
-- Fixed a bug where migrating from Craft Commerce 4 could fail with a database error if any line items had a negative sale price. ([#4352](https://github.com/craftcms/commerce/issues/4352))
+- Fixed a bug where the deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()` method could still be called. ([#4349](https://github.com/craftcms/commerce/issues/4349))
 - Fixed a bug where a variant's `skuFormat` containing `{id}` would generate a SKU missing that value for new variants.
 
 ## 5.7.2 - 2026-08-12

--- a/src/elements/Variant.php
+++ b/src/elements/Variant.php
@@ -226,6 +226,12 @@ class Variant extends Purchasable implements NestedElementInterface
     private ?string $_productTypeHandle = null;
 
     /**
+     * @var bool Whether the SKU was auto-generated from a `skuFormat` containing `{id}` before this element had an ID,
+     * meaning it needs to be regenerated in [[afterAssignedId()]] once the ID is available.
+     */
+    private bool $_regenerateSkuAfterIdAssigned = false;
+
+    /**
      * @throws InvalidConfigException
      */
     public function behaviors(): array
@@ -726,6 +732,12 @@ class Variant extends Purchasable implements NestedElementInterface
             $language = Craft::$app->language;
             Craft::$app->language = $this->getSite()->language;
             $this->sku = Craft::$app->getView()->renderSandboxedObjectTemplate($type->skuFormat, $this);
+
+            // If the format references the element's own ID but it doesn't have one yet, the rendered SKU will be
+            // missing that value — flag it for regeneration once afterAssignedId() runs.
+            if (!$this->id && str_contains($type->skuFormat, '{id}')) {
+                $this->_regenerateSkuAfterIdAssigned = true;
+            }
 
             $skuExistsQuery = function(string $sku, ?int $id) {
                 $query = (new Query())
@@ -1257,6 +1269,12 @@ class Variant extends Purchasable implements NestedElementInterface
 
         $product = $this->getOwner();
         $this->updateTitle($product);
+
+        if ($this->_regenerateSkuAfterIdAssigned) {
+            $this->_regenerateSkuAfterIdAssigned = false;
+            $this->sku = '';
+            $this->updateSku($product);
+        }
     }
 
     /**

--- a/tests/unit/elements/product/ProductTest.php
+++ b/tests/unit/elements/product/ProductTest.php
@@ -442,6 +442,32 @@ class ProductTest extends Unit
         $this->setProductTypeSkuFormat(2001, null);
     }
 
+    /**
+     * @group Product
+     */
+    public function testSkuFormatWithIdIsRegeneratedAfterIdAssigned(): void
+    {
+        $this->setProductTypeSkuFormat(2001, 'SKU-{id}');
+
+        $product = new Product();
+        $product->title = 'SKU Format Id Test Product';
+        $product->typeId = 2001;
+        $product->enabled = false;
+
+        $variant = new Variant();
+        $variant->title = 'Test Variant';
+        // No SKU — format references {id}, which isn't available until after the element is saved
+
+        $product->setVariants([$variant]);
+        \Craft::$app->getElements()->saveElement($product, false);
+
+        $savedVariant = $product->getDefaultVariant();
+        self::assertEquals('SKU-' . $savedVariant->id, $savedVariant->sku);
+
+        \Craft::$app->getElements()->deleteElementById($product->id, Product::class, null, true);
+        $this->setProductTypeSkuFormat(2001, null);
+    }
+
     private function resetSkuSequence(string $baseSku): void
     {
         \Craft::$app->getDb()->createCommand()


### PR DESCRIPTION
## Summary

- `skuFormat` values containing `{id}` produced a truncated SKU (e.g. `SKU-4012-`) for new variants, because `updateSku()` runs before the variant has an ID.
- `updateTitle()` got the same fix for `variantTitleFormat` in #4308, via `afterAssignedId()`. This applies the same idea to SKUs.
