### PR TITLE
Fix custom field values not saved on order addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where the deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()` method could still be called. ([#4349](https://github.com/craftcms/commerce/issues/4349)) 
+- Fixed a bug where `craft\commerce\elements\Order::setShippingAddress()` and `setBillingAddress()` weren’t setting custom field values passed in via a `fields` array key. ([#4353](https://github.com/craftcms/commerce/issues/4353))
 
 ## 5.7.2 - 2026-08-12
 

--- a/src/controllers/CartController.php
+++ b/src/controllers/CartController.php
@@ -820,10 +820,6 @@ class CartController extends BaseFrontEndController
                 $this->_cart->sourceShippingAddressId = null;
                 $this->_cart->setShippingAddress($shippingAddress);
 
-                if (!empty($shippingAddress['fields']) && $this->_cart->getShippingAddress()) {
-                    $this->_cart->getShippingAddress()->setFieldValues($shippingAddress['fields']);
-                }
-
                 if ($billingIsShipping) {
                     $this->_cart->sourceBillingAddressId = null;
                     $this->_cart->setBillingAddress($this->_cart->getShippingAddress());
@@ -864,10 +860,6 @@ class CartController extends BaseFrontEndController
             } elseif ($billingAddress && !$billingIsShipping) {
                 $this->_cart->sourceBillingAddressId = null;
                 $this->_cart->setBillingAddress($billingAddress);
-
-                if (!empty($billingAddress['fields']) && $this->_cart->getBillingAddress()) {
-                    $this->_cart->getBillingAddress()->setFieldValues($billingAddress['fields']);
-                }
 
                 if ($shippingIsBilling) {
                     $this->_cart->sourceShippingAddressId = null;

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -3302,6 +3302,9 @@ class Order extends Element implements HasStoreInterface
             unset($address['id']);
             $addressElement = $this->_shippingAddress ?: new AddressElement();
             $addressElement->setAttributes($address);
+            if (!empty($address['fields']) && is_array($address['fields'])) {
+                $addressElement->setFieldValues($address['fields']);
+            }
             $this->_populateAddressNameAttributes($addressElement, $address);
             $addressElement->setPrimaryOwner($this);
             $address = $addressElement;
@@ -3400,6 +3403,9 @@ class Order extends Element implements HasStoreInterface
             unset($address['id']); // only ever allow setting of the address data
             $addressElement = $this->_billingAddress ?: new AddressElement();
             $addressElement->setAttributes($address);
+            if (!empty($address['fields']) && is_array($address['fields'])) {
+                $addressElement->setFieldValues($address['fields']);
+            }
             $this->_populateAddressNameAttributes($addressElement, $address);
             $addressElement->setPrimaryOwner($this);
             $address = $addressElement;

--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -3361,6 +3361,9 @@ class Order extends Element implements HasStoreInterface
         if (!$address instanceof AddressElement) {
             $addressElement = new AddressElement();
             $addressElement->setAttributes($address);
+            if (!empty($address['fields']) && is_array($address['fields'])) {
+                $addressElement->setFieldValues($address['fields']);
+            }
             $address = $addressElement;
         }
 
@@ -3522,6 +3525,9 @@ class Order extends Element implements HasStoreInterface
         if (!$address instanceof AddressElement) {
             $addressElement = new AddressElement();
             $addressElement->setAttributes($address);
+            if (!empty($address['fields']) && is_array($address['fields'])) {
+                $addressElement->setFieldValues($address['fields']);
+            }
             $address = $addressElement;
         }
 


### PR DESCRIPTION
- `Order::setShippingAddress()` and `setBillingAddress()` ignored a `fields` array key, silently dropping custom field values when given an address array.
- Removed `CartController`'s manual workaround, now redundant.

Fixes #4353