### PR TITLE
[5.x] Fix catalog pricing saves failing on the queue mutex

### DIFF
--- a/src/queue/jobs/CatalogPricing.php
+++ b/src/queue/jobs/CatalogPricing.php
@@ -7,8 +7,10 @@
 
 namespace craft\commerce\queue\jobs;
 
+use Craft;
 use craft\commerce\Plugin;
 use craft\commerce\records\CatalogPricingQueue as CatalogPricingQueueRecord;
+use craft\helpers\Queue as QueueHelper;
 use craft\queue\BaseJob;
 
 class CatalogPricing extends BaseJob
@@ -32,24 +34,18 @@ class CatalogPricing extends BaseJob
     {
         $catalogPricingService = Plugin::getInstance()->getCatalogPricing();
         $isConsolidatedJob = $this->storeId === null && $this->purchasableIds === null && $this->catalogPricingRuleIds === null;
-        $catalogPricingRules = null;
-        $reservedRowId = null;
 
         // @TODO: remove these properties and behaviour at next breaking change
-        $storeId = $this->storeId;
-        $purchasableIds = $this->purchasableIds;
-        $catalogPricingRuleIds = $this->catalogPricingRuleIds;
+        if (!$isConsolidatedJob) {
+            $this->_generate($queue, $this->storeId, $this->purchasableIds, $this->catalogPricingRuleIds);
+            return;
+        }
 
-        if ($isConsolidatedJob) {
-            // New method of processing catalog pricing via queue table: reserve a row and process based on its type and IDs
-            $reservedRecord = $catalogPricingService->reserveCatalogPricingQueueRow();
-
-            if (!$reservedRecord) {
-                return;
-            }
-
-            $reservedRowId = $reservedRecord->id;
-            $storeId = $reservedRecord->storeId;
+        // Work through every pending row. One row per job would leave the rest waiting on a further
+        // push, and claiming them all up front would strand the lot if this worker died.
+        while ($reservedRecord = $catalogPricingService->reserveCatalogPricingQueueRow()) {
+            $purchasableIds = null;
+            $catalogPricingRuleIds = null;
 
             if ($reservedRecord->type === CatalogPricingQueueRecord::TYPE_PURCHASABLE) {
                 // Specific purchasable IDs: regenerate against all applicable rules
@@ -59,7 +55,30 @@ class CatalogPricing extends BaseJob
             } else {
                 throw new \UnexpectedValueException("Unrecognized catalog pricing queue row type: {$reservedRecord->type}");
             }
+
+            try {
+                $this->_generate($queue, $reservedRecord->storeId, $purchasableIds, $catalogPricingRuleIds);
+                $catalogPricingService->deleteCatalogPricingQueueRowById($reservedRecord->id);
+            } catch (\Throwable $e) {
+                $catalogPricingService->releaseCatalogPricingQueueRowById($reservedRecord->id);
+
+                throw $e;
+            }
         }
+
+        // A row added between the last check and here would otherwise wait for the next save.
+        if ($catalogPricingService->hasPendingCatalogPricingQueueRows()) {
+            QueueHelper::push(Craft::createObject(self::class));
+        }
+    }
+
+    /**
+     * @param array<int>|null $purchasableIds
+     * @param array<int>|null $catalogPricingRuleIds
+     */
+    private function _generate($queue, ?int $storeId, ?array $purchasableIds, ?array $catalogPricingRuleIds): void
+    {
+        $catalogPricingRules = null;
 
         if (!empty($catalogPricingRuleIds)) {
             $catalogPricingRules = Plugin::getInstance()->getCatalogPricingRules()
@@ -68,19 +87,8 @@ class CatalogPricing extends BaseJob
                 ->all();
         }
 
-        try {
-            $catalogPricingService->generateCatalogPrices($purchasableIds, $catalogPricingRules, queue: $queue);
-
-            if ($reservedRowId) {
-                $catalogPricingService->deleteCatalogPricingQueueRowById($reservedRowId);
-            }
-        } catch (\Throwable $e) {
-            if ($reservedRowId) {
-                $catalogPricingService->releaseCatalogPricingQueueRowById($reservedRowId);
-            }
-
-            throw $e;
-        }
+        Plugin::getInstance()->getCatalogPricing()
+            ->generateCatalogPrices($purchasableIds, $catalogPricingRules, queue: $queue);
     }
 
     protected function defaultDescription(): ?string

--- a/src/services/CatalogPricing.php
+++ b/src/services/CatalogPricing.php
@@ -512,6 +512,10 @@ class CatalogPricing extends Component
         // Queue purchasable-based and rule-based work into separate rows so they are never cross-contaminated.
         // Catalog pricing rules determine which purchasables are relevant, so the two must be processed independently.
 
+        // A job already working through the queue will pick up anything added while it runs, so only
+        // push when nothing is pending. Otherwise every save queues a job that reserves nothing.
+        $wasEmpty = !$this->hasPendingCatalogPricingQueueRows();
+
         if (!empty($purchasableIds) || ($purchasableIds === null && empty($catalogPricingRuleIds))) {
             // Specific purchasable IDs: these will be regenerated against all applicable rules
             $this->_queueCatalogPricingIds($storeId, CatalogPricingQueueRecord::TYPE_PURCHASABLE, $purchasableIds);
@@ -521,7 +525,20 @@ class CatalogPricing extends Component
             $this->_queueCatalogPricingIds($storeId, CatalogPricingQueueRecord::TYPE_RULE, $catalogPricingRuleIds);
         }
 
-        QueueHelper::push(Craft::createObject(CatalogPricingJob::class), $priority);
+        if ($wasEmpty) {
+            QueueHelper::push(Craft::createObject(CatalogPricingJob::class), $priority);
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPendingCatalogPricingQueueRows(): bool
+    {
+        return (new Query())
+            ->from(Table::CATALOG_PRICING_QUEUE)
+            ->where(['reserved' => false])
+            ->exists();
     }
 
     /**
@@ -542,16 +559,9 @@ class CatalogPricing extends Component
      */
     public function reserveCatalogPricingQueueRow(): ?CatalogPricingQueueRecord
     {
-        $mutex = Craft::$app->getMutex();
+        $this->_releaseExpiredCatalogPricingQueueRows();
 
-        // Use the same lock as the write methods so that reservation and inserts/merges are fully serialised.
-        // Non-blocking: if a write operation is currently holding the lock, return null and let the next
-        // queue job execution pick up the row instead.
-        if (!$mutex->acquire('catalogpricingqueue', 0)) {
-            return null;
-        }
-
-        try {
+        while (true) {
             $pendingId = (new Query())
                 ->select(['id'])
                 ->from(Table::CATALOG_PRICING_QUEUE)
@@ -563,20 +573,36 @@ class CatalogPricing extends Component
                 return null;
             }
 
-            /** @var CatalogPricingQueueRecord|null $record */
-            $record = CatalogPricingQueueRecord::findOne(['id' => (int)$pendingId, 'reserved' => false]);
+            // Claiming in one conditional statement leaves the row lock to the database, so no
+            // application lock is needed. A losing claim affects no rows and moves to the next one.
+            $claimed = Db::update(Table::CATALOG_PRICING_QUEUE, ['reserved' => true], [
+                'id' => (int)$pendingId,
+                'reserved' => false,
+            ]);
 
-            if (!$record) {
-                return null;
+            if ($claimed === 1) {
+                return CatalogPricingQueueRecord::findOne(['id' => (int)$pendingId]);
             }
-
-            $record->reserved = true;
-            $record->save(false);
-
-            return $record;
-        } finally {
-            $mutex->release('catalogpricingqueue');
         }
+    }
+
+    /**
+     * Frees rows still reserved by a job that never finished, so the work is not lost.
+     *
+     * @return void
+     * @throws Exception
+     */
+    private function _releaseExpiredCatalogPricingQueueRows(): void
+    {
+        // The queue has already given up on a job holding a row this long.
+        $ttr = Craft::$app->getQueue()->ttr;
+        $expiredBefore = (new DateTime('now', new \DateTimeZone('UTC')))->modify("-{$ttr} seconds");
+
+        Db::update(Table::CATALOG_PRICING_QUEUE, ['reserved' => false], [
+            'and',
+            ['reserved' => true],
+            ['<', 'dateUpdated', Db::prepareDateForDb($expiredBefore)],
+        ]);
     }
 
     /**
@@ -613,19 +639,10 @@ class CatalogPricing extends Component
      * @param array|null $ids
      * @return void
      * @throws Exception
-     * @throws \RuntimeException if the queue mutex cannot be acquired
      */
     private function _queueCatalogPricingIds(?int $storeId, string $type, ?array $ids): void
     {
-        $mutex = Craft::$app->getMutex();
-
-        if (!$mutex->acquire('catalogpricingqueue', 5)) {
-            throw new \RuntimeException('Unable to acquire the catalog pricing queue mutex.');
-        }
-
-        try {
-            // Merge into an existing unreserved row for the same store and type.
-            // _mergeIdSets keeps null when either side is null (broader scope wins).
+        while (true) {
             /** @var CatalogPricingQueueRecord|null $pendingRecord */
             $pendingRecord = CatalogPricingQueueRecord::findOne([
                 'storeId' => $storeId,
@@ -633,27 +650,37 @@ class CatalogPricing extends Component
                 'reserved' => false,
             ]);
 
-            if ($pendingRecord) {
-                // Merge IDs, preserving null to represent the broader "all IDs" scope.
-                $pendingIds = $pendingRecord->getIds();
-                $ids = ($pendingIds === null || $ids === null)
-                    ? null
-                    : $this->_normalizeIds(array_merge($pendingIds, $ids));
-
-                $pendingRecord->setIds($ids);
-                $pendingRecord->save(false);
+            if (!$pendingRecord) {
+                $record = new CatalogPricingQueueRecord();
+                $record->storeId = $storeId;
+                $record->type = $type;
+                $record->setIds($ids);
+                $record->reserved = false;
+                $record->save(false);
 
                 return;
             }
 
-            $record = new CatalogPricingQueueRecord();
-            $record->storeId = $storeId;
-            $record->type = $type;
-            $record->setIds($ids);
-            $record->reserved = false;
-            $record->save(false);
-        } finally {
-            $mutex->release('catalogpricingqueue');
+            // Merge IDs, preserving null to represent the broader "all IDs" scope.
+            $originalIds = $pendingRecord->getAttribute('ids');
+            $pendingIds = $pendingRecord->getIds();
+            $pendingRecord->setIds(($pendingIds === null || $ids === null)
+                ? null
+                : $this->_normalizeIds(array_merge($pendingIds, $ids)));
+
+            // Write back only if the row is unchanged and still unreserved, so the read and write
+            // need no lock between them. Losing the race affects no rows, so re-read and merge again.
+            $merged = Db::update(Table::CATALOG_PRICING_QUEUE, [
+                'ids' => $pendingRecord->getAttribute('ids'),
+            ], [
+                'id' => $pendingRecord->id,
+                'reserved' => false,
+                'ids' => $originalIds,
+            ]);
+
+            if ($merged === 1) {
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
This one has been nagging us for a long time. And it's about to bite us again on a new build, so we dove in deeper to offer what we see is a solid fix.

Specifically, the build pulls its products in from an ERP. Running the sync piles up so many catalog pricing jobs that the sync itself starts failing on the mutex. Pausing the queue is the only way to get through it. We see the same thing on another build whenever a lot of products get created at once.

Pausing the queue works for the console command, but we're importing off of webhooks, so the same saves will be running in a web request where we can't pause anything.

[edited]
#4123 was closed asking for a new ticket if it persisted. On 5.7.3 we still get 600 jobs for 600 saves.

This doesn't fix the database deadlocks in #4003 and #4141, which are in `generateCatalogPrices()` rather than the queue table. Fewer jobs means fewer of them running at once, so it should reduce how often those happen.
[/end edit]

## Problem

N saves push N jobs against the one row they all merged into. All but a few reserve nothing, each taking the `catalogpricingqueue` mutex on the way.

The two sides of that mutex disagree:

| | Timeout | On failure |
|---|---|---|
| `reserveCatalogPricingQueueRow()` | `0` | returns `null` |
| `_queueCatalogPricingIds()` | `5` | `throw new RuntimeException` |

So a background job can fail a foreground save.

## Changes

| | |
|---|---|
| Merge by compare-and-swap | Write back conditional on the row being unchanged and still unreserved. A losing merge affects no rows and retries |
| Claim by conditional update | `UPDATE ... SET reserved = true WHERE id = ? AND reserved = false`, checking affected rows |
| Push only when nothing is pending | A job already working the queue picks up what arrives while it runs |
| Job loops over every pending row | Re-queues if a row arrives as it exits |
| Release reservations older than the queue's `ttr` | Nothing frees a row when a worker is killed rather than caught, so that work was stranded silently |

We first tried dropping the merge and inserting a row per save. That made the write path much faster, 0.26s against 7.0s for 1200 saves, but it put `generateCatalogPrices()` on every row: 60 IDs in one call measured 0.025s against 0.081s as 60 single-ID calls. We kept the merge.

We also tried claiming every pending row up front. Killing a worker mid-drain left 200 rows reserved with nothing to free them, so we kept claiming one row at a time.

Our changes don't include any schema change, or `SKIP LOCKED` or `RETURNING`.

## Verification

Postgres, `runQueueAutomatically` off, no workers running. 
Six processes, 100 `createCatalogPricingJob()` calls each with a distinct purchasable ID.

| | 5.7.2 | Patched |
|---|---|---|
| Queue rows | 1 | 1 |
| IDs preserved | 600 | 600 |
| Errors | 0 | 0 |
| **Jobs pushed** | **600** | **3** |

**Mutex contention.** Holding `catalogpricingqueue` and then saving throws `RuntimeException: Unable to acquire the catalog pricing queue mutex.` on 5.7.2, succeeds patched.

**Lost updates.** Compare-and-swap against an unguarded read-modify-write of the same row, six processes merging 30 IDs each:

| | Expected | Survived |
|---|---|---|
| Read-modify-write | 180 | 66 |
| Compare-and-swap | 180 | **180** |

**Reservation.** Eight processes against 400 seeded rows: 400 claims, 400 distinct, 0 double-claimed, 0 left unreserved.

**Crash.** A worker that is killed after claiming leaves just its 1 row reserved; others drain the rest, and the expired-reservation release recovers it.
