### PR TITLE
Fix migration error for line items with negative salePrice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed a bug where the deprecated `craft\commerce\services\ProductTypes::getEditableProductTypes()` method could still be called. ([#4349](https://github.com/craftcms/commerce/issues/4349)) 
+- Fixed a migration error that could occur for line items with a negative sale price. ([#4352](https://github.com/craftcms/commerce/issues/4352))
 
 ## 5.7.2 - 2026-08-12
 

--- a/src/migrations/m241213_083338_update_promotional_price_in_line_items.php
+++ b/src/migrations/m241213_083338_update_promotional_price_in_line_items.php
@@ -28,6 +28,9 @@ class m241213_083338_update_promotional_price_in_line_items extends Migration
             ->where(['orderId' => $ordersQuery])
             ->andWhere(['promotionalPrice' => null])
             ->andWhere(new Expression('[[salePrice]] < [[price]]'))
+            // `promotionalPrice` is unsigned, but legacy `salePrice` values can be negative
+            // (e.g. when a discount adjustment exceeded the line item price), so skip those.
+            ->andWhere(['>=', 'salePrice', 0])
             ->column();
 
         foreach (array_chunk($lineItemsQuery, 1000) as $chunk) {


### PR DESCRIPTION
## Summary
Fixes #4352. `promotionalPrice` is an unsigned column, but some legacy line items have a negative `salePrice`. Copying that negative value into `promotionalPrice` during migration caused a data truncation error. This skips those rows instead.