### PR TITLE
[5.x] Cache control-panel order status badge counts

### DIFF
--- a/src/elements/Order.php
+++ b/src/elements/Order.php
@@ -2282,6 +2282,8 @@ class Order extends Element implements HasStoreInterface
             }
 
             $oldStatusId = $orderRecord->orderStatusId;
+            $oldStoreId = $orderRecord->storeId;
+            $wasCompleted = (bool)$orderRecord->isCompleted;
 
             $orderRecord->storeId = $this->storeId ?? Plugin::getInstance()->getStores()->getCurrentStore()->id;
             $orderRecord->number = $this->number;
@@ -2414,6 +2416,19 @@ class Order extends Element implements HasStoreInterface
             }
 
             $orderRecord->save(false);
+
+            if (
+                $wasCompleted !== (bool)$orderRecord->isCompleted ||
+                ($orderRecord->isCompleted && ($isNew || $oldStatusId != $orderRecord->orderStatusId || $oldStoreId != $orderRecord->storeId))
+            ) {
+                $orderStatuses = Plugin::getInstance()->getOrderStatuses();
+                if ($wasCompleted) {
+                    $orderStatuses->invalidateOrderCountByStatus($oldStoreId);
+                }
+                if ($orderRecord->isCompleted && (!$wasCompleted || $oldStoreId != $orderRecord->storeId)) {
+                    $orderStatuses->invalidateOrderCountByStatus($orderRecord->storeId);
+                }
+            }
 
             $this->_saveAdjustments();
             $this->_saveLineItems();
@@ -3812,12 +3827,25 @@ class Order extends Element implements HasStoreInterface
         parent::afterDelete();
 
         if ($this->isCompleted) {
+            Plugin::getInstance()->getOrderStatuses()->invalidateOrderCountByStatus($this->storeId);
             foreach ($this->_deletingLineItems as $lineItem) {
                 $purchasable = $lineItem->getPurchasable();
                 if ($purchasable instanceof Purchasable && $purchasable::hasInventory() && $purchasable->inventoryTracked) {
                     Plugin::getInstance()->getPurchasables()->updateStoreStockCache($purchasable, true);
                 }
             }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function afterRestore(): void
+    {
+        parent::afterRestore();
+
+        if ($this->isCompleted) {
+            Plugin::getInstance()->getOrderStatuses()->invalidateOrderCountByStatus($this->storeId);
         }
     }
 

--- a/src/services/OrderStatuses.php
+++ b/src/services/OrderStatuses.php
@@ -34,6 +34,7 @@ use yii\base\ErrorException;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 use yii\base\NotSupportedException;
+use yii\caching\TagDependency;
 use yii\web\ServerErrorHttpException;
 use function count;
 
@@ -226,7 +227,7 @@ class OrderStatuses extends Component
     {
         $storeId ??= Plugin::getInstance()->getStores()->getCurrentStore()->id;
 
-        $countGroupedByStatusId = (new Query())
+        $query = (new Query())
             ->select(['[[o.orderStatusId]]', 'count(o.id) as orderCount'])
             ->where([
                 '[[o.isCompleted]]' => true,
@@ -236,8 +237,20 @@ class OrderStatuses extends Component
             ->from([Table::ORDERS . ' o'])
             ->innerJoin([CraftTable::ELEMENTS . ' e'], '[[o.id]] = [[e.id]]')
             ->groupBy(['[[o.orderStatusId]]'])
-            ->indexBy('orderStatusId')
-            ->all();
+            ->indexBy('orderStatusId');
+
+        // Never share uncommitted counts or read cached counts within a transaction.
+        // Expiry reconciles direct DB updates that bypass the order lifecycle.
+        $countGroupedByStatusId = Craft::$app->getDb()->getTransaction() !== null
+            ? $query->all()
+            : Craft::$app->getCache()->getOrSet(
+                [__METHOD__, $storeId],
+                fn() => $query->all(),
+                3600,
+                new TagDependency([
+                    'tags' => ['element', 'element::' . Order::class, "commerce:order-counts:$storeId"],
+                ]),
+            );
 
         // For those not in the groupBy
         $allStatuses = $this->getAllOrderStatuses($storeId);
@@ -255,6 +268,16 @@ class OrderStatuses extends Component
         }
 
         return $countGroupedByStatusId;
+    }
+
+    /**
+     * Invalidates a store's badge counts once pending order changes are committed or rolled back.
+     */
+    public function invalidateOrderCountByStatus(int $storeId): void
+    {
+        Craft::$app->getDb()->onAfterTransaction(static function() use ($storeId) {
+            TagDependency::invalidate(Craft::$app->getCache(), "commerce:order-counts:$storeId");
+        });
     }
 
     /**


### PR DESCRIPTION
### Description

The control-panel order index already loads its status badges asynchronously, but each badge request reruns `getOrderCountByStatus()` against the orders and elements tables. With a large order history, repeated index refreshes repeat the same expensive grouped count even when no relevant order state has changed.

Cache the grouped counts per store through Craft's configured cache component, without depending on Redis or another specific backend. Status handles and zero-count statuses are still resolved outside the cache, preserving the existing response structure and fresh status labels.

Invalidate affected stores when orders become completed or incomplete, completed orders change status or store, or completed orders are deleted or restored. Cart saves and unrelated order edits leave the cache intact. Invalidation runs after the database transaction ends, and reads inside a transaction bypass the shared cache to avoid sharing uncommitted counts. Existing global and order-type cache clearing remains supported.

A one-hour expiry provides fallback reconciliation for direct database updates that bypass the order lifecycle; these updates can leave badge counts stale until expiry unless they explicitly invalidate the counts.

### Related issues

No linked issue.
